### PR TITLE
fix: LastAttachAt zero-value in JSON

### DIFF
--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -41,7 +41,7 @@ type VolumeResponse struct {
 	Clients      int       `json:"clients"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
-	LastAttachAt time.Time `json:"last_attach_at,omitempty"`
+	LastAttachAt *time.Time `json:"last_attach_at,omitempty"`
 }
 
 type VolumeListResponse struct {

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -18,7 +18,7 @@ type VolumeMetadata struct {
 	Clients      []string  `json:"clients,omitempty"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
-	LastAttachAt time.Time `json:"last_attach_at,omitempty"`
+	LastAttachAt *time.Time `json:"last_attach_at,omitempty"`
 }
 
 type SnapshotMetadata struct {

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -428,7 +428,7 @@ func (s *Storage) ExportVolume(ctx context.Context, tenant, name, client string)
 			}
 		}
 		now := time.Now().UTC()
-		meta.LastAttachAt = now
+		meta.LastAttachAt = &now
 		meta.UpdatedAt = now
 		if !found {
 			meta.Clients = append(meta.Clients, client)


### PR DESCRIPTION
Use *time.Time so omitempty actually omits the field for unattached volumes. Dashboard shows - instead of 0001-01-01.