### PR TITLE
fix: prevent false zero usage on qgroup failure

### DIFF
--- a/agent/storage/usage.go
+++ b/agent/storage/usage.go
@@ -75,13 +75,13 @@ func updateAll(ctx context.Context, basePath string, tenant string) {
 		if meta.QuotaBytes > 0 {
 			u, err := btrfs.QgroupUsage(ctx, dataDir)
 			if err != nil {
-				log.Debug().Err(err).Str("volume", e.Name()).Msg("usage updater: qgroup query failed")
+				log.Warn().Err(err).Str("volume", e.Name()).Msg("usage updater: qgroup query failed, skipping volume - if issue persists check your quotas")
 				failed++
-			} else {
-				used = u
-				if used != meta.UsedBytes {
-					changed = true
-				}
+				continue
+			}
+			used = u
+			if used != meta.UsedBytes {
+				changed = true
 			}
 		}
 


### PR DESCRIPTION
When btrfs.QgroupUsage fails, the usage updater previously continued with used=0, silently overwriting real usage in metadata.json. Now it skips the volume with a warn-level log instead, so that a admin can check it.