### PR TITLE
Fix nil pointer panic on volume/clone conflict

### DIFF
--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -29,7 +29,7 @@ func NewClient(url, token string) *Client {
 func (c *Client) CreateVolume(ctx context.Context, req VolumeCreateRequest) (*VolumeDetailResponse, error) {
 	var resp VolumeDetailResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/volumes", req, &resp); err != nil {
-		if IsConflict(err) && resp.Path != "" {
+		if IsConflict(err) {
 			return &resp, err
 		}
 		return nil, err
@@ -64,7 +64,7 @@ func (c *Client) DeleteSnapshot(ctx context.Context, name string) error {
 func (c *Client) CreateClone(ctx context.Context, req CloneCreateRequest) (*CloneResponse, error) {
 	var resp CloneResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/clones", req, &resp); err != nil {
-		if IsConflict(err) && resp.Path != "" {
+		if IsConflict(err) {
 			return &resp, err
 		}
 		return nil, err

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -35,7 +35,7 @@ func (h *Handler) CreateVolume(c *echo.Context) error {
 	meta, err := h.Store.CreateVolume(c.Request().Context(), tenant, req)
 	if err != nil {
 		if meta != nil {
-			return c.JSON(http.StatusConflict, volumeResponseFrom(meta))
+			return c.JSON(http.StatusConflict, volumeDetailResponseFrom(meta))
 		}
 		return StorageError(c, err)
 	}


### PR DESCRIPTION
## Summary
- Fix handler returning `VolumeResponse` (no `Path`) instead of `VolumeDetailResponse` on 409 Conflict, causing client to return nil                                                                           
- Remove redundant `resp.Path != ""` guard in client — always return response on conflict                                                                                                                      
- Add nil safety in controller for `volResp` (fallback to `GetVolume`) and `cloneResp` on conflict