### PR TITLE
Add nix flake for the package and service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ btrfs-nfs-csi
 *.test
 *.out
 .env
+result

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,6 +103,46 @@ curl -Lo /etc/systemd/system/btrfs-nfs-csi-agent.service \
 
 To build from source: `CGO_ENABLED=0 go build -o btrfs-nfs-csi .`
 
+### 3c. NixOS
+
+This is an example working flake:
+
+```nix
+{
+  inputs = {
+    ...
+    btrfs-nfs-csi.url = "github:erikmagkekse/btrfs-nfs-csi";
+  };
+
+  outputs = {
+    nixpkgs,
+    ...,
+    btrfs-nfs-csi
+  }: {
+    nixosConfigurations."demo" = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        btrfs-nfs-csi.nixosModules.btrfs-nfs-csi
+        {
+          services.btrfs-nfs-csi.agent = {
+            enable = true;
+
+            basePath = "/export/data";
+            listenAddr = ":8080";
+
+            environmentFile = ./envfile.env;
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+WARNING: The NixOS module does not read from ``/etc/btrfs-nfs-csi``, you need to specify the configuration file as an option.
+
+To hide environment secrets from the store, I suggest using something like [sops-nix](https://github.com/Mic92/sops-nix).
+
 ### 4. Configure and Start
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Kubernetes Enterprise storage vibes for your homelab.";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default-linux";
+  };
+
+  outputs =
+    inputs@{ self, flake-parts, ... }: let
+      rev = inputs.self.shortRev or inputs.self.dirtyShortRev;
+    in flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+      perSystem =
+        { pkgs, ... }:
+        {
+          packages = rec {
+            btrfs-nfs-csi = pkgs.callPackage ./package.nix { inherit rev; };
+            default = btrfs-nfs-csi;
+          };
+        };
+      flake.nixosModules = rec {
+        btrfs-nfs-csi = { pkgs, lib, ... }: {
+          imports = [ ./nixos.nix ];
+          services.btrfs-nfs-csi.agent.package = lib.mkDefault
+            self.packages.${pkgs.stdenv.hostPlatform.system}.btrfs-nfs-csi;
+        };
+        default = btrfs-nfs-csi;
+      };
+    };
+}
+

--- a/nixos.nix
+++ b/nixos.nix
@@ -1,0 +1,80 @@
+{
+  config,
+  lib,
+  pkgs,
+  rev,
+  ...
+}:
+let
+  cfg = config.services.btrfs-nfs-csi.agent;
+
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    ;
+
+  inherit (lib.types) package;
+in
+{
+  options.services.btrfs-nfs-csi.agent = {
+    enable = mkEnableOption "BTRFS-NFS CSI agent";
+
+    basePath = lib.mkOption {
+      type = lib.types.str;
+      default = "/export/data";
+      description = "Base path for btrfs subvolume creation (AGENT_BASE_PATH)";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to environment file containing secrets such as AGENT_TENANTS";
+    };
+
+    listenAddr = lib.mkOption {
+      type = lib.types.str;
+      default = ":8000";
+      description = "Address for the agent to listen on (AGENT_LISTEN_ADDR)";
+    };
+
+    package = mkOption {
+      type = package;
+      description = "The btrfs-nfs-csi package to use";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.environmentFile != null;
+        message = "services.btrfs-nfs-csi-agent.environmentFile must be set because AGENT_TENTATS is required to run the service";
+      }
+    ];
+
+    # This parodies deploy/agent/agent.service
+    systemd.services."btrfs-nfs-csi-agent" = {
+      description = "btrfs-nfs-csi agent";
+      after = [ "network.target" ];
+
+      environment = {
+        AGENT_BASE_PATH   = cfg.basePath;
+        AGENT_LISTEN_ADDR = cfg.listenAddr;
+      };
+
+      path = [
+        pkgs.btrfs-progs
+        pkgs.nfs-utils
+      ];
+
+      script = "${cfg.package}/bin/btrfs-nfs-csi agent";
+      serviceConfig = {
+        EnvironmentFile = cfg.environmentFile;
+        Restart = "always";
+        RestartSec = "5";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}
+

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,17 @@
+{
+  buildGoModule,
+  rev
+}: let
+  src = ./.;
+  version = builtins.readFile "${src}/VERSION";
+in buildGoModule {
+  pname = "btrfs-nfs-csi";
+  inherit version;
+  inherit src;
+
+  ldflags = [
+    "-X main.version=${version} -X main.commit=${rev}"
+  ];
+
+  vendorHash = "sha256-yRCmPMMli/EmnAavGXD/eqtGHs7ZGo9ww06kkP8aR8I=";
+}


### PR DESCRIPTION
Hello, 

I really like what you're doing with this Kubernetes operator, this is just what homelabbers needed.

Anyway, since I'm on NixOS, I thought I could add flake files which would trivialize setup of this operator's agent for anyone using NixOS on their homelab. Basic instructions were added to docs/installation.md, the rest stays the same in terms of setup.