### PR TITLE
Add NFS integration tests, migrate to testify, and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Format check
+        run: test -z "$(gofmt -l .)"
+
+      # This is also running go vet already
       - name: Lint
         uses: golangci/golangci-lint-action@v9
 
@@ -48,7 +52,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test
-        run: go test ./...
+        run: go test -race ./...
 
   integration:
     runs-on: ubuntu-latest
@@ -60,11 +64,12 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install btrfs-progs
-        run: sudo apt-get update && sudo apt-get install -y btrfs-progs
+      # Hope this works
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y btrfs-progs nfs-kernel-server
 
       - name: Integration tests
-        run: sudo go test ./agent/storage/btrfs/... -tags integration -v -count=1
+        run: sudo go test -race ./... -tags integration -v -count=1
 
   build:
     runs-on: ubuntu-latest

--- a/agent/storage/btrfs/btrfs_test.go
+++ b/agent/storage/btrfs/btrfs_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -68,20 +70,10 @@ func TestQgroupUsageEx(t *testing.T) {
 		mgr := newTestManager(m)
 
 		info, err := mgr.QgroupUsageEx(context.Background(), "/mnt/data/vol1")
-		if err != nil {
-			t.Fatalf("QgroupUsageEx() error: %v", err)
-		}
-
-		if info.Referenced != 16384 {
-			t.Errorf("Referenced = %d, want 16384", info.Referenced)
-		}
-		if info.Exclusive != 8192 {
-			t.Errorf("Exclusive = %d, want 8192", info.Exclusive)
-		}
-
-		if len(m.Calls) != 2 {
-			t.Fatalf("expected 2 calls, got %d", len(m.Calls))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, uint64(16384), info.Referenced)
+		assert.Equal(t, uint64(8192), info.Exclusive)
+		require.Len(t, m.Calls, 2)
 	})
 
 	t.Run("show error", func(t *testing.T) {
@@ -89,9 +81,7 @@ func TestQgroupUsageEx(t *testing.T) {
 		mgr := newTestManager(m)
 
 		_, err := mgr.QgroupUsageEx(context.Background(), "/mnt/data/vol1")
-		if err == nil {
-			t.Fatal("QgroupUsageEx() should return error when show fails")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("missing subvolume id", func(t *testing.T) {
@@ -99,12 +89,7 @@ func TestQgroupUsageEx(t *testing.T) {
 		mgr := newTestManager(m)
 
 		_, err := mgr.QgroupUsageEx(context.Background(), "/mnt/data/vol1")
-		if err == nil {
-			t.Fatal("QgroupUsageEx() should return error when subvolume ID missing")
-		}
-		if !strings.Contains(err.Error(), "subvolume ID not found") {
-			t.Errorf("unexpected error: %v", err)
-		}
+		assert.ErrorContains(t, err, "subvolume ID not found")
 	})
 
 	t.Run("qgroup show error", func(t *testing.T) {
@@ -119,9 +104,7 @@ func TestQgroupUsageEx(t *testing.T) {
 		mgr := newTestManager(m)
 
 		_, err := mgr.QgroupUsageEx(context.Background(), "/mnt/data/vol1")
-		if err == nil {
-			t.Fatal("QgroupUsageEx() should return error when qgroup show fails")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("qgroup not found", func(t *testing.T) {
@@ -137,12 +120,7 @@ func TestQgroupUsageEx(t *testing.T) {
 		mgr := newTestManager(m)
 
 		_, err := mgr.QgroupUsageEx(context.Background(), "/mnt/data/vol1")
-		if err == nil {
-			t.Fatal("QgroupUsageEx() should return error when qgroup not found")
-		}
-		if !strings.Contains(err.Error(), "qgroup 0/259 not found") {
-			t.Errorf("unexpected error: %v", err)
-		}
+		assert.ErrorContains(t, err, "qgroup 0/259 not found")
 	})
 }
 
@@ -161,12 +139,8 @@ func TestQgroupUsage(t *testing.T) {
 	mgr := newTestManager(m)
 
 	used, err := mgr.QgroupUsage(context.Background(), "/mnt/data/vol1")
-	if err != nil {
-		t.Fatalf("QgroupUsage() error: %v", err)
-	}
-	if used != 16384 {
-		t.Errorf("QgroupUsage() = %d, want 16384", used)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, uint64(16384), used)
 }
 
 func TestSubvolumeList(t *testing.T) {
@@ -185,19 +159,12 @@ func TestSubvolumeList(t *testing.T) {
 		mgr := newTestManager(m)
 
 		subs, err := mgr.SubvolumeList(context.Background(), "/mnt/data")
-		if err != nil {
-			t.Fatalf("SubvolumeList() error: %v", err)
-		}
-
-		if len(subs) != 3 {
-			t.Fatalf("expected 3 subvolumes, got %d", len(subs))
-		}
+		require.NoError(t, err)
+		require.Len(t, subs, 3)
 
 		want := []string{"vol1", "vol2", "nested/vol3"}
 		for i, s := range subs {
-			if s.Path != want[i] {
-				t.Errorf("subs[%d].Path = %q, want %q", i, s.Path, want[i])
-			}
+			assert.Equal(t, want[i], s.Path)
 		}
 	})
 
@@ -206,12 +173,8 @@ func TestSubvolumeList(t *testing.T) {
 		mgr := newTestManager(m)
 
 		subs, err := mgr.SubvolumeList(context.Background(), "/mnt/data")
-		if err != nil {
-			t.Fatalf("SubvolumeList() error: %v", err)
-		}
-		if len(subs) != 0 {
-			t.Errorf("expected 0 subvolumes, got %d", len(subs))
-		}
+		require.NoError(t, err)
+		assert.Empty(t, subs)
 	})
 
 	t.Run("error", func(t *testing.T) {
@@ -219,25 +182,19 @@ func TestSubvolumeList(t *testing.T) {
 		mgr := newTestManager(m)
 
 		_, err := mgr.SubvolumeList(context.Background(), "/mnt/data")
-		if err == nil {
-			t.Fatal("SubvolumeList() should return error")
-		}
+		require.Error(t, err)
 	})
 }
 
 func TestIsValidCompression(t *testing.T) {
 	valid := []string{"", "none", "zstd", "lzo", "zlib", "zstd:1", "zstd:15", "zlib:9"}
 	for _, s := range valid {
-		if !IsValidCompression(s) {
-			t.Errorf("IsValidCompression(%q) = false, want true", s)
-		}
+		assert.True(t, IsValidCompression(s), "IsValidCompression(%q) should be true", s)
 	}
 
 	invalid := []string{"doesnotexist", "zstd:0", "zstd:16", "zstd:420", "zstd:abc", "lz4", "gzip"}
 	for _, s := range invalid {
-		if IsValidCompression(s) {
-			t.Errorf("IsValidCompression(%q) = true, want false", s)
-		}
+		assert.False(t, IsValidCompression(s), "IsValidCompression(%q) should be false", s)
 	}
 }
 
@@ -246,23 +203,17 @@ func TestSetCompression(t *testing.T) {
 		m := &utils.MockRunner{Out: ""}
 		mgr := newTestManager(m)
 
-		if err := mgr.SetCompression(context.Background(), "/mnt/data/vol1", "zstd"); err != nil {
-			t.Fatalf("SetCompression() error: %v", err)
-		}
-		if len(m.Calls) != 1 {
-			t.Fatalf("expected 1 call, got %d", len(m.Calls))
-		}
+		err := mgr.SetCompression(context.Background(), "/mnt/data/vol1", "zstd")
+		require.NoError(t, err)
+		require.Len(t, m.Calls, 1)
 	})
 
 	t.Run("invalid rejected before exec", func(t *testing.T) {
 		m := &utils.MockRunner{Out: ""}
 		mgr := newTestManager(m)
 
-		if err := mgr.SetCompression(context.Background(), "/mnt/data/vol1", "zstd:420"); err == nil {
-			t.Fatal("SetCompression(zstd:420) should return an error")
-		}
-		if len(m.Calls) != 0 {
-			t.Error("should not call btrfs for invalid algorithm")
-		}
+		err := mgr.SetCompression(context.Background(), "/mnt/data/vol1", "zstd:420")
+		require.Error(t, err)
+		assert.Empty(t, m.Calls)
 	})
 }

--- a/agent/storage/btrfs/integration_test.go
+++ b/agent/storage/btrfs/integration_test.go
@@ -11,335 +11,243 @@ import (
 	"testing"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
+	"github.com/stretchr/testify/suite"
 )
 
-// setupLoopBtrfs creates a loop-mounted btrfs filesystem with quotas enabled.
-// Requires root and btrfs-progs.
-func setupLoopBtrfs(t *testing.T) string {
-	t.Helper()
+type BtrfsIntegrationSuite struct {
+	suite.Suite
+	mnt     string
+	mgr     *Manager
+	cmd     *utils.ShellRunner
+	ctx     context.Context
+	loopDev string
+}
 
-	ctx := context.Background()
-	cmd := &utils.ShellRunner{}
+func TestBtrfsIntegration(t *testing.T) {
+	suite.Run(t, new(BtrfsIntegrationSuite))
+}
+
+func (s *BtrfsIntegrationSuite) SetupSuite() {
+	t := s.T()
+
+	s.ctx = context.Background()
+	s.cmd = &utils.ShellRunner{}
 
 	tmpDir := t.TempDir()
 	imgFile := filepath.Join(tmpDir, "btrfs.img")
-	mountDir := filepath.Join(tmpDir, "mnt")
+	s.mnt = filepath.Join(tmpDir, "mnt")
 
-	if err := os.MkdirAll(mountDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	err := os.MkdirAll(s.mnt, 0o755)
+	s.Require().NoError(err, "mkdir")
 
-	// sparse file
-	if _, err := cmd.Run(ctx, "fallocate", "-l", "256M", imgFile); err != nil {
-		t.Fatalf("fallocate: %v", err)
-	}
+	_, err = s.cmd.Run(s.ctx, "fallocate", "-l", "1G", imgFile)
+	s.Require().NoError(err, "fallocate")
 
-	// loop device
-	loopOut, err := cmd.Run(ctx, "losetup", "--find", "--show", imgFile)
+	loopOut, err := s.cmd.Run(s.ctx, "losetup", "--find", "--show", imgFile)
+	s.Require().NoError(err, "losetup")
+	s.loopDev = strings.TrimSpace(loopOut)
+
+	_, err = s.cmd.Run(s.ctx, "mkfs.btrfs", "-f", s.loopDev)
 	if err != nil {
-		t.Fatalf("losetup: %v", err)
-	}
-	loopDev := strings.TrimSpace(loopOut)
-
-	// mkfs.btrfs
-	if _, err := cmd.Run(ctx, "mkfs.btrfs", "-f", loopDev); err != nil {
-		// cleanup loop on failure
-		_, _ = cmd.Run(ctx, "losetup", "-d", loopDev)
-		t.Fatalf("mkfs.btrfs: %v", err)
+		_, _ = s.cmd.Run(s.ctx, "losetup", "-d", s.loopDev)
+		s.Require().NoError(err, "mkfs.btrfs")
 	}
 
-	// mount
-	if _, err := cmd.Run(ctx, "mount", loopDev, mountDir); err != nil {
-		_, _ = cmd.Run(ctx, "losetup", "-d", loopDev)
-		t.Fatalf("mount: %v", err)
+	_, err = s.cmd.Run(s.ctx, "mount", s.loopDev, s.mnt)
+	if err != nil {
+		_, _ = s.cmd.Run(s.ctx, "losetup", "-d", s.loopDev)
+		s.Require().NoError(err, "mount")
 	}
 
-	// enable quotas
-	if _, err := cmd.Run(ctx, "btrfs", "quota", "enable", mountDir); err != nil {
-		_, _ = cmd.Run(ctx, "umount", mountDir)
-		_, _ = cmd.Run(ctx, "losetup", "-d", loopDev)
-		t.Fatalf("quota enable: %v", err)
+	_, err = s.cmd.Run(s.ctx, "btrfs", "quota", "enable", s.mnt)
+	if err != nil {
+		_, _ = s.cmd.Run(s.ctx, "umount", s.mnt)
+		_, _ = s.cmd.Run(s.ctx, "losetup", "-d", s.loopDev)
+		s.Require().NoError(err, "quota enable")
 	}
 
-	t.Cleanup(func() {
-		_, _ = cmd.Run(ctx, "umount", mountDir)
-		_, _ = cmd.Run(ctx, "losetup", "-d", loopDev)
-	})
-
-	return mountDir
+	s.mgr = NewManager("btrfs")
 }
 
-func TestIntegrationSubvolumeCreateDelete(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
-
-	subPath := filepath.Join(mnt, "testvol")
-
-	if err := mgr.SubvolumeCreate(ctx, subPath); err != nil {
-		t.Fatalf("SubvolumeCreate: %v", err)
-	}
-	if !mgr.SubvolumeExists(ctx, subPath) {
-		t.Fatal("SubvolumeExists should return true after create")
-	}
-
-	if err := mgr.SubvolumeDelete(ctx, subPath); err != nil {
-		t.Fatalf("SubvolumeDelete: %v", err)
-	}
-	if mgr.SubvolumeExists(ctx, subPath) {
-		t.Fatal("SubvolumeExists should return false after delete")
-	}
+func (s *BtrfsIntegrationSuite) TearDownSuite() {
+	_, _ = s.cmd.Run(s.ctx, "umount", s.mnt)
+	_, _ = s.cmd.Run(s.ctx, "losetup", "-d", s.loopDev)
 }
 
-func TestIntegrationSnapshot(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
+func (s *BtrfsIntegrationSuite) TestSubvolumeCreateDelete() {
+	subPath := filepath.Join(s.mnt, "testvol")
 
-	src := filepath.Join(mnt, "srcvol")
-	rwSnap := filepath.Join(mnt, "rwsnap")
-	roSnap := filepath.Join(mnt, "rosnap")
+	err := s.mgr.SubvolumeCreate(s.ctx, subPath)
+	s.Require().NoError(err, "SubvolumeCreate")
+	s.Assert().True(s.mgr.SubvolumeExists(s.ctx, subPath), "should exist after create")
 
-	if err := mgr.SubvolumeCreate(ctx, src); err != nil {
-		t.Fatalf("SubvolumeCreate: %v", err)
-	}
-
-	if err := mgr.SubvolumeSnapshot(ctx, src, rwSnap, false); err != nil {
-		t.Fatalf("SubvolumeSnapshot(rw): %v", err)
-	}
-	if !mgr.SubvolumeExists(ctx, rwSnap) {
-		t.Fatal("rw snapshot should exist")
-	}
-
-	if err := mgr.SubvolumeSnapshot(ctx, src, roSnap, true); err != nil {
-		t.Fatalf("SubvolumeSnapshot(ro): %v", err)
-	}
-	if !mgr.SubvolumeExists(ctx, roSnap) {
-		t.Fatal("ro snapshot should exist")
-	}
+	err = s.mgr.SubvolumeDelete(s.ctx, subPath)
+	s.Require().NoError(err, "SubvolumeDelete")
+	s.Assert().False(s.mgr.SubvolumeExists(s.ctx, subPath), "should not exist after delete")
 }
 
-func TestIntegrationQgroupLimit(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
+func (s *BtrfsIntegrationSuite) TestSnapshot() {
+	src := filepath.Join(s.mnt, "srcvol-snap")
+	rwSnap := filepath.Join(s.mnt, "rwsnap")
+	roSnap := filepath.Join(s.mnt, "rosnap")
 
-	subPath := filepath.Join(mnt, "quotavol")
-	if err := mgr.SubvolumeCreate(ctx, subPath); err != nil {
-		t.Fatalf("SubvolumeCreate: %v", err)
-	}
+	err := s.mgr.SubvolumeCreate(s.ctx, src)
+	s.Require().NoError(err, "SubvolumeCreate")
 
-	// set 10MB limit
-	if err := mgr.QgroupLimit(ctx, subPath, 10*1024*1024); err != nil {
-		t.Fatalf("QgroupLimit: %v", err)
-	}
+	err = s.mgr.SubvolumeSnapshot(s.ctx, src, rwSnap, false)
+	s.Require().NoError(err, "SubvolumeSnapshot(rw)")
+	s.Assert().True(s.mgr.SubvolumeExists(s.ctx, rwSnap), "rw snapshot should exist")
 
-	// write some data
+	err = s.mgr.SubvolumeSnapshot(s.ctx, src, roSnap, true)
+	s.Require().NoError(err, "SubvolumeSnapshot(ro)")
+	s.Assert().True(s.mgr.SubvolumeExists(s.ctx, roSnap), "ro snapshot should exist")
+}
+
+func (s *BtrfsIntegrationSuite) TestQgroupLimit() {
+	subPath := filepath.Join(s.mnt, "quotavol")
+	err := s.mgr.SubvolumeCreate(s.ctx, subPath)
+	s.Require().NoError(err, "SubvolumeCreate")
+
+	err = s.mgr.QgroupLimit(s.ctx, subPath, 10*1024*1024)
+	s.Require().NoError(err, "QgroupLimit")
+
 	data := make([]byte, 64*1024)
-	if err := os.WriteFile(filepath.Join(subPath, "testfile"), data, 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	err = os.WriteFile(filepath.Join(subPath, "testfile"), data, 0o644)
+	s.Require().NoError(err, "WriteFile")
 
-	// sync filesystem so qgroup accounting is up to date
-	cmd := &utils.ShellRunner{}
-	if _, err := cmd.Run(ctx, "sync"); err != nil {
-		t.Fatalf("sync: %v", err)
-	}
+	_, err = s.cmd.Run(s.ctx, "sync")
+	s.Require().NoError(err, "sync")
 
-	used, err := mgr.QgroupUsage(ctx, subPath)
-	if err != nil {
-		t.Fatalf("QgroupUsage: %v", err)
-	}
-	if used == 0 {
-		t.Error("QgroupUsage should be > 0 after writing data")
-	}
+	used, err := s.mgr.QgroupUsage(s.ctx, subPath)
+	s.Require().NoError(err, "QgroupUsage")
+	s.Assert().NotZero(used, "QgroupUsage should be > 0 after writing data")
 }
 
-func TestIntegrationQgroupUsageEx(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
+func (s *BtrfsIntegrationSuite) TestQgroupUsageEx() {
+	subPath := filepath.Join(s.mnt, "usagevol")
+	err := s.mgr.SubvolumeCreate(s.ctx, subPath)
+	s.Require().NoError(err, "SubvolumeCreate")
 
-	subPath := filepath.Join(mnt, "usagevol")
-	if err := mgr.SubvolumeCreate(ctx, subPath); err != nil {
-		t.Fatalf("SubvolumeCreate: %v", err)
-	}
-
-	// write data
 	data := make([]byte, 128*1024)
-	if err := os.WriteFile(filepath.Join(subPath, "testfile"), data, 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	err = os.WriteFile(filepath.Join(subPath, "testfile"), data, 0o644)
+	s.Require().NoError(err, "WriteFile")
 
-	// sync filesystem so qgroup accounting is up to date
-	cmd := &utils.ShellRunner{}
-	if _, err := cmd.Run(ctx, "sync"); err != nil {
-		t.Fatalf("sync: %v", err)
-	}
+	_, err = s.cmd.Run(s.ctx, "sync")
+	s.Require().NoError(err, "sync")
 
-	info, err := mgr.QgroupUsageEx(ctx, subPath)
-	if err != nil {
-		t.Fatalf("QgroupUsageEx: %v", err)
-	}
-	if info.Referenced == 0 {
-		t.Error("Referenced should be > 0")
-	}
-	if info.Exclusive == 0 {
-		t.Error("Exclusive should be > 0")
-	}
+	info, err := s.mgr.QgroupUsageEx(s.ctx, subPath)
+	s.Require().NoError(err, "QgroupUsageEx")
+	s.Assert().NotZero(info.Referenced, "Referenced should be > 0")
+	s.Assert().NotZero(info.Exclusive, "Exclusive should be > 0")
 }
 
-func TestIntegrationSubvolumeList(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
+func (s *BtrfsIntegrationSuite) TestSubvolumeList() {
+	vol1 := filepath.Join(s.mnt, "listvol1")
+	vol2 := filepath.Join(s.mnt, "listvol2")
 
-	vol1 := filepath.Join(mnt, "listvol1")
-	vol2 := filepath.Join(mnt, "listvol2")
+	err := s.mgr.SubvolumeCreate(s.ctx, vol1)
+	s.Require().NoError(err, "SubvolumeCreate(vol1)")
+	err = s.mgr.SubvolumeCreate(s.ctx, vol2)
+	s.Require().NoError(err, "SubvolumeCreate(vol2)")
 
-	if err := mgr.SubvolumeCreate(ctx, vol1); err != nil {
-		t.Fatalf("SubvolumeCreate(vol1): %v", err)
-	}
-	if err := mgr.SubvolumeCreate(ctx, vol2); err != nil {
-		t.Fatalf("SubvolumeCreate(vol2): %v", err)
-	}
-
-	subs, err := mgr.SubvolumeList(ctx, mnt)
-	if err != nil {
-		t.Fatalf("SubvolumeList: %v", err)
-	}
-
-	if len(subs) != 2 {
-		t.Fatalf("expected 2 subvolumes, got %d", len(subs))
-	}
+	subs, err := s.mgr.SubvolumeList(s.ctx, s.mnt)
+	s.Require().NoError(err, "SubvolumeList")
 
 	paths := make(map[string]bool)
-	for _, s := range subs {
-		paths[s.Path] = true
+	for _, sub := range subs {
+		paths[sub.Path] = true
 	}
-	if !paths["listvol1"] && !paths["listvol2"] {
-		t.Errorf("unexpected paths: %v", subs)
-	}
+	s.Assert().True(paths["listvol1"], "listvol1 should be in list")
+	s.Assert().True(paths["listvol2"], "listvol2 should be in list")
 }
 
-func TestIntegrationSetCompression(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
-	cmd := &utils.ShellRunner{}
+func (s *BtrfsIntegrationSuite) TestSetCompression() {
+	subPath := filepath.Join(s.mnt, "compvol")
+	err := s.mgr.SubvolumeCreate(s.ctx, subPath)
+	s.Require().NoError(err, "SubvolumeCreate")
 
-	subPath := filepath.Join(mnt, "compvol")
-	if err := mgr.SubvolumeCreate(ctx, subPath); err != nil {
-		t.Fatalf("SubvolumeCreate: %v", err)
-	}
+	err = s.mgr.SetCompression(s.ctx, subPath, "zstd")
+	s.Require().NoError(err, "SetCompression")
 
-	if err := mgr.SetCompression(ctx, subPath, "zstd"); err != nil {
-		t.Fatalf("SetCompression: %v", err)
-	}
-
-	out, err := cmd.Run(ctx, "btrfs", "property", "get", subPath, "compression")
-	if err != nil {
-		t.Fatalf("property get: %v", err)
-	}
-	if !strings.Contains(out, "zstd") {
-		t.Errorf("expected compression=zstd, got: %s", strings.TrimSpace(out))
-	}
+	out, err := s.cmd.Run(s.ctx, "btrfs", "property", "get", subPath, "compression")
+	s.Require().NoError(err, "property get")
+	s.Assert().Contains(out, "zstd")
 }
 
-// not sure how useful they are but who knows :D
-func TestIntegrationConcurrentCreate(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
+func (s *BtrfsIntegrationSuite) TestConcurrentCreate() {
+	errs := make(chan error, 31)
+	for i := range 31 {
+		go func() {
+			name := fmt.Sprintf("cc-vol-%02d", i)
+			errs <- s.mgr.SubvolumeCreate(s.ctx, filepath.Join(s.mnt, name))
+		}()
+	}
+	for range 31 {
+		s.Assert().NoError(<-errs, "SubvolumeCreate")
+	}
+
+	subs, err := s.mgr.SubvolumeList(s.ctx, s.mnt)
+	s.Require().NoError(err, "SubvolumeList")
+
+	count := 0
+	for _, sub := range subs {
+		if strings.HasPrefix(sub.Path, "cc-vol-") {
+			count++
+		}
+	}
+	s.Assert().Equal(31, count, "expected 31 cc-vol-* subvolumes")
+}
+
+func (s *BtrfsIntegrationSuite) TestConcurrentDelete() {
+	for i := range 31 {
+		name := fmt.Sprintf("cd-vol-%02d", i)
+		err := s.mgr.SubvolumeCreate(s.ctx, filepath.Join(s.mnt, name))
+		s.Require().NoError(err, "SubvolumeCreate(%s)", name)
+	}
 
 	errs := make(chan error, 31)
 	for i := range 31 {
 		go func() {
-			name := fmt.Sprintf("vol-%02d", i)
-			errs <- mgr.SubvolumeCreate(ctx, filepath.Join(mnt, name))
+			name := fmt.Sprintf("cd-vol-%02d", i)
+			errs <- s.mgr.SubvolumeDelete(s.ctx, filepath.Join(s.mnt, name))
 		}()
 	}
 	for range 31 {
-		if err := <-errs; err != nil {
-			t.Errorf("SubvolumeCreate: %v", err)
-		}
+		s.Assert().NoError(<-errs, "SubvolumeDelete")
 	}
 
-	subs, err := mgr.SubvolumeList(ctx, mnt)
-	if err != nil {
-		t.Fatalf("SubvolumeList: %v", err)
-	}
-	if len(subs) != 31 {
-		t.Errorf("expected 31 subvolumes, got %d", len(subs))
+	subs, err := s.mgr.SubvolumeList(s.ctx, s.mnt)
+	s.Require().NoError(err, "SubvolumeList")
+
+	for _, sub := range subs {
+		s.Assert().False(strings.HasPrefix(sub.Path, "cd-vol-"), "cd-vol-* should be deleted, found %s", sub.Path)
 	}
 }
 
-func TestIntegrationConcurrentDelete(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
+func (s *BtrfsIntegrationSuite) TestConcurrentSnapshot() {
+	src := filepath.Join(s.mnt, "cs-srcvol")
+	err := s.mgr.SubvolumeCreate(s.ctx, src)
+	s.Require().NoError(err, "SubvolumeCreate")
 
-	// create 31 subvolumes sequentially
-	for i := range 31 {
-		name := fmt.Sprintf("vol-%02d", i)
-		if err := mgr.SubvolumeCreate(ctx, filepath.Join(mnt, name)); err != nil {
-			t.Fatalf("SubvolumeCreate(%s): %v", name, err)
-		}
-	}
-
-	// delete all concurrently
 	errs := make(chan error, 31)
 	for i := range 31 {
 		go func() {
-			name := fmt.Sprintf("vol-%02d", i)
-			errs <- mgr.SubvolumeDelete(ctx, filepath.Join(mnt, name))
+			name := fmt.Sprintf("cs-snap-%02d", i)
+			errs <- s.mgr.SubvolumeSnapshot(s.ctx, src, filepath.Join(s.mnt, name), true)
 		}()
 	}
 	for range 31 {
-		if err := <-errs; err != nil {
-			t.Errorf("SubvolumeDelete: %v", err)
+		s.Assert().NoError(<-errs, "SubvolumeSnapshot")
+	}
+
+	subs, err := s.mgr.SubvolumeList(s.ctx, s.mnt)
+	s.Require().NoError(err, "SubvolumeList")
+
+	snapCount := 0
+	for _, sub := range subs {
+		if strings.HasPrefix(sub.Path, "cs-snap-") {
+			snapCount++
 		}
 	}
-
-	subs, err := mgr.SubvolumeList(ctx, mnt)
-	if err != nil {
-		t.Fatalf("SubvolumeList: %v", err)
-	}
-	if len(subs) != 0 {
-		t.Errorf("expected 0 subvolumes, got %d", len(subs))
-	}
-}
-
-func TestIntegrationConcurrentSnapshot(t *testing.T) {
-	mnt := setupLoopBtrfs(t)
-	mgr := NewManager("btrfs")
-	ctx := context.Background()
-
-	src := filepath.Join(mnt, "srcvol")
-	if err := mgr.SubvolumeCreate(ctx, src); err != nil {
-		t.Fatalf("SubvolumeCreate: %v", err)
-	}
-
-	// 31 concurrent snapshots from same source
-	errs := make(chan error, 31)
-	for i := range 31 {
-		go func() {
-			name := fmt.Sprintf("snap-%02d", i)
-			errs <- mgr.SubvolumeSnapshot(ctx, src, filepath.Join(mnt, name), true)
-		}()
-	}
-	for range 31 {
-		if err := <-errs; err != nil {
-			t.Errorf("SubvolumeSnapshot: %v", err)
-		}
-	}
-
-	// +1 for srcvol itself
-	subs, err := mgr.SubvolumeList(ctx, mnt)
-	if err != nil {
-		t.Fatalf("SubvolumeList: %v", err)
-	}
-	if len(subs) != 32 {
-		t.Errorf("expected 32 subvolumes (1 src + 31 snaps), got %d", len(subs))
-	}
+	s.Assert().Equal(31, snapCount, "expected 31 cs-snap-* snapshots")
 }

--- a/agent/storage/metadata.go
+++ b/agent/storage/metadata.go
@@ -1,0 +1,73 @@
+package storage
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+// ghetto mutex pool - because sync.Map told us "i'll hold your locks forever babe"
+// and we believed it until OOM said otherwise. ref-counted so we don't
+// accidentally give two goroutines different locks for the same path.
+var metaLocksMu sync.Mutex
+var metaLocksMap = map[string]*refMutex{}
+
+type refMutex struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func metaLock(path string) *refMutex {
+	metaLocksMu.Lock()
+	rm, ok := metaLocksMap[path]
+	if !ok {
+		rm = &refMutex{}
+		metaLocksMap[path] = rm
+	}
+	rm.refs++
+	metaLocksMu.Unlock()
+	rm.mu.Lock()
+	return rm
+}
+
+func metaUnlock(path string, rm *refMutex) {
+	rm.mu.Unlock()
+	metaLocksMu.Lock()
+	rm.refs--
+	if rm.refs == 0 {
+		delete(metaLocksMap, path)
+	}
+	metaLocksMu.Unlock()
+}
+
+func writeMetadataAtomic(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func ReadMetadata(path string, v any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func UpdateMetadata[T any](path string, fn func(*T)) error {
+	rm := metaLock(path)
+	defer metaUnlock(path, rm)
+
+	var meta T
+	if err := ReadMetadata(path, &meta); err != nil {
+		return err
+	}
+	fn(&meta)
+	return writeMetadataAtomic(path, &meta)
+}

--- a/agent/storage/metadata_integration_test.go
+++ b/agent/storage/metadata_integration_test.go
@@ -1,0 +1,169 @@
+//go:build integration
+
+// This test file also contains tests for Types like VolumeMetadata, kinda.
+
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
+	"github.com/stretchr/testify/suite"
+)
+
+type UtilsIntegrationSuite struct {
+	suite.Suite
+	mnt     string
+	cmd     *utils.ShellRunner
+	ctx     context.Context
+	loopDev string
+}
+
+func TestUtilsIntegration(t *testing.T) {
+	suite.Run(t, new(UtilsIntegrationSuite))
+}
+
+func (s *UtilsIntegrationSuite) SetupSuite() {
+	t := s.T()
+
+	s.ctx = context.Background()
+	s.cmd = &utils.ShellRunner{}
+
+	tmpDir := t.TempDir()
+	imgFile := filepath.Join(tmpDir, "btrfs.img")
+	s.mnt = filepath.Join(tmpDir, "mnt")
+
+	err := os.MkdirAll(s.mnt, 0o755)
+	s.Require().NoError(err, "mkdir")
+
+	_, err = s.cmd.Run(s.ctx, "fallocate", "-l", "1G", imgFile)
+	s.Require().NoError(err, "fallocate")
+
+	loopOut, err := s.cmd.Run(s.ctx, "losetup", "--find", "--show", imgFile)
+	s.Require().NoError(err, "losetup")
+	s.loopDev = strings.TrimSpace(loopOut)
+
+	_, err = s.cmd.Run(s.ctx, "mkfs.btrfs", "-f", s.loopDev)
+	if err != nil {
+		_, _ = s.cmd.Run(s.ctx, "losetup", "-d", s.loopDev)
+		s.Require().NoError(err, "mkfs.btrfs")
+	}
+
+	_, err = s.cmd.Run(s.ctx, "mount", s.loopDev, s.mnt)
+	if err != nil {
+		_, _ = s.cmd.Run(s.ctx, "losetup", "-d", s.loopDev)
+		s.Require().NoError(err, "mount")
+	}
+}
+
+func (s *UtilsIntegrationSuite) TearDownSuite() {
+	_, _ = s.cmd.Run(s.ctx, "umount", s.mnt)
+	_, _ = s.cmd.Run(s.ctx, "losetup", "-d", s.loopDev)
+}
+
+func (s *UtilsIntegrationSuite) TestWriteReadMetadata() {
+	path := filepath.Join(s.mnt, "meta.json")
+
+	now := time.Now().Truncate(time.Second).UTC()
+	written := VolumeMetadata{
+		Name:        "testvol",
+		Path:        "/data/testvol",
+		SizeBytes:   1024 * 1024,
+		NoCOW:       true,
+		Compression: "zstd",
+		QuotaBytes:  2 * 1024 * 1024,
+		UID:         1000,
+		GID:         1000,
+		Mode:        "0755",
+		Clients:     []string{"10.0.0.1"},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	s.Require().NoError(writeMetadataAtomic(path, &written))
+
+	var read VolumeMetadata
+	s.Require().NoError(ReadMetadata(path, &read))
+
+	s.Assert().Equal(written, read)
+
+	// Verify no .tmp file remains (atomic rename)
+	_, err := os.Stat(path + ".tmp")
+	s.Assert().True(os.IsNotExist(err), ".tmp file should not remain after atomic write")
+}
+
+func (s *UtilsIntegrationSuite) TestReadMetadataNotFound() {
+	path := filepath.Join(s.mnt, "nonexistent.json")
+
+	var meta VolumeMetadata
+	err := ReadMetadata(path, &meta)
+	s.Require().Error(err)
+	s.Assert().True(os.IsNotExist(err))
+}
+
+func (s *UtilsIntegrationSuite) TestUpdateMetadata() {
+	path := filepath.Join(s.mnt, "update-meta.json")
+
+	initial := VolumeMetadata{
+		Name:      "testvol",
+		Path:      "/data/testvol",
+		SizeBytes: 1024,
+	}
+	s.Require().NoError(writeMetadataAtomic(path, &initial))
+
+	err := UpdateMetadata(path, func(m *VolumeMetadata) {
+		m.SizeBytes = 2048
+		m.Compression = "zstd"
+	})
+	s.Require().NoError(err)
+
+	var updated VolumeMetadata
+	s.Require().NoError(ReadMetadata(path, &updated))
+
+	s.Assert().Equal("testvol", updated.Name)
+	s.Assert().Equal(uint64(2048), updated.SizeBytes)
+	s.Assert().Equal("zstd", updated.Compression)
+}
+
+func (s *UtilsIntegrationSuite) TestWriteMetadataAtomicInvalidPath() {
+	path := filepath.Join(s.mnt, "nonexistent", "subdir", "meta.json")
+
+	meta := VolumeMetadata{Name: "testvol"}
+	err := writeMetadataAtomic(path, &meta)
+	s.Require().Error(err)
+}
+
+func (s *UtilsIntegrationSuite) TestUpdateMetadataConcurrent() {
+	path := filepath.Join(s.mnt, "concurrent-meta.json")
+
+	initial := VolumeMetadata{
+		Name:      "testvol",
+		Path:      "/data/testvol",
+		UsedBytes: 0,
+	}
+	s.Require().NoError(writeMetadataAtomic(path, &initial))
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			err := UpdateMetadata(path, func(m *VolumeMetadata) {
+				m.UsedBytes++
+			})
+			s.Assert().NoError(err)
+		}()
+	}
+	wg.Wait()
+
+	var result VolumeMetadata
+	s.Require().NoError(ReadMetadata(path, &result))
+	s.Assert().Equal(uint64(goroutines), result.UsedBytes, "expected no lost updates")
+}

--- a/agent/storage/metadata_test.go
+++ b/agent/storage/metadata_test.go
@@ -1,0 +1,128 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMetadataCorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not valid json!!!"), 0o644))
+
+	var meta VolumeMetadata
+	err := ReadMetadata(path, &meta)
+	require.Error(t, err)
+}
+
+func TestUpdateMetadataNotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	err := UpdateMetadata(path, func(m *VolumeMetadata) {
+		m.SizeBytes = 1024
+	})
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestMetaLock(t *testing.T) {
+	t.Run("serializes_same_path", func(t *testing.T) {
+		path := "/test/serialize"
+		var seq []int
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+
+		// First goroutine grabs the lock immediately
+		rm := metaLock(path)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// This will block until the first lock is released
+			rm2 := metaLock(path)
+			mu.Lock()
+			seq = append(seq, 2)
+			mu.Unlock()
+			metaUnlock(path, rm2)
+		}()
+
+		// Give goroutine time to block on the lock
+		mu.Lock()
+		seq = append(seq, 1)
+		mu.Unlock()
+		metaUnlock(path, rm)
+
+		wg.Wait()
+		assert.Equal(t, []int{1, 2}, seq)
+	})
+
+	t.Run("cleanup_on_zero_refs", func(t *testing.T) {
+		path := "/test/cleanup"
+		rm := metaLock(path)
+
+		metaLocksMu.Lock()
+		_, exists := metaLocksMap[path]
+		metaLocksMu.Unlock()
+		assert.True(t, exists, "lock should exist while held")
+
+		metaUnlock(path, rm)
+
+		metaLocksMu.Lock()
+		_, exists = metaLocksMap[path]
+		metaLocksMu.Unlock()
+		assert.False(t, exists, "lock should be removed after unlock with refs==0")
+	})
+
+	// Overengineered testing? At least we know now here is no risk of OOM
+	t.Run("refcount_partial_unlock", func(t *testing.T) {
+		path := "/test/refcount"
+		rm1 := metaLock(path)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var rm2 *refMutex
+		go func() {
+			defer wg.Done()
+			rm2 = metaLock(path)
+		}()
+
+		metaUnlock(path, rm1)
+		wg.Wait()
+
+		// After first unlock, entry should still exist (refs == 1)
+		metaLocksMu.Lock()
+		_, exists := metaLocksMap[path]
+		metaLocksMu.Unlock()
+		assert.True(t, exists, "lock should still exist with refs > 0")
+
+		metaUnlock(path, rm2)
+
+		// After second unlock, entry should be gone (refs == 0)
+		metaLocksMu.Lock()
+		_, exists = metaLocksMap[path]
+		metaLocksMu.Unlock()
+		assert.False(t, exists, "lock should be removed after all refs released")
+	})
+
+	t.Run("independent_paths", func(t *testing.T) {
+		pathA := "/test/indep/a"
+		pathB := "/test/indep/b"
+		var wg sync.WaitGroup
+
+		rmA := metaLock(pathA)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Should not block — different path
+			rmB := metaLock(pathB)
+			metaUnlock(pathB, rmB)
+		}()
+		wg.Wait() // Would deadlock if pathB blocked on pathA
+		metaUnlock(pathA, rmA)
+	})
+}

--- a/agent/storage/nfs/integration_test.go
+++ b/agent/storage/nfs/integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package nfs
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type KernelExporterSuite struct {
+	suite.Suite
+	exp Exporter
+	ctx context.Context
+	dir string
+}
+
+func TestKernelExporterIntegration(t *testing.T) {
+	suite.Run(t, new(KernelExporterSuite))
+}
+
+func (s *KernelExporterSuite) SetupSuite() {
+	bin, err := exec.LookPath("exportfs")
+	s.Require().NoError(err, "exportfs not found")
+	s.exp = NewKernelExporter(bin)
+	s.ctx = context.Background()
+}
+
+func (s *KernelExporterSuite) SetupTest() {
+	s.dir = s.T().TempDir()
+}
+
+func (s *KernelExporterSuite) TearDownTest() {
+	_ = s.exp.Unexport(s.ctx, s.dir, "")
+}
+
+func (s *KernelExporterSuite) TestExportAndList() {
+	err := s.exp.Export(s.ctx, s.dir, "127.0.0.1")
+	s.Require().NoError(err, "Export")
+
+	exports, err := s.exp.ListExports(s.ctx)
+	s.Require().NoError(err, "ListExports")
+
+	s.Assert().True(containsExport(exports, s.dir, "127.0.0.1"),
+		"expected %s for 127.0.0.1 in exports: %v", s.dir, exports)
+}
+
+func (s *KernelExporterSuite) TestExportMultipleClients() {
+	err := s.exp.Export(s.ctx, s.dir, "127.0.0.1")
+	s.Require().NoError(err, "Export client 1")
+
+	err = s.exp.Export(s.ctx, s.dir, "127.0.0.2")
+	s.Require().NoError(err, "Export client 2")
+
+	exports, err := s.exp.ListExports(s.ctx)
+	s.Require().NoError(err, "ListExports")
+
+	s.Assert().True(containsExport(exports, s.dir, "127.0.0.1"),
+		"expected 127.0.0.1 in exports: %v", exports)
+	s.Assert().True(containsExport(exports, s.dir, "127.0.0.2"),
+		"expected 127.0.0.2 in exports: %v", exports)
+}
+
+func (s *KernelExporterSuite) TestUnexportSingleClient() {
+	err := s.exp.Export(s.ctx, s.dir, "127.0.0.1")
+	s.Require().NoError(err, "Export client 1")
+
+	err = s.exp.Export(s.ctx, s.dir, "127.0.0.2")
+	s.Require().NoError(err, "Export client 2")
+
+	err = s.exp.Unexport(s.ctx, s.dir, "127.0.0.1")
+	s.Require().NoError(err, "Unexport client 1")
+
+	exports, err := s.exp.ListExports(s.ctx)
+	s.Require().NoError(err, "ListExports")
+
+	s.Assert().False(containsExport(exports, s.dir, "127.0.0.1"),
+		"127.0.0.1 should be removed: %v", exports)
+	s.Assert().True(containsExport(exports, s.dir, "127.0.0.2"),
+		"127.0.0.2 should still be exported: %v", exports)
+}
+
+func (s *KernelExporterSuite) TestUnexportAllClients() {
+	err := s.exp.Export(s.ctx, s.dir, "127.0.0.1")
+	s.Require().NoError(err, "Export client 1")
+
+	err = s.exp.Export(s.ctx, s.dir, "127.0.0.2")
+	s.Require().NoError(err, "Export client 2")
+
+	err = s.exp.Unexport(s.ctx, s.dir, "")
+	s.Require().NoError(err, "Unexport all")
+
+	exports, err := s.exp.ListExports(s.ctx)
+	s.Require().NoError(err, "ListExports")
+
+	s.Assert().False(containsExport(exports, s.dir, "127.0.0.1"),
+		"127.0.0.1 should be removed: %v", exports)
+	s.Assert().False(containsExport(exports, s.dir, "127.0.0.2"),
+		"127.0.0.2 should be removed: %v", exports)
+}
+
+func (s *KernelExporterSuite) TestUnexportNotFound() {
+	err := s.exp.Unexport(s.ctx, s.dir, "127.0.0.1")
+	s.Assert().NoError(err, "Unexport on non-exported path should not error")
+}
+
+func (s *KernelExporterSuite) TestExportIdempotent() {
+	err := s.exp.Export(s.ctx, s.dir, "127.0.0.1")
+	s.Require().NoError(err, "Export first call")
+
+	err = s.exp.Export(s.ctx, s.dir, "127.0.0.1")
+	s.Require().NoError(err, "Export second call (idempotent)")
+
+	exports, err := s.exp.ListExports(s.ctx)
+	s.Require().NoError(err, "ListExports")
+
+	count := 0
+	for _, e := range exports {
+		if e.Path == s.dir && e.Client == "127.0.0.1" {
+			count++
+		}
+	}
+	s.Assert().Equal(1, count,
+		"expected exactly 1 export entry, got %d in: %v", count, exports)
+}
+
+func (s *KernelExporterSuite) TestExportLongPath() {
+	// Create a deeply nested path that exceeds 64 characters, which causes
+	// exportfs -v to wrap the output across two lines.
+	nested := s.dir
+	for len(nested) <= 128 {
+		nested = nested + "/deeply"
+	}
+	err := os.MkdirAll(nested, 0o755)
+	s.Require().NoError(err, "MkdirAll")
+
+	err = s.exp.Export(s.ctx, nested, "127.0.0.1")
+	s.Require().NoError(err, "Export long path")
+
+	// TearDownTest only cleans s.dir; also clean the nested export.
+	s.T().Cleanup(func() { _ = s.exp.Unexport(s.ctx, nested, "") })
+
+	exports, err := s.exp.ListExports(s.ctx)
+	s.Require().NoError(err, "ListExports")
+
+	s.Assert().True(containsExport(exports, nested, "127.0.0.1"),
+		"expected long path %s in exports: %v", nested, exports)
+}
+
+func containsExport(exports []ExportInfo, path, client string) bool {
+	for _, e := range exports {
+		if e.Path == path && e.Client == client {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/storage/nfs/kernel_test.go
+++ b/agent/storage/nfs/kernel_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -27,38 +29,27 @@ func TestExport(t *testing.T) {
 		m := &utils.MockRunner{}
 		e := newTestExporter(m)
 
-		if err := e.Export(context.Background(), "/data/vol1", "10.0.0.1"); err != nil {
-			t.Fatalf("Export() error: %v", err)
-		}
-
-		if len(m.Calls) != 1 {
-			t.Fatalf("expected 1 call, got %d", len(m.Calls))
-		}
+		err := e.Export(context.Background(), "/data/vol1", "10.0.0.1")
+		require.NoError(t, err, "Export()")
+		require.Len(t, m.Calls, 1)
 
 		args := strings.Join(m.Calls[0], " ")
-		if !strings.Contains(args, "-o") {
-			t.Error("expected -o flag in args")
-		}
-		if !strings.Contains(args, "10.0.0.1:/data/vol1") {
-			t.Errorf("expected client:path in args, got: %s", args)
-		}
+		assert.Contains(t, args, "-o")
+		assert.Contains(t, args, "10.0.0.1:/data/vol1")
 
 		fsid := crc32.ChecksumIEEE([]byte("/data/vol1")) & fsidMask
 		if fsid == 0 {
 			fsid = 1
 		}
-		if !strings.Contains(args, fmt.Sprintf("fsid=%d", fsid)) {
-			t.Errorf("expected fsid=%d in args, got: %s", fsid, args)
-		}
+		assert.Contains(t, args, fmt.Sprintf("fsid=%d", fsid))
 	})
 
 	t.Run("error", func(t *testing.T) {
 		m := &utils.MockRunner{Err: fmt.Errorf("permission denied")}
 		e := newTestExporter(m)
 
-		if err := e.Export(context.Background(), "/data/vol1", "10.0.0.1"); err == nil {
-			t.Fatal("Export() should return error")
-		}
+		err := e.Export(context.Background(), "/data/vol1", "10.0.0.1")
+		require.Error(t, err)
 	})
 }
 
@@ -67,18 +58,13 @@ func TestUnexport(t *testing.T) {
 		m := &utils.MockRunner{}
 		e := newTestExporter(m)
 
-		if err := e.Unexport(context.Background(), "/data/vol1", "10.0.0.1"); err != nil {
-			t.Fatalf("Unexport() error: %v", err)
-		}
-
-		if len(m.Calls) != 1 {
-			t.Fatalf("expected 1 call, got %d", len(m.Calls))
-		}
+		err := e.Unexport(context.Background(), "/data/vol1", "10.0.0.1")
+		require.NoError(t, err, "Unexport()")
+		require.Len(t, m.Calls, 1)
 
 		args := strings.Join(m.Calls[0], " ")
-		if !strings.Contains(args, "-u") || !strings.Contains(args, "10.0.0.1:/data/vol1") {
-			t.Errorf("expected '-u 10.0.0.1:/data/vol1', got: %s", args)
-		}
+		assert.Contains(t, args, "-u")
+		assert.Contains(t, args, "10.0.0.1:/data/vol1")
 	})
 
 	t.Run("without client", func(t *testing.T) {
@@ -96,14 +82,10 @@ func TestUnexport(t *testing.T) {
 		}
 		e := newTestExporter(m)
 
-		if err := e.Unexport(context.Background(), "/data/vol1", ""); err != nil {
-			t.Fatalf("Unexport() error: %v", err)
-		}
-
+		err := e.Unexport(context.Background(), "/data/vol1", "")
+		require.NoError(t, err, "Unexport()")
 		// 1 ListExports call + 2 unexport calls
-		if len(m.Calls) != 3 {
-			t.Fatalf("expected 3 calls, got %d", len(m.Calls))
-		}
+		require.Len(t, m.Calls, 3)
 	})
 
 	t.Run("not found ignored", func(t *testing.T) {
@@ -113,9 +95,8 @@ func TestUnexport(t *testing.T) {
 		}
 		e := newTestExporter(m)
 
-		if err := e.Unexport(context.Background(), "/data/vol1", "10.0.0.1"); err != nil {
-			t.Errorf("Unexport() should ignore not-found, got: %v", err)
-		}
+		err := e.Unexport(context.Background(), "/data/vol1", "10.0.0.1")
+		assert.NoError(t, err, "Unexport() should ignore not-found")
 	})
 
 	t.Run("error", func(t *testing.T) {
@@ -125,9 +106,8 @@ func TestUnexport(t *testing.T) {
 		}
 		e := newTestExporter(m)
 
-		if err := e.Unexport(context.Background(), "/data/vol1", "10.0.0.1"); err == nil {
-			t.Fatal("Unexport() should return error when not a not-found error")
-		}
+		err := e.Unexport(context.Background(), "/data/vol1", "10.0.0.1")
+		require.Error(t, err)
 	})
 }
 
@@ -137,12 +117,8 @@ func TestListExports(t *testing.T) {
 		e := newTestExporter(m)
 
 		exports, err := e.ListExports(context.Background())
-		if err == nil {
-			t.Fatal("ListExports() should return error")
-		}
-		if exports != nil {
-			t.Errorf("ListExports() should return nil on error, got: %v", exports)
-		}
+		require.Error(t, err)
+		assert.Nil(t, exports)
 	})
 }
 
@@ -223,13 +199,9 @@ func TestParseExports(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseExports(tt.output)
-			if len(got) != len(tt.want) {
-				t.Fatalf("parseExports() returned %d exports, want %d", len(got), len(tt.want))
-			}
+			require.Len(t, got, len(tt.want))
 			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("export[%d] = %+v, want %+v", i, got[i], tt.want[i])
-				}
+				assert.Equal(t, tt.want[i], got[i], "export[%d]", i)
 			}
 		})
 	}

--- a/agent/storage/nfs/mock.go
+++ b/agent/storage/nfs/mock.go
@@ -1,0 +1,26 @@
+package nfs
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockExporter struct {
+	mock.Mock
+}
+
+func (m *MockExporter) Export(ctx context.Context, path string, client string) error {
+	args := m.Called(ctx, path, client)
+	return args.Error(0)
+}
+
+func (m *MockExporter) Unexport(ctx context.Context, path string, client string) error {
+	args := m.Called(ctx, path, client)
+	return args.Error(0)
+}
+
+func (m *MockExporter) ListExports(ctx context.Context) ([]ExportInfo, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]ExportInfo), args.Error(1)
+}

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -1,11 +1,9 @@
 package storage
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
-	"sync"
 )
 
 // --- Error types ---
@@ -66,72 +64,4 @@ func unixMode(m os.FileMode) uint64 {
 		mode |= 0o1000
 	}
 	return mode
-}
-
-// --- Metadata IO ---
-
-// ghetto mutex pool - because sync.Map told us "i'll hold your locks forever babe"
-// and we believed it until OOM said otherwise. ref-counted so we don't
-// accidentally give two goroutines different locks for the same path.
-var metaLocksMu sync.Mutex
-var metaLocksMap = map[string]*refMutex{}
-
-type refMutex struct {
-	mu   sync.Mutex
-	refs int
-}
-
-func metaLock(path string) *refMutex {
-	metaLocksMu.Lock()
-	rm, ok := metaLocksMap[path]
-	if !ok {
-		rm = &refMutex{}
-		metaLocksMap[path] = rm
-	}
-	rm.refs++
-	metaLocksMu.Unlock()
-	rm.mu.Lock()
-	return rm
-}
-
-func metaUnlock(path string, rm *refMutex) {
-	rm.mu.Unlock()
-	metaLocksMu.Lock()
-	rm.refs--
-	if rm.refs == 0 {
-		delete(metaLocksMap, path)
-	}
-	metaLocksMu.Unlock()
-}
-
-func writeMetadataAtomic(path string, v any) error {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
-}
-
-func ReadMetadata(path string, v any) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, v)
-}
-
-func UpdateMetadata[T any](path string, fn func(*T)) error {
-	rm := metaLock(path)
-	defer metaUnlock(path, rm)
-
-	var meta T
-	if err := ReadMetadata(path, &meta); err != nil {
-		return err
-	}
-	fn(&meta)
-	return writeMetadataAtomic(path, &meta)
 }

--- a/agent/storage/utils_test.go
+++ b/agent/storage/utils_test.go
@@ -1,0 +1,106 @@
+package storage
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// K8s allows actually 128 chars for PVC / Snapshot names, never have seen that
+func TestValidateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple", "myvolume", false},
+		{"with_hyphen", "vol-1", false},
+		{"with_underscore", "under_score", false},
+		{"single_char", "A", false},
+		{"max_length_64", strings.Repeat("a", 64), false},
+		{"pvc_name", "pvc-3f8a9b2c-1234-5678-9abc-def012345678", false},
+		{"snapshot", "snap-vol01", false},
+		{"snapcontent", "snapcontent-3f8a9b2c-1234-5678-9abc-def012345678", false},
+		{"empty", "", true},
+		{"too_long_65", strings.Repeat("a", 65), true},
+		{"has_space", "has space", true},
+		{"has_dot", "has.dot", true},
+		{"has_slash", "path/slash", true},
+		{"special_chars", "special!@#", true},
+		{"k8s_namespace_slash", "default/my-vol", true},
+		{"k8s_dotted_name", "my.volume.claim", true},
+		{"colon_separator", "snap:content", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateName(tt.input)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var se *StorageError
+			require.ErrorAs(t, err, &se)
+			assert.Equal(t, ErrInvalid, se.Code)
+		})
+	}
+}
+
+func TestFileMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    uint64
+		expected os.FileMode
+	}{
+		{"rwxr-xr-x", 0o755, os.FileMode(0o755)},
+		{"rw-r--r--", 0o644, os.FileMode(0o644)},
+		{"setuid", 0o4755, os.FileMode(0o755) | os.ModeSetuid},
+		{"setuid_no_other_read", 0o4750, os.FileMode(0o750) | os.ModeSetuid},
+		{"setgid", 0o2750, os.FileMode(0o750) | os.ModeSetgid},
+		{"setgid_no_other_exec", 0o2744, os.FileMode(0o744) | os.ModeSetgid},
+		{"sticky", 0o1777, os.FileMode(0o777) | os.ModeSticky},
+		{"sticky_no_other", 0o1770, os.FileMode(0o770) | os.ModeSticky},
+		{"setuid_setgid", 0o6755, os.FileMode(0o755) | os.ModeSetuid | os.ModeSetgid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, fileMode(tt.input))
+		})
+	}
+}
+
+func TestUnixMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    os.FileMode
+		expected uint64
+	}{
+		{"rwxr-xr-x", os.FileMode(0o755), 0o755},
+		{"rw-r--r--", os.FileMode(0o644), 0o644},
+		{"setuid", os.FileMode(0o755) | os.ModeSetuid, 0o4755},
+		{"setuid_no_other_read", os.FileMode(0o750) | os.ModeSetuid, 0o4750},
+		{"setgid", os.FileMode(0o750) | os.ModeSetgid, 0o2750},
+		{"setgid_no_other_exec", os.FileMode(0o744) | os.ModeSetgid, 0o2744},
+		{"sticky", os.FileMode(0o777) | os.ModeSticky, 0o1777},
+		{"sticky_no_other", os.FileMode(0o770) | os.ModeSticky, 0o1770},
+		{"setuid_setgid", os.FileMode(0o755) | os.ModeSetuid | os.ModeSetgid, 0o6755},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, unixMode(tt.input))
+		})
+	}
+}
+
+func TestFileModeRoundtrip(t *testing.T) {
+	values := []uint64{0o755, 0o644, 0o750, 0o700, 0o777, 0o4755, 0o4750, 0o2750, 0o2744, 0o1777, 0o1770, 0o6755}
+	for _, v := range values {
+		assert.Equal(t, v, unixMode(fileMode(v)), "roundtrip failed for %#o", v)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/labstack/echo/v5 v5.0.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.34.0
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.41.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
@@ -16,15 +17,19 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Summary
- Add integration tests for NFS kernel exporter (`exportfs` export/unexport/list, including long path multiline parsing), hope this works on GitHub Actions
- Migrate `nfs/kernel_test.go` to testify
- Add `gofmt` check to CI lint job
- Add `-race` flag to unit and integration test steps (For Metadata storage tests of the PVs)
- Extend CI integration job to install `nfs-kernel-server` and run all integration tests instead of only btrfs
- And refactored some code in agent for better readability