### PR TITLE
Task system and btrfs scrub

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ If you run a homelab, a small on-prem cluster, or an edge deployment and want re
 - Dynamic device discovery with live stats, hot-added devices are picked up automatically
 - Prometheus `/metrics` on all components
 - Web dashboard (`/v1/dashboard`)
+- Background task system with progress tracking and persistence
+- Filesystem scrub via API (`POST /v1/tasks/scrub`)
 - TLS support
 - HA via DRBD + Pacemaker (active/passive failover)
 
 **Roadmap:**
-NFS-Ganesha support, `VOLUME_CONDITION` health reporting
+NFS-Ganesha support, cross-agent snapshot transfers, `VOLUME_CONDITION` health reporting
 
 ## Quick Start
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,7 +64,7 @@ func (a *Agent) Start(ctx context.Context) {
 		a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames,
 		a.cfg.DefaultDirMode, a.cfg.DefaultDataMode, a.cfg.BtrfsBin,
 	)
-	h := &v1.Handler{Store: store}
+	h := &v1.Handler{Store: store, Tasks: store.Tasks()}
 
 	// unauthenticated endpoints
 	e.GET("/healthz", v1.Healthz(a.version, a.commit, features, store))
@@ -93,10 +93,15 @@ func (a *Agent) Start(ctx context.Context) {
 	api.POST("/clones", h.CreateClone)
 	api.POST("/volumes/clone", h.CloneVolume)
 
+	api.GET("/tasks", h.ListTasks)
+	api.POST("/tasks/scrub", h.StartScrub)
+	api.GET("/tasks/:id", h.GetTask)
+	api.DELETE("/tasks/:id", h.CancelTask)
+
 	a.echo = e
 	a.ready = true
 
-	store.StartWorkers(ctx, a.cfg.UsageInterval, a.cfg.NFSReconcileInterval, a.cfg.DeviceIOInterval, a.cfg.DeviceStatsInterval)
+	store.StartWorkers(ctx, a.cfg.UsageInterval, a.cfg.NFSReconcileInterval, a.cfg.DeviceIOInterval, a.cfg.DeviceStatsInterval, a.cfg.TaskCleanupInterval)
 
 	go func() {
 		var err error

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -10,6 +10,7 @@ import (
 
 type Handler struct {
 	Store *storage.Storage
+	Tasks *storage.TaskManager
 }
 
 // --- Volumes ---
@@ -373,4 +374,39 @@ func (h *Handler) CreateClone(c *echo.Context) error {
 		Path:           meta.Path,
 		CreatedAt:      meta.CreatedAt,
 	})
+}
+
+// --- Scrub ---
+
+func (h *Handler) StartScrub(c *echo.Context) error {
+	taskID, err := h.Store.StartScrub(c.Request().Context())
+	if err != nil {
+		return StorageError(c, err)
+	}
+	return c.JSON(http.StatusAccepted, map[string]any{
+		"task_id": taskID,
+		"status":  storage.TaskPending,
+	})
+}
+
+// --- Tasks ---
+
+func (h *Handler) ListTasks(c *echo.Context) error {
+	tasks := h.Tasks.List(c.QueryParam("type"))
+	return c.JSON(http.StatusOK, TaskListResponse{Tasks: tasks, Total: len(tasks)})
+}
+
+func (h *Handler) GetTask(c *echo.Context) error {
+	task, err := h.Tasks.Get(c.Param("id"))
+	if err != nil {
+		return StorageError(c, err)
+	}
+	return c.JSON(http.StatusOK, task)
+}
+
+func (h *Handler) CancelTask(c *echo.Context) error {
+	if err := h.Tasks.Cancel(c.Param("id")); err != nil {
+		return StorageError(c, err)
+	}
+	return c.NoContent(http.StatusNoContent)
 }

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -159,6 +159,11 @@ type FilesystemStatsResponse struct {
 	Devices            []DeviceStatsResponse `json:"devices"`
 }
 
+type TaskListResponse struct {
+	Tasks []storage.Task `json:"tasks"`
+	Total int            `json:"total"`
+}
+
 type ErrorResponse struct {
 	Error string `json:"error"`
 	Code  string `json:"code"`

--- a/agent/storage/btrfs/btrfs.go
+++ b/agent/storage/btrfs/btrfs.go
@@ -171,6 +171,21 @@ func (m *Manager) FilesystemUsage(ctx context.Context, path string) (FilesystemU
 	return parseFilesystemUsage(out)
 }
 
+// ScrubStart runs a btrfs scrub in foreground mode (-B).
+// Blocks until the scrub completes or the context is cancelled.
+func (m *Manager) ScrubStart(ctx context.Context, path string) error {
+	return m.run(ctx, "scrub", "start", "-B", path)
+}
+
+// ScrubStatus returns the status of the last/current scrub on the filesystem at path.
+func (m *Manager) ScrubStatus(ctx context.Context, path string) (*ScrubStatus, error) {
+	out, err := m.cmd.Run(ctx, m.bin, "scrub", "status", "-R", path)
+	if err != nil {
+		return nil, err
+	}
+	return parseScrubStatus(out)
+}
+
 func (m *Manager) SubvolumeList(ctx context.Context, path string) ([]SubvolumeInfo, error) {
 	out, err := m.cmd.Run(ctx, m.bin, "subvolume", "list", "-o", path)
 	if err != nil {

--- a/agent/storage/btrfs/btrfs_test.go
+++ b/agent/storage/btrfs/btrfs_test.go
@@ -496,3 +496,110 @@ func TestDevices(t *testing.T) {
 		assert.ErrorContains(t, err, "no devices found")
 	})
 }
+
+func TestScrubStatus(t *testing.T) {
+	t.Run("finished", func(t *testing.T) {
+		out := strings.Join([]string{
+			"UUID:             a8172da2-5e15-4125-bb09-23169dafd6da",
+			"Scrub started:    Wed Apr  1 10:00:00 2026",
+			"Status:           finished",
+			"Duration:         0:05:23",
+			"Total to scrub:   40.00GiB",
+			"Rate:             127.45MiB/s",
+			"data_extents_scrubbed: 524288",
+			"tree_extents_scrubbed: 16384",
+			"data_bytes_scrubbed: 536870912",
+			"tree_bytes_scrubbed: 268435456",
+			"read_errors: 0",
+			"csum_errors: 0",
+			"verify_errors: 0",
+			"no_csum: 0",
+			"csum_discards: 0",
+			"super_errors: 0",
+			"malloc_errors: 0",
+			"uncorrectable_errors: 0",
+			"unverified_errors: 0",
+			"corrected_errors: 0",
+			"last_physical: 536870912",
+		}, "\n")
+
+		m := &utils.MockRunner{Out: out}
+		mgr := newTestManager(m)
+
+		s, err := mgr.ScrubStatus(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		assert.False(t, s.Running)
+		assert.Equal(t, uint64(536870912), s.DataBytesScrubbed)
+		assert.Equal(t, uint64(268435456), s.TreeBytesScrubbed)
+		assert.Equal(t, uint64(0), s.ReadErrors)
+		assert.Equal(t, uint64(0), s.CSumErrors)
+		assert.Equal(t, uint64(0), s.VerifyErrors)
+		assert.Equal(t, uint64(0), s.SuperErrors)
+		assert.Equal(t, uint64(0), s.UncorrectableErrs)
+		assert.Equal(t, uint64(0), s.CorrectedErrs)
+	})
+
+	t.Run("running", func(t *testing.T) {
+		out := strings.Join([]string{
+			"UUID:             a8172da2-5e15-4125-bb09-23169dafd6da",
+			"Scrub started:    Wed Apr  1 10:00:00 2026",
+			"Status:           running",
+			"data_bytes_scrubbed: 100000000",
+			"tree_bytes_scrubbed: 50000000",
+			"read_errors: 0",
+			"csum_errors: 0",
+		}, "\n")
+
+		m := &utils.MockRunner{Out: out}
+		mgr := newTestManager(m)
+
+		s, err := mgr.ScrubStatus(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		assert.True(t, s.Running)
+		assert.Equal(t, uint64(100000000), s.DataBytesScrubbed)
+		assert.Equal(t, uint64(50000000), s.TreeBytesScrubbed)
+	})
+
+	t.Run("with errors", func(t *testing.T) {
+		out := strings.Join([]string{
+			"Status:           finished",
+			"data_bytes_scrubbed: 536870912",
+			"tree_bytes_scrubbed: 268435456",
+			"read_errors: 3",
+			"csum_errors: 2",
+			"verify_errors: 1",
+			"super_errors: 0",
+			"uncorrectable_errors: 5",
+			"corrected_errors: 1",
+		}, "\n")
+
+		m := &utils.MockRunner{Out: out}
+		mgr := newTestManager(m)
+
+		s, err := mgr.ScrubStatus(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(3), s.ReadErrors)
+		assert.Equal(t, uint64(2), s.CSumErrors)
+		assert.Equal(t, uint64(1), s.VerifyErrors)
+		assert.Equal(t, uint64(5), s.UncorrectableErrs)
+		assert.Equal(t, uint64(1), s.CorrectedErrs)
+	})
+
+	t.Run("command error", func(t *testing.T) {
+		m := &utils.MockRunner{Err: fmt.Errorf("scrub status failed")}
+		mgr := newTestManager(m)
+
+		_, err := mgr.ScrubStatus(context.Background(), "/mnt/data")
+		require.Error(t, err)
+	})
+
+	t.Run("scrub start uses foreground mode", func(t *testing.T) {
+		m := &utils.MockRunner{}
+		mgr := newTestManager(m)
+
+		err := mgr.ScrubStart(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		require.Len(t, m.Calls, 1)
+		assert.Equal(t, []string{"scrub", "start", "-B", "/mnt/data"}, m.Calls[0])
+	})
+}

--- a/agent/storage/btrfs/integration_test.go
+++ b/agent/storage/btrfs/integration_test.go
@@ -251,3 +251,48 @@ func (s *BtrfsIntegrationSuite) TestConcurrentSnapshot() {
 	}
 	s.Assert().Equal(31, snapCount, "expected 31 cs-snap-* snapshots")
 }
+
+func (s *BtrfsIntegrationSuite) TestScrubStartAndStatus() {
+	// write some data so scrub has something to check
+	subPath := filepath.Join(s.mnt, "scrubvol")
+	err := s.mgr.SubvolumeCreate(s.ctx, subPath)
+	s.Require().NoError(err, "SubvolumeCreate")
+
+	data := make([]byte, 256*1024)
+	err = os.WriteFile(filepath.Join(subPath, "testfile"), data, 0o644)
+	s.Require().NoError(err, "WriteFile")
+
+	_, err = s.cmd.Run(s.ctx, "sync")
+	s.Require().NoError(err, "sync")
+
+	// run scrub in foreground (-B)
+	err = s.mgr.ScrubStart(s.ctx, s.mnt)
+	s.Require().NoError(err, "ScrubStart")
+
+	// check result
+	status, err := s.mgr.ScrubStatus(s.ctx, s.mnt)
+	s.Require().NoError(err, "ScrubStatus")
+	s.Assert().False(status.Running, "scrub should be finished")
+	s.Assert().NotZero(status.DataBytesScrubbed, "should have scrubbed some data bytes")
+	s.Assert().Equal(uint64(0), status.ReadErrors, "no read errors expected")
+	s.Assert().Equal(uint64(0), status.CSumErrors, "no csum errors expected")
+	s.Assert().Equal(uint64(0), status.UncorrectableErrs, "no uncorrectable errors expected")
+}
+
+func (s *BtrfsIntegrationSuite) TestScrubCancelViaContext() {
+	ctx, cancel := context.WithCancel(s.ctx)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.mgr.ScrubStart(ctx, s.mnt)
+	}()
+
+	// cancel immediately
+	cancel()
+
+	err := <-done
+	// either the scrub finished before cancel (small filesystem) or was killed
+	if err != nil {
+		s.Assert().ErrorIs(err, context.Canceled, "should be context.Canceled or wrapped")
+	}
+}

--- a/agent/storage/btrfs/model.go
+++ b/agent/storage/btrfs/model.go
@@ -40,3 +40,15 @@ type QgroupInfo struct {
 	Referenced uint64
 	Exclusive  uint64
 }
+
+type ScrubStatus struct {
+	DataBytesScrubbed uint64 `json:"data_bytes_scrubbed"`
+	TreeBytesScrubbed uint64 `json:"tree_bytes_scrubbed"`
+	ReadErrors        uint64 `json:"read_errors"`
+	CSumErrors        uint64 `json:"csum_errors"`
+	VerifyErrors      uint64 `json:"verify_errors"`
+	SuperErrors       uint64 `json:"super_errors"`
+	UncorrectableErrs uint64 `json:"uncorrectable_errors"`
+	CorrectedErrs     uint64 `json:"corrected_errors"`
+	Running           bool   `json:"running"`
+}

--- a/agent/storage/btrfs/utils.go
+++ b/agent/storage/btrfs/utils.go
@@ -179,6 +179,47 @@ func parseKVBytes(line string) (key string, val uint64, ok bool) {
 	return key, v, true
 }
 
+// parseScrubStatus parses `btrfs scrub status -R` output.
+// Key lines: "Status: running/finished/aborted/no stats available"
+// and "key: value" pairs for counters.
+func parseScrubStatus(out string) (*ScrubStatus, error) {
+	s := &ScrubStatus{}
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		parts := strings.SplitN(trimmed, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "Status":
+			s.Running = val == "running"
+		case "data_bytes_scrubbed":
+			s.DataBytesScrubbed, _ = strconv.ParseUint(val, 10, 64)
+		case "tree_bytes_scrubbed":
+			s.TreeBytesScrubbed, _ = strconv.ParseUint(val, 10, 64)
+		case "read_errors":
+			s.ReadErrors, _ = strconv.ParseUint(val, 10, 64)
+		case "csum_errors":
+			s.CSumErrors, _ = strconv.ParseUint(val, 10, 64)
+		case "verify_errors":
+			s.VerifyErrors, _ = strconv.ParseUint(val, 10, 64)
+		case "super_errors":
+			s.SuperErrors, _ = strconv.ParseUint(val, 10, 64)
+		case "uncorrectable_errors":
+			s.UncorrectableErrs, _ = strconv.ParseUint(val, 10, 64)
+		case "corrected_errors":
+			s.CorrectedErrs, _ = strconv.ParseUint(val, 10, 64)
+		}
+	}
+	return s, nil
+}
+
 // parseProfileSizeUsed parses "Metadata,DUP: Size:1073741824, Used:536870912".
 func parseProfileSizeUsed(line string) (size, used uint64) {
 	if idx := strings.Index(line, "Size:"); idx >= 0 {

--- a/agent/storage/metrics.go
+++ b/agent/storage/metrics.go
@@ -195,6 +195,22 @@ var (
 		Name:      "filesystem_data_ratio",
 		Help:      "Data RAID profile ratio (1.0 for single, 2.0 for RAID1/DUP).",
 	}, []string{"path"})
+
+	// Task metrics
+	TasksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "btrfs_nfs_csi",
+		Subsystem: "agent",
+		Name:      "tasks_total",
+		Help:      "Total number of completed tasks by type and status.",
+	}, []string{"type", "status"})
+
+	TaskDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "btrfs_nfs_csi",
+		Subsystem: "agent",
+		Name:      "task_duration_seconds",
+		Help:      "Duration of tasks in seconds.",
+		Buckets:   prometheus.ExponentialBuckets(1, 2, 15),
+	}, []string{"type"})
 )
 
 func init() {
@@ -229,5 +245,8 @@ func init() {
 		FilesystemMetadataUsedBytes,
 		FilesystemMetadataTotalBytes,
 		FilesystemDataRatio,
+		// Tasks
+		TasksTotal,
+		TaskDuration,
 	)
 }

