### PR TITLE
feat: make default directory and data modes configurable

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -62,7 +62,7 @@ func (a *Agent) Start(ctx context.Context) {
 	}
 
 	// storage layer + handler
-	store := storage.New(a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames)
+	store := storage.New(a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames, a.cfg.DefaultDirMode, a.cfg.DefaultDataMode)
 	h := &v1.Handler{Store: store}
 
 	// v1 API with auth

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,8 @@
 | `AGENT_EXPORTFS_BIN` | `exportfs` | exportfs binary path |
 | `AGENT_NFS_RECONCILE_INTERVAL` | `10m` | Export reconciliation (`0` = off) |
 | `AGENT_DASHBOARD_REFRESH_SECONDS` | `5` | Dashboard refresh |
+| `AGENT_DEFAULT_DIR_MODE` | `0700` | Default mode for volume/snapshot/clone directories |
+| `AGENT_DEFAULT_DATA_MODE` | `2770` | Default mode for data subvolumes (setgid + group rwx) |
 | `LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
 
 ## Controller Environment Variables

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -106,7 +106,7 @@ annotations:
   btrfs-nfs-csi/mode: "0750"
 ```
 
-Default mode: `0750`. Applied at creation via `chown`/`chmod`. Updated on attach if annotations change. Usage updater detects drift from NFS-level changes.
+Default mode: `2770` (configurable via `AGENT_DEFAULT_DATA_MODE`). Applied at creation via `chown`/`chmod`. Updated on attach if annotations change. Usage updater detects drift from NFS-level changes.
 
 ## NFS Exports
 

--- a/model/config.go
+++ b/model/config.go
@@ -32,6 +32,8 @@ type AgentConfig struct {
 	ExportfsBin          string        `env:"AGENT_EXPORTFS_BIN" envDefault:"exportfs"`
 	NFSReconcileInterval time.Duration `env:"AGENT_NFS_RECONCILE_INTERVAL" envDefault:"10m"`
 	DashboardRefresh     int           `env:"AGENT_DASHBOARD_REFRESH_SECONDS" envDefault:"5"`
+	DefaultDirMode       string        `env:"AGENT_DEFAULT_DIR_MODE" envDefault:"0700"`
+	DefaultDataMode      string        `env:"AGENT_DEFAULT_DATA_MODE" envDefault:"2770"`
 }
 
 type ControllerConfig struct {


### PR DESCRIPTION
Adds AGENT_DEFAULT_DIR_MODE (default 0700) and AGENT_DEFAULT_DATA_MODE (default 2770) as environment variables. Previously hardcoded, now adjustable per deployment, got requested as important feature.