### PR TITLE
Separate agent metrics server from API

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -45,7 +45,7 @@ func (a *Agent) Start(ctx context.Context) {
 
 	// unauthenticated endpoints
 	e.GET("/healthz", v1.Healthz(a.version, a.commit, features))
-	e.GET("/metrics", v1.MetricsHandler())
+	startMetricsServer(a.cfg.MetricsAddr)
 
 	// NFS exporter
 	var exp nfs.Exporter

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog/log"
+)
+
+func startMetricsServer(addr string) {
+	if addr == "" {
+		return
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	go func() {
+		log.Info().Str("addr", addr).Msg("metrics server listening")
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			log.Error().Err(err).Msg("metrics server failed")
+		}
+	}()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ const (
 type AgentConfig struct {
 	BasePath             string        `env:"AGENT_BASE_PATH" envDefault:"./storage"`
 	ListenAddr           string        `env:"AGENT_LISTEN_ADDR" envDefault:":8080"`
+	MetricsAddr          string        `env:"AGENT_METRICS_ADDR" envDefault:"127.0.0.1:9090"`
 	Tenants              string        `env:"AGENT_TENANTS,required"`
 	TLSCert              string        `env:"AGENT_TLS_CERT"`
 	TLSKey               string        `env:"AGENT_TLS_KEY"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@
 | `AGENT_BASE_PATH` | `./storage` | btrfs mount point |
 | `AGENT_TENANTS` | **required** | `name:token,name:token` |
 | `AGENT_LISTEN_ADDR` | `:8080` | HTTP listen address |
+| `AGENT_METRICS_ADDR` | `127.0.0.1:9090` | Metrics server address |
 | `AGENT_TLS_CERT` | - | TLS certificate path |
 | `AGENT_TLS_KEY` | - | TLS key path |
 | `AGENT_FEATURE_QUOTA_ENABLED` | `true` | btrfs quota tracking |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,7 +2,7 @@
 
 36 metrics across 3 components.
 
-## Agent (26) - port 8080
+## Agent (26) - port 9090
 
 | Metric | Type | Labels |
 |---|---|---|


### PR DESCRIPTION
## Summary
- Move `/metrics` endpoint from the authenticated Echo API server (`:8080`) to a dedicated plain HTTP server (`127.0.0.1:9090` via `AGENT_METRICS_ADDR`)
- Aligns agent with the controller/driver pattern where metrics are served on a separate port