### PR TITLE
PVC-to-PVC volume cloning

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -91,6 +91,7 @@ func (a *Agent) Start(ctx context.Context) {
 	api.DELETE("/snapshots/:name", h.DeleteSnapshot)
 
 	api.POST("/clones", h.CreateClone)
+	api.POST("/volumes/clone", h.CloneVolume)
 
 	a.echo = e
 	a.ready = true

--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -72,6 +72,17 @@ func (c *Client) CreateClone(ctx context.Context, req CloneCreateRequest) (*Clon
 	return &resp, nil
 }
 
+func (c *Client) CloneVolume(ctx context.Context, req VolumeCloneRequest) (*VolumeDetailResponse, error) {
+	var resp VolumeDetailResponse
+	if err := c.do(ctx, http.MethodPost, "/v1/volumes/clone", req, &resp); err != nil {
+		if IsConflict(err) {
+			return &resp, err
+		}
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (c *Client) ExportVolume(ctx context.Context, name string, cl string) error {
 	return c.do(ctx, http.MethodPost, "/v1/volumes/"+name+"/export", ExportRequest{Client: cl}, nil)
 }

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -323,6 +323,27 @@ func (h *Handler) DeleteSnapshot(c *echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// --- Volume Clone (PVC-to-PVC) ---
+
+func (h *Handler) CloneVolume(c *echo.Context) error {
+	tenant := c.Get("tenant").(string)
+
+	var req storage.VolumeCloneRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body", Code: "BAD_REQUEST"})
+	}
+
+	meta, err := h.Store.CloneVolume(c.Request().Context(), tenant, req)
+	if err != nil {
+		if meta != nil {
+			return c.JSON(http.StatusConflict, volumeDetailResponseFrom(meta))
+		}
+		return StorageError(c, err)
+	}
+
+	return c.JSON(http.StatusCreated, volumeDetailResponseFrom(meta))
+}
+
 // --- Clones ---
 
 func (h *Handler) CreateClone(c *echo.Context) error {

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -13,6 +13,7 @@ type (
 	VolumeUpdateRequest   = storage.VolumeUpdateRequest
 	SnapshotCreateRequest = storage.SnapshotCreateRequest
 	CloneCreateRequest    = storage.CloneCreateRequest
+	VolumeCloneRequest    = storage.VolumeCloneRequest
 	VolumeMetadata        = storage.VolumeMetadata
 	SnapshotMetadata      = storage.SnapshotMetadata
 	CloneMetadata         = storage.CloneMetadata

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -72,6 +72,11 @@ type CloneCreateRequest struct {
 	Name     string `json:"name"`
 }
 
+type VolumeCloneRequest struct {
+	Source string `json:"source"`
+	Name   string `json:"name"`
+}
+
 type ExportEntry struct {
 	Path   string `json:"path"`
 	Client string `json:"client"`

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -295,6 +295,82 @@ func (s *Storage) UpdateVolume(ctx context.Context, tenant, name string, req Vol
 	return &updated, nil
 }
 
+func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeCloneRequest) (*VolumeMetadata, error) {
+	bp, err := s.tenantPath(tenant)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateName(req.Name); err != nil {
+		return nil, err
+	}
+
+	src, err := s.GetVolume(tenant, req.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	cloneDir := filepath.Join(bp, req.Name)
+	if _, err := os.Stat(cloneDir); err == nil {
+		var existing VolumeMetadata
+		if err := ReadMetadata(filepath.Join(cloneDir, config.MetadataFile), &existing); err != nil {
+			return nil, fmt.Errorf("volume %q exists but metadata is corrupt: %w", req.Name, err)
+		}
+		return &existing, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("volume %q already exists", req.Name)}
+	}
+
+	if err := os.MkdirAll(cloneDir, s.defaultDirMode); err != nil {
+		return nil, fmt.Errorf("create clone directory: %w", err)
+	}
+
+	srcData := filepath.Join(bp, req.Source, config.DataDir)
+	cloneData := filepath.Join(cloneDir, config.DataDir)
+
+	cleanup := func() {
+		if err := s.btrfs.SubvolumeDelete(ctx, cloneData); err != nil {
+			log.Warn().Err(err).Str("path", cloneData).Msg("cleanup: failed to delete subvolume")
+		}
+		if err := os.RemoveAll(cloneDir); err != nil {
+			log.Warn().Err(err).Str("path", cloneDir).Msg("cleanup: failed to remove directory")
+		}
+	}
+
+	if err := s.btrfs.SubvolumeSnapshot(ctx, srcData, cloneData, false); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("btrfs snapshot failed: %w", err)
+	}
+
+	if s.quotaEnabled {
+		if err := s.btrfs.QgroupLimit(ctx, cloneData, src.QuotaBytes); err != nil {
+			log.Error().Err(err).Str("path", cloneData).Msg("failed to set qgroup limit on clone")
+			cleanup()
+			return nil, fmt.Errorf("qgroup limit failed: %w", err)
+		}
+	}
+
+	now := time.Now().UTC()
+	meta := VolumeMetadata{
+		Name:        req.Name,
+		Path:        cloneDir,
+		SizeBytes:   src.SizeBytes,
+		NoCOW:       src.NoCOW,
+		Compression: src.Compression,
+		QuotaBytes:  src.QuotaBytes,
+		UID:         src.UID,
+		GID:         src.GID,
+		Mode:        src.Mode,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := writeMetadataAtomic(filepath.Join(cloneDir, config.MetadataFile), meta); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to write metadata: %w", err)
+	}
+
+	log.Info().Str("tenant", tenant).Str("name", req.Name).Str("source", req.Source).Msg("volume cloned")
+	return &meta, nil
+}
+
 func (s *Storage) DeleteVolume(ctx context.Context, tenant, name string) error {
 	bp, err := s.tenantPath(tenant)
 	if err != nil {

--- a/controller/volumes.go
+++ b/controller/volumes.go
@@ -99,11 +99,52 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		volCtx[config.PvcNamespaceKey] = ns
 	}
 
-	// Clone from snapshot
+	// Clone from volume or snapshot
 	if req.VolumeContentSource != nil {
+		// PVC-to-PVC clone
+		if srcVol := req.VolumeContentSource.GetVolume(); srcVol != nil {
+			_, srcName, err := utils.ParseVolumeID(srcVol.VolumeId)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid source volume ID: %v", err)
+			}
+
+			start := time.Now()
+			cloneResp, err := client.CloneVolume(ctx, agentAPI.VolumeCloneRequest{
+				Source: srcName,
+				Name:   req.Name,
+			})
+			agentDuration.WithLabelValues("clone_volume", sc).Observe(time.Since(start).Seconds())
+			if err != nil {
+				if agentAPI.IsConflict(err) {
+					agentOpsTotal.WithLabelValues("clone_volume", "conflict", sc).Inc()
+					if cloneResp == nil {
+						return nil, status.Errorf(codes.Internal, "clone conflict but no metadata returned: %v", err)
+					}
+				} else {
+					agentOpsTotal.WithLabelValues("clone_volume", "error", sc).Inc()
+					return nil, status.Errorf(codes.Internal, "clone volume: %v", err)
+				}
+			} else {
+				agentOpsTotal.WithLabelValues("clone_volume", "success", sc).Inc()
+			}
+			volCtx[config.ParamNFSSharePath] = cloneResp.Path
+
+			log.Info().Str("volume", req.Name).Str("source", srcName).Msg("volume cloned from volume")
+
+			return &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					VolumeId:      utils.MakeVolumeID(sc, req.Name),
+					CapacityBytes: int64(sizeBytes),
+					VolumeContext: volCtx,
+					ContentSource: req.VolumeContentSource,
+				},
+			}, nil
+		}
+
+		// Clone from snapshot
 		snap := req.VolumeContentSource.GetSnapshot()
 		if snap == nil {
-			return nil, status.Error(codes.InvalidArgument, "only snapshot content source is supported")
+			return nil, status.Error(codes.InvalidArgument, "unsupported content source")
 		}
 		_, snapName, err := utils.ParseVolumeID(snap.SnapshotId)
 		if err != nil {

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -231,11 +231,42 @@ Returns a summary list of snapshots for a specific volume. Same response format 
 
 204 No Content. 404 if not found.
 
-## Clones
+## Volume Clone (PVC-to-PVC)
+
+### POST /v1/volumes/clone
+
+Direct volume-to-volume clone via a single atomic btrfs snapshot. No intermediate snapshot needed. 409 returns existing volume.
+
+```json
+// Request
+{
+  "source": "my-volume",
+  "name": "my-clone"
+}
+
+// Response 201
+{
+  "name": "my-clone",
+  "path": "/srv/csi/default/my-clone",
+  "size_bytes": 10737418240,
+  "nocow": false,
+  "compression": "zstd",
+  "quota_bytes": 10737418240,
+  "used_bytes": 0,
+  "uid": 0,
+  "gid": 0,
+  "mode": "2770",
+  "clients": [],
+  "created_at": "2025-01-15T12:30:00Z",
+  "updated_at": "2025-01-15T12:30:00Z"
+}
+```
+
+## Clones (from Snapshot)
 
 ### POST /v1/clones
 
-409 returns existing clone.
+Clone from a read-only snapshot. 409 returns existing clone.
 
 ```json
 // Request

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -59,6 +59,7 @@ Device IO metrics are updated every 5s (configurable via `AGENT_DEVICE_IO_INTERV
 | `create_snapshot` | `success`, `error`, `conflict` |
 | `delete_snapshot` | `success`, `error`, `not_found` |
 | `create_clone` | `success`, `error`, `conflict` |
+| `clone_volume` | `success`, `error`, `conflict` |
 | `export` | `success`, `error` |
 | `unexport` | `success`, `error`, `not_found` |
 | `update_volume` | `success`, `error` |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -21,7 +21,9 @@ Usage updater tracks `used_bytes` (referenced) and `exclusive_bytes` (unique blo
 
 ## Clones
 
-Writable snapshot from a read-only snapshot. Instant, independent of source.
+### From Snapshot
+
+Writable clone from a read-only VolumeSnapshot. Instant, independent of source.
 
 ```yaml
 apiVersion: v1
@@ -40,7 +42,27 @@ spec:
     apiGroup: snapshot.storage.k8s.io
 ```
 
-Agent: `btrfs subvolume snapshot <src>/data <dst>/data` (writable) → stored at `{basePath}/{tenant}/{name}/`
+### From PVC (PVC-to-PVC)
+
+Direct clone from an existing PVC. No intermediate snapshot needed, a single atomic `btrfs subvolume snapshot` under the hood.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-clone
+spec:
+  storageClassName: btrfs-nfs
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+  dataSource:
+    name: source-pvc
+    kind: PersistentVolumeClaim
+```
+
+Both clone types are instant (btrfs CoW), independent of the source, and stored at `{basePath}/{tenant}/{name}/`.
 
 ## Expansion
 


### PR DESCRIPTION
## Summary
- Add direct PVC-to-PVC cloning support (`dataSource.kind: PersistentVolumeClaim`)
- Single atomic `btrfs subvolume snapshot` under the hood, no intermediate snapshot needed
- New agent endpoint `POST /v1/volumes/clone`