--- a/agent/storage/metrics.go
+++ b/agent/storage/metrics.go
@@ -195,7 +195,6 @@ var (
 		Name:      "filesystem_data_ratio",
 		Help:      "Data RAID profile ratio (1.0 for single, 2.0 for RAID1/DUP).",
 	}, []string{"path"})
-
 )
 
 func init() {

--- a/agent/storage/metrics.go
+++ b/agent/storage/metrics.go
@@ -195,6 +195,7 @@ var (
 		Name:      "filesystem_data_ratio",
 		Help:      "Data RAID profile ratio (1.0 for single, 2.0 for RAID1/DUP).",
 	}, []string{"path"})
+
 )
 
 func init() {

--- a/agent/storage/scrub.go
+++ b/agent/storage/scrub.go
@@ -1,0 +1,88 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	TaskTypeScrub     = "scrub"
+	scrubPollInterval = 5 * time.Second
+)
+
+// StartScrub starts a btrfs scrub as a background task and returns the task ID.
+func (s *Storage) StartScrub(ctx context.Context) (string, error) {
+	for _, t := range s.tasks.List(TaskTypeScrub) {
+		if t.Status == TaskRunning || t.Status == TaskPending {
+			return "", &StorageError{Code: ErrBusy, Message: "scrub already running"}
+		}
+	}
+	status, err := s.btrfs.ScrubStatus(ctx, s.mountPoint)
+	if err == nil && status.Running {
+		return "", &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
+	}
+
+	id := s.tasks.Submit(TaskTypeScrub, func(ctx context.Context, update *TaskUpdate) error {
+		return s.runScrub(ctx, update)
+	})
+
+	log.Info().Str("task", id).Str("path", s.mountPoint).Msg("scrub started")
+	return id, nil
+}
+
+func (s *Storage) runScrub(ctx context.Context, update *TaskUpdate) error {
+	stopProgress := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(scrubPollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopProgress:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				status, err := s.btrfs.ScrubStatus(ctx, s.mountPoint)
+				if err != nil {
+					continue
+				}
+				scrubbed := status.DataBytesScrubbed + status.TreeBytesScrubbed
+				if total := s.filesystemUsedBytes(); total > 0 {
+					pct := int(scrubbed * 100 / total)
+					if pct > 100 {
+						pct = 100
+					}
+					update.SetProgress(pct)
+				}
+			}
+		}
+	}()
+
+	err := s.btrfs.ScrubStart(ctx, s.mountPoint)
+	close(stopProgress)
+
+	if err != nil {
+		return fmt.Errorf("btrfs scrub: %w", err)
+	}
+
+	status, statusErr := s.btrfs.ScrubStatus(context.Background(), s.mountPoint)
+	if statusErr != nil {
+		log.Warn().Err(statusErr).Msg("failed to read scrub result")
+		return nil
+	}
+	if err := update.SetResult(status); err != nil {
+		log.Warn().Err(err).Msg("failed to store scrub result")
+	}
+	return nil
+}
+
+func (s *Storage) filesystemUsedBytes() uint64 {
+	fs := s.cachedFilesystem.Load()
+	if fs == nil {
+		return 0
+	}
+	return fs.UsedBytes
+}

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -28,6 +28,7 @@ type Storage struct {
 	tenants         []string
 	defaultDirMode  os.FileMode
 	defaultDataMode string
+	tasks           *TaskManager
 
 	// cachedDevices is written by both the IO poller (5s) and btrfs stats poller (1m).
 	// Each poller loads the current state, updates its own fields (IO or Errors),
@@ -109,12 +110,13 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 	for i, d := range devices {
 		initialStates[i] = DeviceState{BTRFSDevice: d}
 	}
-	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode}
+	taskDir := filepath.Join(basePath, config.TasksDir)
+	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, tasks: NewTaskManager(taskDir)}
 	s.cachedDevices.Store(&initialStates)
 	return s
 }
 
