### PR TITLE
Make btrfs binary path configurable via AGENT_BTRFS_BIN

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -62,7 +62,7 @@ func (a *Agent) Start(ctx context.Context) {
 	}
 
 	// storage layer + handler
-	store := storage.New(a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames, a.cfg.DefaultDirMode, a.cfg.DefaultDataMode)
+	store := storage.New(a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames, a.cfg.DefaultDirMode, a.cfg.DefaultDataMode, a.cfg.BtrfsBin)
 	h := &v1.Handler{Store: store}
 
 	// v1 API with auth

--- a/agent/storage/btrfs/btrfs_test.go
+++ b/agent/storage/btrfs/btrfs_test.go
@@ -18,7 +18,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestManager(r utils.Runner) *Manager {
-	return &Manager{cmd: r}
+	return &Manager{bin: "btrfs", cmd: r}
 }
 
 func TestQgroupUsageEx(t *testing.T) {

--- a/agent/storage/btrfs/integration_test.go
+++ b/agent/storage/btrfs/integration_test.go
@@ -71,7 +71,7 @@ func setupLoopBtrfs(t *testing.T) string {
 
 func TestIntegrationSubvolumeCreateDelete(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	subPath := filepath.Join(mnt, "testvol")
@@ -93,7 +93,7 @@ func TestIntegrationSubvolumeCreateDelete(t *testing.T) {
 
 func TestIntegrationSnapshot(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	src := filepath.Join(mnt, "srcvol")
@@ -121,7 +121,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 
 func TestIntegrationQgroupLimit(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	subPath := filepath.Join(mnt, "quotavol")
@@ -157,7 +157,7 @@ func TestIntegrationQgroupLimit(t *testing.T) {
 
 func TestIntegrationQgroupUsageEx(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	subPath := filepath.Join(mnt, "usagevol")
@@ -191,7 +191,7 @@ func TestIntegrationQgroupUsageEx(t *testing.T) {
 
 func TestIntegrationSubvolumeList(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	vol1 := filepath.Join(mnt, "listvol1")
@@ -224,7 +224,7 @@ func TestIntegrationSubvolumeList(t *testing.T) {
 
 func TestIntegrationSetCompression(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 	cmd := &utils.ShellRunner{}
 
@@ -249,7 +249,7 @@ func TestIntegrationSetCompression(t *testing.T) {
 // not sure how useful they are but who knows :D
 func TestIntegrationConcurrentCreate(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	errs := make(chan error, 31)
@@ -276,7 +276,7 @@ func TestIntegrationConcurrentCreate(t *testing.T) {
 
 func TestIntegrationConcurrentDelete(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	// create 31 subvolumes sequentially
@@ -312,7 +312,7 @@ func TestIntegrationConcurrentDelete(t *testing.T) {
 
 func TestIntegrationConcurrentSnapshot(t *testing.T) {
 	mnt := setupLoopBtrfs(t)
-	mgr := NewManager()
+	mgr := NewManager("btrfs")
 	ctx := context.Background()
 
 	src := filepath.Join(mnt, "srcvol")

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -33,7 +33,7 @@ type Storage struct {
 	defaultDataMode string
 }
 
-func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode string) *Storage {
+func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin string) *Storage {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -52,7 +52,7 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 	if !btrfs.IsBtrfs(basePath) {
 		log.Fatal().Str("path", basePath).Msg("base path is not on a btrfs filesystem")
 	}
-	mgr := btrfs.NewManager()
+	mgr := btrfs.NewManager(btrfsBin)
 	if !mgr.IsAvailable(ctx) {
 		log.Fatal().Msg("btrfs tools not found - is btrfs-progs installed?")
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -48,6 +48,7 @@ type AgentConfig struct {
 	UsageInterval        time.Duration `env:"AGENT_FEATURE_QUOTA_UPDATE_INTERVAL" envDefault:"1m"`
 	NFSExporter          string        `env:"AGENT_NFS_EXPORTER" envDefault:"kernel"`
 	ExportfsBin          string        `env:"AGENT_EXPORTFS_BIN" envDefault:"exportfs"`
+	BtrfsBin             string        `env:"AGENT_BTRFS_BIN" envDefault:"btrfs"`
 	NFSReconcileInterval time.Duration `env:"AGENT_NFS_RECONCILE_INTERVAL" envDefault:"10m"`
 	DashboardRefresh     int           `env:"AGENT_DASHBOARD_REFRESH_SECONDS" envDefault:"5"`
 	DefaultDirMode       string        `env:"AGENT_DEFAULT_DIR_MODE" envDefault:"0700"`


### PR DESCRIPTION
## Summary
- Add `BtrfsBin` config field with `AGENT_BTRFS_BIN` env var (default: `btrfs`), matching the existing `ExportfsBin` pattern