### PR TITLE
Block volume deletion when NFS exports are active

### DIFF
--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -218,3 +218,10 @@ func IsNotFound(err error) bool {
 	}
 	return false
 }
+
+func IsLocked(err error) bool {
+	if ae, ok := err.(*AgentError); ok {
+		return ae.StatusCode == http.StatusLocked
+	}
+	return false
+}

--- a/agent/api/v1/utils.go
+++ b/agent/api/v1/utils.go
@@ -12,6 +12,7 @@ var codeStatus = map[string]int{
 	storage.ErrInvalid:       http.StatusBadRequest,
 	storage.ErrNotFound:      http.StatusNotFound,
 	storage.ErrAlreadyExists: http.StatusConflict,
+	storage.ErrBusy:          http.StatusLocked,
 }
 
 func StorageError(c *echo.Context, err error) error {

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -12,6 +12,7 @@ const (
 	ErrInvalid       = "INVALID"
 	ErrNotFound      = "NOT_FOUND"
 	ErrAlreadyExists = "ALREADY_EXISTS"
+	ErrBusy          = "BUSY"
 )
 
 type StorageError struct {

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -309,8 +309,13 @@ func (s *Storage) DeleteVolume(ctx context.Context, tenant, name string) error {
 		return &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("volume %q not found", name)}
 	}
 
-	if err := s.exporter.Unexport(ctx, volDir, ""); err != nil {
-		log.Warn().Err(err).Str("path", volDir).Msg("failed to unexport via NFS")
+	var meta VolumeMetadata
+	metaPath := filepath.Join(volDir, config.MetadataFile)
+	if err := ReadMetadata(metaPath, &meta); err != nil {
+		return fmt.Errorf("failed to read volume metadata: %w", err)
+	}
+	if len(meta.Clients) > 0 {
+		return &StorageError{Code: ErrBusy, Message: fmt.Sprintf("volume %q still has active NFS exports", name)}
 	}
 
 	dataDir := filepath.Join(volDir, config.DataDir)

--- a/agent/storage/volume_test.go
+++ b/agent/storage/volume_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -501,20 +500,17 @@ func TestDeleteVolume(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("success", func(t *testing.T) {
-		s, bp, _, exporter := newTestStorage(t)
+		s, bp, _, _ := newTestStorage(t)
 
 		volDir := filepath.Join(bp, "myvol")
 		require.NoError(t, os.MkdirAll(volDir, 0o755))
 		writeTestMetadata(t, volDir, VolumeMetadata{Name: "myvol"})
-
-		exporter.On("Unexport", mock.Anything, volDir, "").Return(nil)
 
 		err := s.DeleteVolume(ctx, "test", "myvol")
 		require.NoError(t, err, "DeleteVolume")
 
 		_, statErr := os.Stat(volDir)
 		assert.True(t, os.IsNotExist(statErr), "volDir should be removed")
-		exporter.AssertExpectations(t)
 	})
 
 	t.Run("not_found", func(t *testing.T) {
@@ -524,20 +520,18 @@ func TestDeleteVolume(t *testing.T) {
 		requireStorageError(t, err, ErrNotFound)
 	})
 
-	t.Run("unexport_failure_continues", func(t *testing.T) {
-		s, bp, _, exporter := newTestStorage(t)
+	t.Run("busy_with_exports", func(t *testing.T) {
+		s, bp, _, _ := newTestStorage(t)
 
 		volDir := filepath.Join(bp, "myvol")
 		require.NoError(t, os.MkdirAll(volDir, 0o755))
-		writeTestMetadata(t, volDir, VolumeMetadata{Name: "myvol"})
-
-		exporter.On("Unexport", mock.Anything, volDir, "").Return(fmt.Errorf("nfs error"))
+		writeTestMetadata(t, volDir, VolumeMetadata{Name: "myvol", Clients: []string{"10.0.0.1"}})
 
 		err := s.DeleteVolume(ctx, "test", "myvol")
-		require.NoError(t, err, "unexport failure should not block delete")
+		requireStorageError(t, err, ErrBusy)
 
 		_, statErr := os.Stat(volDir)
-		assert.True(t, os.IsNotExist(statErr), "volDir should be removed despite unexport failure")
+		assert.False(t, os.IsNotExist(statErr), "volDir should still exist when exports are active")
 	})
 
 	t.Run("subvol_delete_fails", func(t *testing.T) {
@@ -548,8 +542,6 @@ func TestDeleteVolume(t *testing.T) {
 		volDir := filepath.Join(bp, "myvol")
 		require.NoError(t, os.MkdirAll(volDir, 0o755))
 		writeTestMetadata(t, volDir, VolumeMetadata{Name: "myvol"})
-
-		exporter.On("Unexport", mock.Anything, volDir, "").Return(nil)
 
 		err := s.DeleteVolume(ctx, "test", "myvol")
 		require.Error(t, err)

--- a/controller/volumes.go
+++ b/controller/volumes.go
@@ -213,6 +213,10 @@ func (s *Server) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 			agentOpsTotal.WithLabelValues("delete_volume", "not_found", sc).Inc()
 			return &csi.DeleteVolumeResponse{}, nil
 		}
+		if agentAPI.IsLocked(deleteErr) {
+			agentOpsTotal.WithLabelValues("delete_volume", "busy", sc).Inc()
+			return nil, status.Errorf(codes.FailedPrecondition, "delete volume: %v", deleteErr)
+		}
 		agentOpsTotal.WithLabelValues("delete_volume", "error", sc).Inc()
 		return nil, status.Errorf(codes.Internal, "delete volume: %v", deleteErr)
 	}

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -126,7 +126,7 @@ All fields optional. `size_bytes` must be larger than current.
 
 ### DELETE /v1/volumes/:name
 
-204 No Content. 404 if not found.
+204 No Content. 404 if not found. 423 if the volume still has active NFS exports, unexport all clients first.
 
 ## NFS Exports
 


### PR DESCRIPTION
## Summary
- Volume deletion now returns `ErrBusy` (HTTP 423) when the volume still has active NFS clients in metadata
- Controller maps this to `codes.FailedPrecondition` so Kubernetes retries after unpublish
- Checks `meta.Clients` instead of shelling out to `exportfs`, consistent with metadata-first pattern