-func (s *Storage) StartWorkers(ctx context.Context, usageInterval, reconcileInterval, deviceIOInterval, deviceStatsInterval time.Duration) {
+func (s *Storage) StartWorkers(ctx context.Context, usageInterval, reconcileInterval, deviceIOInterval, deviceStatsInterval, taskCleanupInterval time.Duration) {
 	for _, tenant := range s.tenants {
 		bp := filepath.Join(s.basePath, tenant)
 		if s.quotaEnabled {
@@ -126,11 +128,13 @@ func (s *Storage) StartWorkers(ctx context.Context, usageInterval, reconcileInte
 	}
 	s.StartDeviceIOUpdater(ctx, deviceIOInterval)
 	s.StartDeviceStatsUpdater(ctx, deviceStatsInterval)
+	s.tasks.StartCleanup(ctx, taskCleanupInterval)
 }
 
 func (s *Storage) BasePath() string       { return s.basePath }
 func (s *Storage) QuotaEnabled() bool     { return s.quotaEnabled }
 func (s *Storage) Exporter() nfs.Exporter { return s.exporter }
+func (s *Storage) Tasks() *TaskManager { return s.tasks }
 
 func (s *Storage) tenantPath(tenant string) (string, error) {
 	if err := validateName(tenant); err != nil {

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -134,7 +134,7 @@ func (s *Storage) StartWorkers(ctx context.Context, usageInterval, reconcileInte
 func (s *Storage) BasePath() string       { return s.basePath }
 func (s *Storage) QuotaEnabled() bool     { return s.quotaEnabled }
 func (s *Storage) Exporter() nfs.Exporter { return s.exporter }
-func (s *Storage) Tasks() *TaskManager { return s.tasks }
+func (s *Storage) Tasks() *TaskManager    { return s.tasks }
 
 func (s *Storage) tenantPath(tenant string) (string, error) {
 	if err := validateName(tenant); err != nil {

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/btrfs"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/nfs"
@@ -81,14 +82,19 @@ func (s *StorageIntegrationSuite) SetupSuite() {
 	exporter.On("Unexport", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo{}, nil).Maybe()
 
+	taskDir := filepath.Join(s.mnt, config.TasksDir)
+	s.Require().NoError(os.MkdirAll(taskDir, 0o755))
+
 	s.storage = &Storage{
 		basePath:        s.mnt,
+		mountPoint:      s.mnt,
 		quotaEnabled:    true,
 		btrfs:           btrfs.NewManager("btrfs"),
 		exporter:        exporter,
 		tenants:         []string{"test"},
 		defaultDirMode:  0o755,
 		defaultDataMode: "2770",
+		tasks:           NewTaskManager(taskDir),
 	}
 }
 
@@ -375,4 +381,123 @@ func (s *StorageIntegrationSuite) TestDeleteNonexistent() {
 	var se *StorageError
 	s.Require().ErrorAs(err, &se)
 	s.Assert().Equal(ErrNotFound, se.Code)
+}
+
+func (s *StorageIntegrationSuite) TestStartScrub() {
+	// write data so scrub has something to check
+	_, err := s.storage.CreateVolume(s.ctx, "test", VolumeCreateRequest{
+		Name: "scrub-vol", SizeBytes: 10 * 1024 * 1024,
+	})
+	s.Require().NoError(err)
+	dataDir := filepath.Join(s.tenantDir, "scrub-vol", config.DataDir)
+	s.Require().NoError(os.WriteFile(filepath.Join(dataDir, "testfile"), make([]byte, 64*1024), 0o644))
+	_, err = s.cmd.Run(s.ctx, "sync")
+	s.Require().NoError(err)
+
+	// start scrub via storage layer
+	taskID, err := s.storage.StartScrub(s.ctx)
+	s.Require().NoError(err)
+	s.Assert().NotEmpty(taskID)
+
+	// wait for completion
+	var task *Task
+	for i := 0; i < 30; i++ {
+		task, err = s.storage.Tasks().Get(taskID)
+		s.Require().NoError(err)
+		if task.Status == TaskCompleted || task.Status == TaskFailed {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	s.Assert().Equal(TaskCompleted, task.Status)
+	s.Assert().Equal(100, task.Progress)
+	s.Assert().NotNil(task.Result, "should have scrub result")
+}
+
+func (s *StorageIntegrationSuite) TestStartScrubDuplicate() {
+	// start a blocking scrub in background
+	started := make(chan struct{})
+	s.storage.Tasks().Submit(TaskTypeScrub, func(ctx context.Context, update *TaskUpdate) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	<-started
+
+	// second scrub should be rejected
+	_, err := s.storage.StartScrub(s.ctx)
+	s.Require().Error(err)
+	var se *StorageError
+	s.Require().ErrorAs(err, &se)
+	s.Assert().Equal(ErrBusy, se.Code)
+}
+
+func (s *StorageIntegrationSuite) TestTaskPersistence() {
+	taskDir := filepath.Join(s.mnt, config.TasksDir)
+
+	// submit a task that completes
+	id := s.storage.Tasks().Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		return update.SetResult(map[string]string{"key": "value"})
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	// task file should exist
+	taskFile := filepath.Join(taskDir, id+".json")
+	_, err := os.Stat(taskFile)
+	s.Assert().NoError(err, "task file should exist on disk")
+
+	// read the file and verify
+	var persisted Task
+	s.Require().NoError(ReadMetadata(taskFile, &persisted))
+	s.Assert().Equal(id, persisted.ID)
+	s.Assert().Equal(TaskCompleted, persisted.Status)
+	s.Assert().NotNil(persisted.Result)
+}
+
+func (s *StorageIntegrationSuite) TestTaskLoadFromDisk() {
+	taskDir := filepath.Join(s.mnt, config.TasksDir)
+
+	// write a "running" task file (simulates agent crash)
+	staleTask := Task{
+		ID:     "stale-task-123",
+		Type:   "test",
+		Status: TaskRunning,
+	}
+	s.Require().NoError(writeMetadataAtomic(filepath.Join(taskDir, "stale-task-123.json"), &staleTask))
+
+	// create new TaskManager (triggers loadFromDisk)
+	tm := NewTaskManager(taskDir)
+
+	// stale task should be marked failed
+	task, err := tm.Get("stale-task-123")
+	s.Require().NoError(err)
+	s.Assert().Equal(TaskFailed, task.Status)
+	s.Assert().Equal("agent restarted", task.Error)
+	s.Assert().NotNil(task.CompletedAt)
+}
+
+func (s *StorageIntegrationSuite) TestTaskCleanupRemovesFiles() {
+	taskDir := filepath.Join(s.mnt, config.TasksDir)
+
+	id := s.storage.Tasks().Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		return nil
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	// file exists
+	taskFile := filepath.Join(taskDir, id+".json")
+	_, err := os.Stat(taskFile)
+	s.Assert().NoError(err)
+
+	// cleanup with 0 maxAge
+	s.storage.Tasks().cleanup(0)
+
+	// file should be gone
+	_, err = os.Stat(taskFile)
+	s.Assert().True(os.IsNotExist(err), "task file should be removed after cleanup")
+
+	// task should be gone from memory too
+	_, err = s.storage.Tasks().Get(id)
+	requireStorageError(s.T(), err, ErrNotFound)
 }

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -501,3 +501,54 @@ func (s *StorageIntegrationSuite) TestTaskCleanupRemovesFiles() {
 	_, err = s.storage.Tasks().Get(id)
 	requireStorageError(s.T(), err, ErrNotFound)
 }
+
+func (s *StorageIntegrationSuite) TestScrubOnEmptyFilesystem() {
+	// no volumes, no data -- scrub should still work
+	taskID, err := s.storage.StartScrub(s.ctx)
+	s.Require().NoError(err)
+
+	for i := 0; i < 30; i++ {
+		task, err := s.storage.Tasks().Get(taskID)
+		s.Require().NoError(err)
+		if task.Status == TaskCompleted || task.Status == TaskFailed {
+			s.Assert().Equal(TaskCompleted, task.Status)
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func (s *StorageIntegrationSuite) TestScrubRestartRecovery() {
+	taskDir := filepath.Join(s.mnt, config.TasksDir)
+
+	// simulate a scrub that was running when agent crashed
+	staleTask := Task{
+		ID:     "stale-scrub",
+		Type:   TaskTypeScrub,
+		Status: TaskRunning,
+	}
+	s.Require().NoError(writeMetadataAtomic(filepath.Join(taskDir, "stale-scrub.json"), &staleTask))
+
+	// create new TaskManager (simulates agent restart)
+	tm := NewTaskManager(taskDir)
+
+	// stale scrub should be failed
+	task, err := tm.Get("stale-scrub")
+	s.Require().NoError(err)
+	s.Assert().Equal(TaskFailed, task.Status)
+	s.Assert().Equal("agent restarted", task.Error)
+
+	// should be able to start a new scrub (stale one doesn't block)
+	s.storage.tasks = tm
+	newID, err := s.storage.StartScrub(s.ctx)
+	s.Require().NoError(err)
+	s.Assert().NotEmpty(newID)
+
+	for i := 0; i < 30; i++ {
+		t, _ := tm.Get(newID)
+		if t.Status == TaskCompleted || t.Status == TaskFailed {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}

--- a/agent/storage/taskmanager.go
+++ b/agent/storage/taskmanager.go
@@ -158,11 +158,15 @@ func (tm *TaskManager) Submit(taskType string, fn TaskFunc) string {
 		rt.state.Store(&final)
 		tm.persist(&final)
 
+		elapsed := time.Since(start)
+		TasksTotal.WithLabelValues(taskType, string(final.Status)).Inc()
+		TaskDuration.WithLabelValues(taskType).Observe(elapsed.Seconds())
+
 		log.Info().
 			Str("task", id).
 			Str("type", taskType).
 			Str("status", string(final.Status)).
-			Dur("duration", time.Since(start)).
+			Dur("duration", elapsed).
 			Msg("task finished")
 	}()
 

--- a/agent/storage/taskmanager.go
+++ b/agent/storage/taskmanager.go
@@ -42,10 +42,11 @@ type Task struct {
 
 // TaskUpdate is passed to TaskFunc for safe progress/result updates.
 type TaskUpdate struct {
-	rt *runningTask
+	rt      *runningTask
+	persist func(*Task)
 }
 
-// SetProgress atomically updates the task's progress (0-100). In-memory only.
+// SetProgress atomically updates the task's progress (0-100) and persists to disk.
 func (u *TaskUpdate) SetProgress(pct int) {
 	for {
 		old := u.rt.state.Load()
@@ -55,6 +56,7 @@ func (u *TaskUpdate) SetProgress(pct int) {
 		cp := *old
 		cp.Progress = pct
 		if u.rt.state.CompareAndSwap(old, &cp) {
+			u.persist(&cp)
 			return
 		}
 	}
@@ -138,7 +140,7 @@ func (tm *TaskManager) Submit(taskType string, fn TaskFunc) string {
 		rt.state.Store(&running)
 		tm.persist(&running) // first persist: running (skip transient pending)
 
-		err := fn(ctx, &TaskUpdate{rt: rt})
+		err := fn(ctx, &TaskUpdate{rt: rt, persist: tm.persist})
 
 		now := time.Now().UTC()
 		final := *rt.state.Load()

--- a/agent/storage/taskmanager.go
+++ b/agent/storage/taskmanager.go
@@ -1,0 +1,318 @@
+package storage
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// TaskStatus represents the current state of a task.
+type TaskStatus string
+
+const (
+	TaskPending   TaskStatus = "pending"
+	TaskRunning   TaskStatus = "running"
+	TaskCompleted TaskStatus = "completed"
+	TaskFailed    TaskStatus = "failed"
+	TaskCancelled TaskStatus = "cancelled"
+)
+
+// Task represents an async long-running operation with progress tracking.
+// Progress is kept in-memory only (updated frequently).
+// Status transitions and Result are persisted to disk.
+type Task struct {
+	ID          string          `json:"id"`
+	Type        string          `json:"type"`
+	Status      TaskStatus      `json:"status"`
+	Progress    int             `json:"progress"`
+	Result      json.RawMessage `json:"result,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	StartedAt   *time.Time      `json:"started_at,omitempty"`
+	CompletedAt *time.Time      `json:"completed_at,omitempty"`
+}
+
+// TaskUpdate is passed to TaskFunc for safe progress/result updates.
+type TaskUpdate struct {
+	rt *runningTask
+}
+
+// SetProgress atomically updates the task's progress (0-100). In-memory only.
+func (u *TaskUpdate) SetProgress(pct int) {
+	for {
+		old := u.rt.state.Load()
+		if old.Progress == pct {
+			return
+		}
+		cp := *old
+		cp.Progress = pct
+		if u.rt.state.CompareAndSwap(old, &cp) {
+			return
+		}
+	}
+}
+
+// SetResult atomically updates the task's result.
+func (u *TaskUpdate) SetResult(result any) error {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	for {
+		old := u.rt.state.Load()
+		cp := *old
+		cp.Result = raw
+		if u.rt.state.CompareAndSwap(old, &cp) {
+			return nil
+		}
+	}
+}
+
+// TaskFunc is the function executed by a task. It receives a context for
+// cancellation and a TaskUpdate handle for safe progress/result updates.
+type TaskFunc func(ctx context.Context, update *TaskUpdate) error
+
+type runningTask struct {
+	state  atomic.Pointer[Task]
+	cancel context.CancelFunc
+}
+
+// TaskManager manages async tasks as goroutines with progress tracking.
+type TaskManager struct {
+	mu      sync.Mutex
+	tasks   map[string]*runningTask
+	taskDir string
+}
+
+// NewTaskManager creates a new TaskManager with persistence under taskDir.
+func NewTaskManager(taskDir string) *TaskManager {
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		log.Fatal().Err(err).Str("path", taskDir).Msg("failed to create tasks directory")
+	}
+
+	tm := &TaskManager{
+		tasks:   make(map[string]*runningTask),
+		taskDir: taskDir,
+	}
+	tm.loadFromDisk()
+	return tm
+}
+
+// Submit starts a task as a background goroutine and returns its ID.
+func (tm *TaskManager) Submit(taskType string, fn TaskFunc) string {
+	id := generateID()
+	now := time.Now().UTC()
+
+	task := &Task{
+		ID:        id,
+		Type:      taskType,
+		Status:    TaskPending,
+		CreatedAt: now,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := &runningTask{cancel: cancel}
+	rt.state.Store(task)
+
+	tm.mu.Lock()
+	tm.tasks[id] = rt
+	tm.mu.Unlock()
+
+	log.Info().Str("task", id).Str("type", taskType).Msg("task submitted")
+
+	go func() {
+		start := time.Now()
+		startUTC := start.UTC()
+
+		running := *task
+		running.Status = TaskRunning
+		running.StartedAt = &startUTC
+		rt.state.Store(&running)
+		tm.persist(&running) // first persist: running (skip transient pending)
+
+		err := fn(ctx, &TaskUpdate{rt: rt})
+
+		now := time.Now().UTC()
+		final := *rt.state.Load()
+		final.CompletedAt = &now
+		switch {
+		case ctx.Err() != nil:
+			final.Status = TaskCancelled
+		case err != nil:
+			final.Status = TaskFailed
+			final.Error = err.Error()
+		default:
+			final.Status = TaskCompleted
+			final.Progress = 100
+		}
+		rt.state.Store(&final)
+		tm.persist(&final)
+
+		log.Info().
+			Str("task", id).
+			Str("type", taskType).
+			Str("status", string(final.Status)).
+			Dur("duration", time.Since(start)).
+			Msg("task finished")
+	}()
+
+	return id
+}
+
+// Get returns a copy of the task with the given ID.
+func (tm *TaskManager) Get(id string) (*Task, error) {
+	tm.mu.Lock()
+	rt, ok := tm.tasks[id]
+	tm.mu.Unlock()
+
+	if !ok {
+		return nil, &StorageError{Code: ErrNotFound, Message: "task not found"}
+	}
+	cp := *rt.state.Load()
+	return &cp, nil
+}
+
+// List returns copies of all tasks, optionally filtered by type.
+func (tm *TaskManager) List(taskType string) []Task {
+	tm.mu.Lock()
+	snapshot := make([]*runningTask, 0, len(tm.tasks))
+	for _, rt := range tm.tasks {
+		snapshot = append(snapshot, rt)
+	}
+	tm.mu.Unlock()
+
+	result := make([]Task, 0, len(snapshot))
+	for _, rt := range snapshot {
+		task := rt.state.Load()
+		if taskType != "" && task.Type != taskType {
+			continue
+		}
+		result = append(result, *task)
+	}
+	return result
+}
+
+// Cancel aborts a running task via context cancellation.
+func (tm *TaskManager) Cancel(id string) error {
+	tm.mu.Lock()
+	rt, ok := tm.tasks[id]
+	tm.mu.Unlock()
+
+	if !ok {
+		return &StorageError{Code: ErrNotFound, Message: "task not found"}
+	}
+	task := rt.state.Load()
+	if task.Status == TaskRunning || task.Status == TaskPending {
+		if rt.cancel != nil {
+			rt.cancel()
+		}
+		log.Info().Str("task", id).Msg("task cancelled")
+	}
+	return nil
+}
+
+// StartCleanup periodically removes completed/failed/cancelled tasks
+// older than maxAge.
+func (tm *TaskManager) StartCleanup(ctx context.Context, maxAge time.Duration) {
+	go func() {
+		tm.cleanup(maxAge)
+		ticker := time.NewTicker(maxAge / 2)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				tm.cleanup(maxAge)
+			}
+		}
+	}()
+}
+
+func (tm *TaskManager) cleanup(maxAge time.Duration) {
+	cutoff := time.Now().UTC().Add(-maxAge)
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	var removed int
+	for id, rt := range tm.tasks {
+		task := rt.state.Load()
+		switch task.Status {
+		case TaskCompleted, TaskFailed, TaskCancelled:
+			if task.CompletedAt != nil && task.CompletedAt.Before(cutoff) {
+				delete(tm.tasks, id)
+				_ = os.Remove(tm.taskFile(id))
+				removed++
+			}
+		}
+	}
+	if removed > 0 {
+		log.Info().Int("removed", removed).Msg("task cleanup complete")
+	}
+}
+
+func (tm *TaskManager) persist(task *Task) {
+	path := tm.taskFile(task.ID)
+	if err := writeMetadataAtomic(path, task); err != nil {
+		log.Error().Err(err).Str("task", task.ID).Msg("failed to persist task")
+	}
+}
+
+func (tm *TaskManager) taskFile(id string) string {
+	return filepath.Join(tm.taskDir, id+".json")
+}
+
+// loadFromDisk reads persisted tasks on startup. Tasks that were running
+// when the agent died are marked as failed.
+func (tm *TaskManager) loadFromDisk() {
+	entries, err := os.ReadDir(tm.taskDir)
+	if err != nil {
+		return
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+
+		var task Task
+		path := filepath.Join(tm.taskDir, e.Name())
+		if err := ReadMetadata(path, &task); err != nil {
+			log.Warn().Err(err).Str("file", e.Name()).Msg("failed to load task from disk")
+			continue
+		}
+
+		if task.Status == TaskRunning || task.Status == TaskPending {
+			now := time.Now().UTC()
+			task.Status = TaskFailed
+			task.Error = "agent restarted"
+			task.CompletedAt = &now
+			if err := writeMetadataAtomic(path, &task); err != nil {
+				log.Warn().Err(err).Str("task", task.ID).Msg("failed to update stale task")
+			}
+		}
+
+		rt := &runningTask{}
+		rt.state.Store(&task)
+		tm.tasks[task.ID] = rt
+
+		log.Debug().Str("task", task.ID).Str("type", task.Type).Str("status", string(task.Status)).Msg("loaded task from disk")
+	}
+}
+
+func generateID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}

--- a/agent/storage/taskmanager_test.go
+++ b/agent/storage/taskmanager_test.go
@@ -1,0 +1,261 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskManager_SubmitAndGet(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		close(started)
+		<-done
+		return nil
+	})
+
+	<-started
+
+	task, err := tm.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, TaskRunning, task.Status)
+	assert.Equal(t, "test", task.Type)
+	assert.NotNil(t, task.StartedAt)
+	assert.Nil(t, task.CompletedAt)
+
+	close(done)
+	time.Sleep(50 * time.Millisecond)
+
+	task, err = tm.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, TaskCompleted, task.Status)
+	assert.Equal(t, 100, task.Progress)
+	assert.NotNil(t, task.CompletedAt)
+	assert.Empty(t, task.Error)
+}
+
+func TestTaskManager_SubmitWithError(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		return fmt.Errorf("something broke")
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	task, err := tm.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, TaskFailed, task.Status)
+	assert.Equal(t, "something broke", task.Error)
+	assert.NotNil(t, task.CompletedAt)
+}
+
+func TestTaskManager_Cancel(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	started := make(chan struct{})
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	<-started
+	require.NoError(t, tm.Cancel(id))
+
+	time.Sleep(50 * time.Millisecond)
+
+	task, err := tm.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, TaskCancelled, task.Status)
+}
+
+func TestTaskManager_CancelFinished(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		return nil
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	err := tm.Cancel(id)
+	assert.NoError(t, err)
+}
+
+func TestTaskManager_CancelUnknown(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	err := tm.Cancel("nonexistent")
+	requireStorageError(t, err, ErrNotFound)
+}
+
+func TestTaskManager_GetUnknown(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	_, err := tm.Get("nonexistent")
+	requireStorageError(t, err, ErrNotFound)
+}
+
+func TestTaskManager_List(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	tm.Submit(TaskTypeScrub, func(ctx context.Context, update *TaskUpdate) error {
+		return nil
+	})
+	tm.Submit("transfer", func(ctx context.Context, update *TaskUpdate) error {
+		return nil
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	all := tm.List("")
+	assert.Len(t, all, 2)
+
+	scrubs := tm.List(TaskTypeScrub)
+	assert.Len(t, scrubs, 1)
+	assert.Equal(t, TaskTypeScrub, scrubs[0].Type)
+
+	transfers := tm.List("transfer")
+	assert.Len(t, transfers, 1)
+	assert.Equal(t, "transfer", transfers[0].Type)
+
+	none := tm.List("unknown")
+	assert.Empty(t, none)
+}
+
+func TestTaskManager_ListReturnsCopies(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		return nil
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	tasks := tm.List("")
+	require.Len(t, tasks, 1)
+
+	tasks[0].Status = TaskFailed
+
+	original, err := tm.Get(tasks[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, TaskCompleted, original.Status)
+}
+
+func TestTaskManager_ProgressUpdate(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	checkpoint := make(chan struct{})
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		update.SetProgress(50)
+		close(checkpoint)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	<-checkpoint
+
+	task, err := tm.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, 50, task.Progress)
+
+	require.NoError(t, tm.Cancel(id))
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestTaskManager_ResultStruct(t *testing.T) {
+	type TestResult struct {
+		Count int    `json:"count"`
+		Name  string `json:"name"`
+	}
+
+	tm := NewTaskManager(t.TempDir())
+
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		return update.SetResult(TestResult{Count: 42, Name: "hello"})
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	task, err := tm.Get(id)
+	require.NoError(t, err)
+	require.NotNil(t, task.Result)
+
+	var result TestResult
+	require.NoError(t, json.Unmarshal(task.Result, &result))
+	assert.Equal(t, 42, result.Count)
+	assert.Equal(t, "hello", result.Name)
+}
+
+func TestTaskManager_Cleanup(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		return nil
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	_, err := tm.Get(id)
+	require.NoError(t, err)
+
+	tm.cleanup(0)
+
+	_, err = tm.Get(id)
+	requireStorageError(t, err, ErrNotFound)
+}
+
+func TestTaskManager_CleanupKeepsRunning(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	done := make(chan struct{})
+	id := tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+		<-done
+		return nil
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	tm.cleanup(0)
+
+	task, err := tm.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, TaskRunning, task.Status)
+
+	close(done)
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestTaskManager_ConcurrentSubmit(t *testing.T) {
+	tm := NewTaskManager(t.TempDir())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tm.Submit("test", func(ctx context.Context, update *TaskUpdate) error {
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+
+	time.Sleep(100 * time.Millisecond)
+
+	tasks := tm.List("")
+	assert.Len(t, tasks, 50)
+	for _, task := range tasks {
+		assert.Equal(t, TaskCompleted, task.Status)
+	}
+}

--- a/agent/storage/taskmanager_test.go
+++ b/agent/storage/taskmanager_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -234,6 +236,37 @@ func TestTaskManager_CleanupKeepsRunning(t *testing.T) {
 
 	close(done)
 	time.Sleep(50 * time.Millisecond)
+}
+
+func TestTaskManager_CorruptTaskFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// write corrupt JSON
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{corrupt"), 0o644))
+
+	// write non-JSON file (should be ignored)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not a task"), 0o644))
+
+	// write valid task
+	valid := Task{ID: "good", Type: "test", Status: TaskCompleted}
+	require.NoError(t, writeMetadataAtomic(filepath.Join(dir, "good.json"), &valid))
+
+	tm := NewTaskManager(dir)
+
+	// only the valid task should be loaded
+	tasks := tm.List("")
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, "good", tasks[0].ID)
+}
+
+func TestTaskManager_EmptyTaskFile(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.json"), []byte(""), 0o644))
+
+	tm := NewTaskManager(dir)
+	tasks := tm.List("")
+	assert.Empty(t, tasks)
 }
 
 func TestTaskManager_ConcurrentSubmit(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ const (
 	DataDir      = "data"
 	MetadataFile = "metadata.json"
 	SnapshotsDir = "snapshots"
+	TasksDir     = "tasks"
 )
 
 type AgentConfig struct {
@@ -54,6 +55,7 @@ type AgentConfig struct {
 	DashboardRefresh     int           `env:"AGENT_DASHBOARD_REFRESH_SECONDS" envDefault:"5"`
 	DefaultDirMode       string        `env:"AGENT_DEFAULT_DIR_MODE" envDefault:"0700"`
 	DefaultDataMode      string        `env:"AGENT_DEFAULT_DATA_MODE" envDefault:"2770"`
+	TaskCleanupInterval  time.Duration `env:"AGENT_TASK_CLEANUP_INTERVAL" envDefault:"24h"`
 }
 
 type ControllerConfig struct {

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -336,6 +336,69 @@ Filesystem space usage, per-device IO counters (from sysfs), per-device btrfs er
 }
 ```
 
+## Tasks
+
+Background task system for long-running operations (scrub, future: transfers). Tasks are persisted to disk and survive agent restarts. Running tasks that were interrupted by an agent restart are marked as `failed`.
+
+### POST /v1/tasks/scrub
+
+Starts a btrfs scrub on the filesystem. Returns 423 if a scrub is already running.
+
+```json
+// Response 202
+{
+  "task_id": "bba30993dee31318f016f5350718cffa",
+  "status": "pending"
+}
+```
+
+```bash
+curl -X POST http://10.0.0.5:8080/v1/tasks/scrub \
+  -H "Authorization: Bearer changeme"
+```
+
+### GET /v1/tasks
+
+List all tasks. Optional `?type=scrub` filter.
+
+```json
+{
+  "tasks": [
+    {
+      "id": "bba30993dee31318f016f5350718cffa",
+      "type": "scrub",
+      "status": "completed",
+      "progress": 100,
+      "result": {
+        "data_bytes_scrubbed": 3145728000,
+        "tree_bytes_scrubbed": 6979584,
+        "read_errors": 0,
+        "csum_errors": 0,
+        "verify_errors": 0,
+        "super_errors": 0,
+        "uncorrectable_errors": 0,
+        "corrected_errors": 0,
+        "running": false
+      },
+      "created_at": "2025-01-15T02:00:00Z",
+      "started_at": "2025-01-15T02:00:00Z",
+      "completed_at": "2025-01-15T02:00:05Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+### GET /v1/tasks/:id
+
+Returns a single task. 404 if not found.
+
+### DELETE /v1/tasks/:id
+
+Cancels a running task. 204 No Content. 404 if not found. Cancelling a finished task is a no-op.
+
+Task statuses: `pending`, `running`, `completed`, `failed`, `cancelled`.
+
 ## Dashboard
 
 ### GET /v1/dashboard

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,17 +32,30 @@ DeleteVolume   → DELETE /v1/volumes/:name (subvolume delete)
 ## Directory Structure
 
 ```
-{AGENT_BASE_PATH}/{tenant}/
-├── {volume}/
-│   ├── data/              ← btrfs subvolume
-│   └── metadata.json
-├── snapshots/{name}/
-│   ├── data/              ← read-only btrfs snapshot
-│   └── metadata.json
-└── {clone}/
-    ├── data/              ← writable btrfs snapshot
-    └── metadata.json
+{AGENT_BASE_PATH}/
+├── tasks/
+│   └── {id}.json          ← persisted task state
+└── {tenant}/
+    ├── {volume}/
+    │   ├── data/           ← btrfs subvolume
+    │   └── metadata.json
+    ├── snapshots/{name}/
+    │   ├── data/           ← read-only btrfs snapshot
+    │   └── metadata.json
+    └── {clone}/
+        ├── data/           ← writable btrfs snapshot
+        └── metadata.json
 ```
+
+## Task System
+
+Long-running operations (scrub, future: cross-agent transfers) run as background tasks with progress tracking.
+
+- Tasks are persisted as JSON files under `{AGENT_BASE_PATH}/tasks/`
+- Progress is tracked in-memory via atomic pointers (no disk IO per update)
+- Status transitions (pending, running, completed, failed, cancelled) are persisted to disk
+- On agent restart, interrupted running/pending tasks are marked as `failed`
+- Completed tasks are cleaned up after `AGENT_TASK_CLEANUP_INTERVAL` (default 24h)
 
 ## CSI Capabilities
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@
 | `AGENT_DASHBOARD_REFRESH_SECONDS` | `5` | Dashboard refresh |
 | `AGENT_DEFAULT_DIR_MODE` | `0700` | Default mode for volume/snapshot/clone directories |
 | `AGENT_DEFAULT_DATA_MODE` | `2770` | Default mode for data subvolumes (setgid + group rwx) |
+| `AGENT_TASK_CLEANUP_INTERVAL` | `24h` | Remove completed/failed tasks after this duration |
 | `LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
 
 ## Controller Environment Variables

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,8 +1,8 @@
 # Metrics
 
-38 metrics across 3 components.
+40 metrics across 3 components.
 
-## Agent (29) - port 9090
+## Agent (31) - port 9090
 
 | Metric | Type | Labels |
 |---|---|---|
@@ -35,6 +35,8 @@
 | `btrfs_nfs_csi_agent_filesystem_metadata_used_bytes` | Gauge | `path` |
 | `btrfs_nfs_csi_agent_filesystem_metadata_total_bytes` | Gauge | `path` |
 | `btrfs_nfs_csi_agent_filesystem_data_ratio` | Gauge | `path` |
+| `btrfs_nfs_csi_agent_tasks_total` | Counter | `type`, `status` |
+| `btrfs_nfs_csi_agent_task_duration_seconds` | Histogram | `type` |
 
 **Buckets (http_request_duration):** `[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5]`
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -148,3 +148,27 @@ nfsvers=4.2,hard,noatime,rsize=1048576,wsize=1048576,nconnect=8
 ```
 
 **Mount timeouts:** NFS/bind mount 2min, unmount falls back to `umount -f`.
+
+## Scrub
+
+btrfs scrub verifies data integrity by reading all blocks and checking checksums. Runs as a background task via the task system.
+
+```bash
+# Start scrub
+curl -X POST http://10.0.0.5:8080/v1/tasks/scrub \
+  -H "Authorization: Bearer changeme"
+# {"task_id": "abc123", "status": "pending"}
+
+# Poll progress
+curl http://10.0.0.5:8080/v1/tasks/abc123 \
+  -H "Authorization: Bearer changeme"
+# {"status": "running", "progress": 42, ...}
+
+# Cancel
+curl -X DELETE http://10.0.0.5:8080/v1/tasks/abc123 \
+  -H "Authorization: Bearer changeme"
+```
+
+Only one scrub can run at a time per filesystem. The agent detects externally started scrubs (e.g. via `btrfs scrub start` on the host) and rejects duplicates.
+
+Completed tasks include a result with bytes scrubbed and error counts. Tasks are persisted to disk and cleaned up after `AGENT_TASK_CLEANUP_INTERVAL` (default 24h).


### PR DESCRIPTION
Adds a generic task system for long-running async operations and btrfs scrub as the first consumer. The task system is the foundation for upcoming features like cross-agent snapshot transfers (btrfs send/receive) which will enable volume migration between agents. This will be a larger release.

## Summary
- Generic task system for async background operations with progress tracking, cancellation, and file persistence
- Filesystem scrub as first task type via `POST /v1/tasks/scrub`
- Tasks persisted to disk as JSON, survive agent restarts (interrupted tasks marked as failed)

## API
- `POST /v1/tasks/scrub` - start scrub (202 / 423 if already running)
- `GET /v1/tasks` - list tasks (optional `?type=` filter)
- `GET /v1/tasks/:id` - get task status + result
- `DELETE /v1/tasks/:id` - cancel running task

## Implementation
- `TaskManager` uses `atomic.Pointer[Task]` for lock-free reads, CAS loops for safe updates
- Scrub runs `btrfs scrub start -B` (foreground), progress polled via `btrfs scrub status -R`
- Detects externally started scrubs, rejects duplicates
- Prometheus metrics: `tasks_total{type, status}`, `task_duration_seconds{type}`

## Config
- `AGENT_TASK_CLEANUP_INTERVAL` (default `24h`)
