### PR TITLE
fix mixed-load.sh fio entrypoint and add scripts README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,19 @@
+# Scripts
+
+## Setup
+
+| Script | Description |
+|--------|-------------|
+| `quickstart-agent.sh` | One-line installer for the agent (Podman Quadlet). Handles install, update, and uninstall. See [installation.md](../docs/installation.md). |
+| `agent-dev-setup.sh` | Creates a 1G btrfs loopback image for local development. `up` to mount, `down` to unmount. |
+
+## Testing
+
+| Script | Description |
+|--------|-------------|
+| `create-100-pvcs.sh` | Bulk create/delete PVCs. Usage: `create-100-pvcs.sh [count] [size] [namespace] [storageclass]` |
+| `stress-test.sh` | API stress + lifecycle chaos test. Creates PVCs, snapshots, clones, resizes, and deletes in rapid succession. Usage: `stress-test.sh [count] [rapid] [namespace]` |
+| `mixed-load.sh` | fio I/O load + API chaos. Runs fio pods with mixed read/write while snapshotting, resizing, and deleting. Usage: `mixed-load.sh [pods] [read_rate] [write_rate] [namespace]` |
+| `stress.sh` | Simple StatefulSet-based stress test with a single fio pod. Usage: `stress.sh [namespace] [storageclass] [timeout]` |
+
+All of these scripts support a `cleanup` subcommand to remove created resources.

--- a/scripts/mixed-load.sh
+++ b/scripts/mixed-load.sh
@@ -76,6 +76,7 @@ spec:
   containers:
     - name: fio
       image: ${FIO_IMAGE}
+      command: ["fio"]
       args: ["--name=mixed", "--directory=/data", "--rw=randrw", "--rwmixread=70", "--bs=4k", "--size=256m", "--rate=${READ_RATE},${WRITE_RATE}", "--runtime=120", "--time_based", "--group_reporting", "--output-format=terse", "--terse-version=3"]
       volumeMounts:
         - name: data


### PR DESCRIPTION
## Summary
- Fix `mixed-load.sh`: add command fio, nixery.dev images have no entrypoint
- Add `scripts/README.md` documenting all setup and testing scripts