### PR TITLE
Improve error handling and logging across all components

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"strings"
 
@@ -99,28 +100,35 @@ func (a *Agent) Start(ctx context.Context) {
 	api.DELETE("/tasks/:id", h.CancelTask)
 
 	a.echo = e
-	a.ready = true
 
 	store.StartWorkers(ctx, a.cfg.UsageInterval, a.cfg.NFSReconcileInterval, a.cfg.DeviceIOInterval, a.cfg.DeviceStatsInterval, a.cfg.TaskCleanupInterval)
 
+	// Verify the listen address is available before going to background
+	ln, err := net.Listen("tcp", a.cfg.ListenAddr)
+	if err != nil {
+		log.Fatal().Err(err).Str("addr", a.cfg.ListenAddr).Msg("failed to bind listen address")
+	}
+
+	a.ready = true
+
 	go func() {
-		var err error
+		var srvErr error
 		if a.cfg.TLSCert != "" && a.cfg.TLSKey != "" {
 			s := &http.Server{
-				Addr:    a.cfg.ListenAddr,
 				Handler: e,
 				TLSConfig: &tls.Config{
 					MinVersion: tls.VersionTLS12,
 				},
 			}
 			log.Info().Str("addr", a.cfg.ListenAddr).Msg("starting agent with TLS")
-			err = s.ListenAndServeTLS(a.cfg.TLSCert, a.cfg.TLSKey)
+			srvErr = s.ServeTLS(ln, a.cfg.TLSCert, a.cfg.TLSKey)
 		} else {
 			log.Warn().Str("addr", a.cfg.ListenAddr).Msg("starting agent without TLS - set AGENT_TLS_CERT and AGENT_TLS_KEY for production")
-			err = e.Start(a.cfg.ListenAddr)
+			s := &http.Server{Handler: e}
+			srvErr = s.Serve(ln)
 		}
-		if err != nil && err != http.ErrServerClosed {
-			log.Fatal().Err(err).Msg("agent server failed")
+		if srvErr != nil && srvErr != http.ErrServerClosed {
+			log.Fatal().Err(srvErr).Msg("agent server failed")
 		}
 	}()
 }

--- a/agent/api/v1/metrics.go
+++ b/agent/api/v1/metrics.go
@@ -57,13 +57,21 @@ func MetricsMiddleware() echo.MiddlewareFunc {
 			httpRequestsTotal.WithLabelValues(method, path, code).Inc()
 			httpRequestDuration.WithLabelValues(method, path).Observe(duration)
 
-			log.Debug().
+			tenant, _ := c.Get("tenant").(string)
+			l := log.Debug().
 				Str("method", method).
-				Str("path", path).
+				Str("path", c.Request().URL.Path).
 				Str("code", code).
 				Str("client", c.RealIP()).
-				Dur("duration", time.Since(start)).
-				Msg("request")
+				Dur("took", time.Since(start))
+			if tenant != "" {
+				l = l.Str("tenant", tenant)
+			}
+			if resp.Status >= 400 {
+				l.Msg("request error")
+			} else {
+				l.Msg("request")
+			}
 
 			return err
 		}

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v5"
+	"github.com/rs/zerolog/log"
 )
 
 // AuthMiddleware validates Bearer or Basic auth and resolves the token to a tenant name.
@@ -14,16 +15,12 @@ func AuthMiddleware(tenants map[string]string) echo.MiddlewareFunc {
 		return func(c *echo.Context) error {
 			auth := c.Request().Header.Get("Authorization")
 			if auth == "" {
-				c.Response().Header().Set("WWW-Authenticate", `Basic realm="agent"`)
-				return c.JSON(http.StatusUnauthorized, ErrorResponse{
-					Error: "missing authorization header",
-					Code:  "UNAUTHORIZED",
-				})
+				return authFailed(c, "missing authorization header")
 			}
 
 			parts := strings.SplitN(auth, " ", 2)
 			if len(parts) != 2 {
-				return unauthorized(c)
+				return authFailed(c, "malformed authorization header")
 			}
 
 			var providedToken string
@@ -33,20 +30,20 @@ func AuthMiddleware(tenants map[string]string) echo.MiddlewareFunc {
 			case "Basic":
 				decoded, err := base64.StdEncoding.DecodeString(parts[1])
 				if err != nil {
-					return unauthorized(c)
+					return authFailed(c, "invalid basic auth encoding")
 				}
 				_, pass, ok := strings.Cut(string(decoded), ":")
 				if !ok {
-					return unauthorized(c)
+					return authFailed(c, "invalid basic auth format")
 				}
 				providedToken = pass
 			default:
-				return unauthorized(c)
+				return authFailed(c, "unsupported auth scheme: "+parts[0])
 			}
 
 			tenant, ok := tenants[providedToken]
 			if !ok {
-				return unauthorized(c)
+				return authFailed(c, "invalid token")
 			}
 			c.Set("tenant", tenant)
 
@@ -55,7 +52,9 @@ func AuthMiddleware(tenants map[string]string) echo.MiddlewareFunc {
 	}
 }
 
-func unauthorized(c *echo.Context) error {
+func authFailed(c *echo.Context, reason string) error {
+	log.Warn().Str("client", c.RealIP()).Str("path", c.Request().URL.Path).Str("reason", reason).Msg("auth failed")
+	log.Debug().Str("client", c.RealIP()).Str("authorization", c.Request().Header.Get("Authorization")).Msg("auth failed detail")
 	c.Response().Header().Set("WWW-Authenticate", `Basic realm="agent"`)
 	return c.JSON(http.StatusUnauthorized, ErrorResponse{
 		Error: "invalid auth token",

--- a/agent/api/v1/utils.go
+++ b/agent/api/v1/utils.go
@@ -15,6 +15,7 @@ var codeStatus = map[string]int{
 	storage.ErrNotFound:      http.StatusNotFound,
 	storage.ErrAlreadyExists: http.StatusConflict,
 	storage.ErrBusy:          http.StatusLocked,
+	storage.ErrMetadata:      http.StatusInternalServerError,
 }
 
 func StorageError(c *echo.Context, err error) error {

--- a/agent/storage/reconciler.go
+++ b/agent/storage/reconciler.go
@@ -101,5 +101,7 @@ func (s *Storage) reconcileExports(ctx context.Context, basePath string, tenant 
 
 	if removed > 0 || restored > 0 {
 		log.Info().Str("tenant", tenant).Int("removed", removed).Int("restored", restored).Msg("nfs reconciler: reconciliation complete")
+	} else {
+		log.Debug().Str("tenant", tenant).Msg("nfs reconciler: in sync")
 	}
 }

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -124,7 +124,10 @@ func (s *Storage) GetSnapshot(tenant, name string) (*SnapshotMetadata, error) {
 	metaPath := filepath.Join(bp, config.SnapshotsDir, name, config.MetadataFile)
 	var meta SnapshotMetadata
 	if err := ReadMetadata(metaPath, &meta); err != nil {
-		return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("snapshot %q not found", name)}
+		if os.IsNotExist(err) {
+			return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("snapshot %q not found", name)}
+		}
+		return nil, &StorageError{Code: ErrMetadata, Message: fmt.Sprintf("snapshot %q: failed to read metadata: %v", name, err)}
 	}
 	return &meta, nil
 }

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -90,7 +90,7 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 			Str("task", id).
 			Str("type", taskType).
 			Str("status", string(final.Status)).
-			Dur("duration", elapsed).
+			Dur("took", elapsed).
 			Msg("task finished")
 	}()
 

--- a/agent/storage/usage.go
+++ b/agent/storage/usage.go
@@ -174,7 +174,5 @@ func updateAll(ctx context.Context, mgr *btrfs.Manager, basePath string, tenant 
 		snapUpdated++
 	}
 
-	if snapUpdated > 0 || snapFailed > 0 {
-		log.Info().Str("tenant", tenant).Int("updated", snapUpdated).Int("failed", snapFailed).Msg("usage updater: snapshot scan complete")
-	}
+	log.Debug().Str("tenant", tenant).Int("snapshots", len(snapEntries)).Int("updated", snapUpdated).Int("failed", snapFailed).Msg("usage updater: snapshot scan complete")
 }

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -13,6 +13,7 @@ const (
 	ErrNotFound      = "NOT_FOUND"
 	ErrAlreadyExists = "ALREADY_EXISTS"
 	ErrBusy          = "BUSY"
+	ErrMetadata      = "METADATA_ERROR"
 )
 
 type StorageError struct {

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -172,7 +172,10 @@ func (s *Storage) GetVolume(tenant, name string) (*VolumeMetadata, error) {
 	metaPath := filepath.Join(bp, name, config.MetadataFile)
 	var meta VolumeMetadata
 	if err := ReadMetadata(metaPath, &meta); err != nil {
-		return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("volume %q not found", name)}
+		if os.IsNotExist(err) {
+			return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("volume %q not found", name)}
+		}
+		return nil, &StorageError{Code: ErrMetadata, Message: fmt.Sprintf("volume %q: failed to read metadata: %v", name, err)}
 	}
 	return &meta, nil
 }
@@ -192,7 +195,10 @@ func (s *Storage) UpdateVolume(ctx context.Context, tenant, name string, req Vol
 
 	var cur VolumeMetadata
 	if err := ReadMetadata(metaPath, &cur); err != nil {
-		return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("volume %q not found", name)}
+		if os.IsNotExist(err) {
+			return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("volume %q not found", name)}
+		}
+		return nil, &StorageError{Code: ErrMetadata, Message: fmt.Sprintf("volume %q: failed to read metadata: %v", name, err)}
 	}
 
 	// validation

--- a/agent/storage/volume_test.go
+++ b/agent/storage/volume_test.go
@@ -292,7 +292,7 @@ func TestGetVolume(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(corrupt, config.MetadataFile), []byte("{bad"), 0o644))
 
 		_, err := s.GetVolume("test", "corrupt")
-		requireStorageError(t, err, ErrNotFound)
+		requireStorageError(t, err, ErrMetadata)
 	})
 }
 

--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -63,7 +64,7 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	}
 
 	start := time.Now()
-	log.Debug().Str("method", info.FullMethod).Msg("gRPC call")
+	log.Debug().Str("method", info.FullMethod).Str("req", fmt.Sprintf("%+v", req)).Msg("gRPC call")
 
 	resp, err := handler(ctx, req)
 
@@ -73,7 +74,9 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	grpcRequestDuration.WithLabelValues(info.FullMethod).Observe(duration)
 
 	if err != nil {
-		log.Error().Err(err).Str("method", info.FullMethod).Msg("gRPC error")
+		log.Error().Err(err).Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC error")
+	} else {
+		log.Debug().Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC ok")
 	}
 
 	return resp, err

--- a/controller/publish.go
+++ b/controller/publish.go
@@ -33,25 +33,29 @@ func (s *Server) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 
 	client, err := agentClientFromStorageClass(s.agents, sc, req.Secrets)
 	if err != nil {
+		log.Error().Err(err).Str("volume", name).Str("sc", sc).Msg("failed to create agent client for publish")
 		return nil, err
 	}
 
 	// apply PVC annotation changes to agent
 	vp := resolveVolumeParams(ctx, req.VolumeContext)
 	if err := vp.validate(); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "volume %s: %v", name, err)
 	}
 	if update, changed := vp.toUpdateRequest(); changed {
+		log.Debug().Str("volume", name).Str("sc", sc).Msg("applying annotation updates")
 		start := time.Now()
 		_, updateErr := client.UpdateVolume(ctx, name, update)
 		agentDuration.WithLabelValues("update_volume", sc).Observe(time.Since(start).Seconds())
 		if updateErr != nil {
 			agentOpsTotal.WithLabelValues("update_volume", "error", sc).Inc()
-			log.Warn().Err(updateErr).Str("volume", name).Msg("failed to apply annotation updates")
+			log.Warn().Err(updateErr).Str("volume", name).Str("sc", sc).Msg("failed to apply annotation updates")
 		} else {
 			agentOpsTotal.WithLabelValues("update_volume", "success", sc).Inc()
 		}
 	}
+
+	log.Debug().Str("volume", name).Str("nodeIP", nodeIP).Str("sc", sc).Msg("exporting volume")
 
 	exportCtx, cancel := context.WithTimeout(ctx, exportTimeout)
 	defer cancel()
@@ -59,12 +63,12 @@ func (s *Server) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	if err := client.ExportVolume(exportCtx, name, nodeIP); err != nil {
 		agentDuration.WithLabelValues("export", sc).Observe(time.Since(start).Seconds())
 		agentOpsTotal.WithLabelValues("export", "error", sc).Inc()
-		return nil, status.Errorf(codes.Internal, "nfs export for node %s: %v", nodeIP, err)
+		return nil, status.Errorf(codes.Internal, "export volume %s to node %s via %s: %v", name, nodeIP, sc, err)
 	}
 	agentDuration.WithLabelValues("export", sc).Observe(time.Since(start).Seconds())
 	agentOpsTotal.WithLabelValues("export", "success", sc).Inc()
 
-	log.Info().Str("volume", name).Str("nodeIP", nodeIP).Msg("nfs export added")
+	log.Info().Str("volume", name).Str("nodeIP", nodeIP).Str("sc", sc).Msg("publish complete")
 
 	return &csi.ControllerPublishVolumeResponse{}, nil
 }
@@ -86,8 +90,11 @@ func (s *Server) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 
 	client, err := agentClientFromStorageClass(s.agents, sc, req.Secrets)
 	if err != nil {
+		log.Error().Err(err).Str("volume", name).Str("sc", sc).Msg("failed to create agent client for unpublish")
 		return nil, err
 	}
+
+	log.Debug().Str("volume", name).Str("nodeIP", nodeIP).Str("sc", sc).Msg("unexporting volume")
 
 	unexportCtx, cancel2 := context.WithTimeout(ctx, exportTimeout)
 	defer cancel2()
@@ -97,15 +104,16 @@ func (s *Server) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 	if unexportErr != nil {
 		if agentAPI.IsNotFound(unexportErr) {
 			agentOpsTotal.WithLabelValues("unexport", "not_found", sc).Inc()
+			log.Info().Str("volume", name).Str("nodeIP", nodeIP).Str("sc", sc).Msg("export already removed")
 		} else {
 			agentOpsTotal.WithLabelValues("unexport", "error", sc).Inc()
-			return nil, status.Errorf(codes.Internal, "nfs unexport for node %s: %v", nodeIP, unexportErr)
+			return nil, status.Errorf(codes.Internal, "unexport volume %s from node %s via %s: %v", name, nodeIP, sc, unexportErr)
 		}
 	} else {
 		agentOpsTotal.WithLabelValues("unexport", "success", sc).Inc()
 	}
 
-	log.Info().Str("volume", name).Str("nodeIP", nodeIP).Msg("nfs export removed")
+	log.Info().Str("volume", name).Str("nodeIP", nodeIP).Str("sc", sc).Msg("unpublish complete")
 
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }

--- a/controller/snapshots.go
+++ b/controller/snapshots.go
@@ -109,8 +109,11 @@ func (s *Server) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 
 	client, err := agentClientFromStorageClass(s.agents, sc, req.Secrets)
 	if err != nil {
+		log.Error().Err(err).Str("snapshot", req.Name).Str("volume", volName).Str("sc", sc).Msg("failed to create agent client for snapshot")
 		return nil, err
 	}
+
+	log.Debug().Str("snapshot", req.Name).Str("volume", volName).Str("sc", sc).Msg("creating snapshot")
 
 	start := time.Now()
 	snapResp, err := client.CreateSnapshot(ctx, agentAPI.SnapshotCreateRequest{
@@ -131,11 +134,11 @@ func (s *Server) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequ
 			}, nil
 		}
 		agentOpsTotal.WithLabelValues("create_snapshot", "error", sc).Inc()
-		return nil, status.Errorf(codes.Internal, "create snapshot: %v", err)
+		return nil, status.Errorf(codes.Internal, "create snapshot %s from volume %s via %s: %v", req.Name, volName, sc, err)
 	}
 	agentOpsTotal.WithLabelValues("create_snapshot", "success", sc).Inc()
 
-	log.Info().Str("snapshot", req.Name).Str("volume", volName).Msg("snapshot created")
+	log.Info().Str("snapshot", req.Name).Str("volume", volName).Str("sc", sc).Msg("snapshot created")
 
 	return &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{
@@ -160,8 +163,11 @@ func (s *Server) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 
 	client, err := agentClientFromStorageClass(s.agents, sc, req.Secrets)
 	if err != nil {
+		log.Error().Err(err).Str("snapshot", name).Str("sc", sc).Msg("failed to create agent client for snapshot delete")
 		return nil, err
 	}
+
+	log.Debug().Str("snapshot", name).Str("sc", sc).Msg("deleting snapshot")
 
 	start := time.Now()
 	deleteErr := client.DeleteSnapshot(ctx, name)
@@ -169,14 +175,15 @@ func (s *Server) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 	if deleteErr != nil {
 		if agentAPI.IsNotFound(deleteErr) {
 			agentOpsTotal.WithLabelValues("delete_snapshot", "not_found", sc).Inc()
+			log.Info().Str("snapshot", name).Str("sc", sc).Msg("snapshot already deleted")
 			return &csi.DeleteSnapshotResponse{}, nil
 		}
 		agentOpsTotal.WithLabelValues("delete_snapshot", "error", sc).Inc()
-		return nil, status.Errorf(codes.Internal, "delete snapshot: %v", deleteErr)
+		return nil, status.Errorf(codes.Internal, "delete snapshot %s via %s: %v", name, sc, deleteErr)
 	}
 	agentOpsTotal.WithLabelValues("delete_snapshot", "success", sc).Inc()
 
-	log.Info().Str("snapshot", name).Msg("snapshot deleted")
+	log.Info().Str("snapshot", name).Str("sc", sc).Msg("snapshot deleted")
 
 	return &csi.DeleteSnapshotResponse{}, nil
 }

--- a/controller/volumes.go
+++ b/controller/volumes.go
@@ -65,6 +65,7 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	client, err := agentClientFromSecrets(agentURL, req.Secrets)
 	if err != nil {
+		log.Error().Err(err).Str("volume", req.Name).Str("agent", agentURL).Msg("failed to create agent client")
 		return nil, err
 	}
 
@@ -73,7 +74,7 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	vp := resolveVolumeParams(ctx, params)
 	sc := vp.StorageClass
 	if sc == "" {
-		return nil, status.Error(codes.Internal, "failed to resolve StorageClass name from PVC")
+		return nil, status.Errorf(codes.Internal, "failed to resolve StorageClass name for volume %s", req.Name)
 	}
 
 	var sizeBytes uint64 = 1 << 30 // 1 GiB default
@@ -108,6 +109,8 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				return nil, status.Errorf(codes.InvalidArgument, "invalid source volume ID: %v", err)
 			}
 
+			log.Debug().Str("volume", req.Name).Str("source", srcName).Str("sc", sc).Str("agent", agentURL).Msg("cloning volume from volume")
+
 			start := time.Now()
 			cloneResp, err := client.CloneVolume(ctx, agentAPI.VolumeCloneRequest{
 				Source: srcName,
@@ -118,18 +121,18 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				if agentAPI.IsConflict(err) {
 					agentOpsTotal.WithLabelValues("clone_volume", "conflict", sc).Inc()
 					if cloneResp == nil {
-						return nil, status.Errorf(codes.Internal, "clone conflict but no metadata returned: %v", err)
+						return nil, status.Errorf(codes.Internal, "clone conflict for volume %s but no metadata returned: %v", req.Name, err)
 					}
 				} else {
 					agentOpsTotal.WithLabelValues("clone_volume", "error", sc).Inc()
-					return nil, status.Errorf(codes.Internal, "clone volume: %v", err)
+					return nil, status.Errorf(codes.Internal, "clone volume %s from %s via %s: %v", req.Name, srcName, agentURL, err)
 				}
 			} else {
 				agentOpsTotal.WithLabelValues("clone_volume", "success", sc).Inc()
 			}
 			volCtx[config.ParamNFSSharePath] = cloneResp.Path
 
-			log.Info().Str("volume", req.Name).Str("source", srcName).Msg("volume cloned from volume")
+			log.Info().Str("volume", req.Name).Str("source", srcName).Str("sc", sc).Str("agent", agentURL).Msg("volume cloned from volume")
 
 			return &csi.CreateVolumeResponse{
 				Volume: &csi.Volume{
@@ -151,6 +154,8 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			return nil, status.Errorf(codes.InvalidArgument, "invalid snapshot ID: %v", err)
 		}
 
+		log.Debug().Str("volume", req.Name).Str("snapshot", snapName).Str("sc", sc).Str("agent", agentURL).Msg("cloning volume from snapshot")
+
 		start := time.Now()
 		cloneResp, err := client.CreateClone(ctx, agentAPI.CloneCreateRequest{
 			Snapshot: snapName,
@@ -161,18 +166,18 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			if agentAPI.IsConflict(err) {
 				agentOpsTotal.WithLabelValues("create_clone", "conflict", sc).Inc()
 				if cloneResp == nil {
-					return nil, status.Errorf(codes.Internal, "clone conflict but no metadata returned: %v", err)
+					return nil, status.Errorf(codes.Internal, "clone conflict for volume %s but no metadata returned: %v", req.Name, err)
 				}
 			} else {
 				agentOpsTotal.WithLabelValues("create_clone", "error", sc).Inc()
-				return nil, status.Errorf(codes.Internal, "create clone: %v", err)
+				return nil, status.Errorf(codes.Internal, "clone volume %s from snapshot %s via %s: %v", req.Name, snapName, agentURL, err)
 			}
 		} else {
 			agentOpsTotal.WithLabelValues("create_clone", "success", sc).Inc()
 		}
 		volCtx[config.ParamNFSSharePath] = cloneResp.Path
 
-		log.Info().Str("volume", req.Name).Str("snapshot", snapName).Msg("volume cloned from snapshot")
+		log.Info().Str("volume", req.Name).Str("snapshot", snapName).Str("sc", sc).Str("agent", agentURL).Msg("volume cloned from snapshot")
 
 		return &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
@@ -191,6 +196,8 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	uid, _ := strconv.Atoi(vp.UID)
 	gid, _ := strconv.Atoi(vp.GID)
 
+	log.Debug().Str("volume", req.Name).Uint64("size", sizeBytes).Str("sc", sc).Str("agent", agentURL).Str("compression", vp.Compression).Msg("creating volume")
+
 	start := time.Now()
 	volResp, err := client.CreateVolume(ctx, agentAPI.VolumeCreateRequest{
 		Name:        req.Name,
@@ -208,19 +215,19 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			if volResp == nil {
 				volResp, err = client.GetVolume(ctx, req.Name)
 				if err != nil {
-					return nil, status.Errorf(codes.Internal, "volume conflict but failed to retrieve: %v", err)
+					return nil, status.Errorf(codes.Internal, "volume %s conflict but failed to retrieve from %s: %v", req.Name, agentURL, err)
 				}
 			}
 		} else {
 			agentOpsTotal.WithLabelValues("create_volume", "error", sc).Inc()
-			return nil, status.Errorf(codes.Internal, "create volume: %v", err)
+			return nil, status.Errorf(codes.Internal, "create volume %s via %s: %v", req.Name, agentURL, err)
 		}
 	} else {
 		agentOpsTotal.WithLabelValues("create_volume", "success", sc).Inc()
 	}
 	volCtx[config.ParamNFSSharePath] = volResp.Path
 
-	log.Info().Str("volume", req.Name).Uint64("size", sizeBytes).Msg("volume created")
+	log.Info().Str("volume", req.Name).Uint64("size", sizeBytes).Str("sc", sc).Str("agent", agentURL).Msg("volume created")
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -243,8 +250,11 @@ func (s *Server) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 
 	client, err := agentClientFromStorageClass(s.agents, sc, req.Secrets)
 	if err != nil {
+		log.Error().Err(err).Str("volume", name).Str("sc", sc).Msg("failed to create agent client for delete")
 		return nil, err
 	}
+
+	log.Debug().Str("volume", name).Str("sc", sc).Msg("deleting volume")
 
 	start := time.Now()
 	deleteErr := client.DeleteVolume(ctx, name)
@@ -252,18 +262,19 @@ func (s *Server) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	if deleteErr != nil {
 		if agentAPI.IsNotFound(deleteErr) {
 			agentOpsTotal.WithLabelValues("delete_volume", "not_found", sc).Inc()
+			log.Info().Str("volume", name).Str("sc", sc).Msg("volume already deleted")
 			return &csi.DeleteVolumeResponse{}, nil
 		}
 		if agentAPI.IsLocked(deleteErr) {
 			agentOpsTotal.WithLabelValues("delete_volume", "busy", sc).Inc()
-			return nil, status.Errorf(codes.FailedPrecondition, "delete volume: %v", deleteErr)
+			return nil, status.Errorf(codes.FailedPrecondition, "delete volume %s: %v", name, deleteErr)
 		}
 		agentOpsTotal.WithLabelValues("delete_volume", "error", sc).Inc()
-		return nil, status.Errorf(codes.Internal, "delete volume: %v", deleteErr)
+		return nil, status.Errorf(codes.Internal, "delete volume %s via %s: %v", name, sc, deleteErr)
 	}
 	agentOpsTotal.WithLabelValues("delete_volume", "success", sc).Inc()
 
-	log.Info().Str("volume", name).Msg("volume deleted")
+	log.Info().Str("volume", name).Str("sc", sc).Msg("volume deleted")
 
 	return &csi.DeleteVolumeResponse{}, nil
 }
@@ -280,6 +291,7 @@ func (s *Server) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 
 	client, err := agentClientFromStorageClass(s.agents, sc, req.Secrets)
 	if err != nil {
+		log.Error().Err(err).Str("volume", name).Str("sc", sc).Msg("failed to create agent client for expand")
 		return nil, err
 	}
 
@@ -295,6 +307,8 @@ func (s *Server) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		return nil, status.Error(codes.InvalidArgument, "capacity range required")
 	}
 
+	log.Debug().Str("volume", name).Uint64("size", sizeBytes).Str("sc", sc).Msg("expanding volume")
+
 	update := agentAPI.VolumeUpdateRequest{SizeBytes: &sizeBytes}
 
 	start := time.Now()
@@ -302,11 +316,11 @@ func (s *Server) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 	agentDuration.WithLabelValues("update_volume", sc).Observe(time.Since(start).Seconds())
 	if updateErr != nil {
 		agentOpsTotal.WithLabelValues("update_volume", "error", sc).Inc()
-		return nil, status.Errorf(codes.Internal, "update volume: %v", updateErr)
+		return nil, status.Errorf(codes.Internal, "expand volume %s via %s: %v", name, sc, updateErr)
 	}
 	agentOpsTotal.WithLabelValues("update_volume", "success", sc).Inc()
 
-	log.Info().Str("volume", name).Uint64("size", sizeBytes).Msg("volume expanded")
+	log.Info().Str("volume", name).Uint64("size", sizeBytes).Str("sc", sc).Msg("volume expanded")
 
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         int64(sizeBytes),

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -22,6 +22,8 @@ Token resolves to tenant via `AGENT_TENANTS`. All `/v1/*` endpoints require auth
 | `UNAUTHORIZED` | 401 | Bad/missing token |
 | `NOT_FOUND` | 404 | Resource missing |
 | `ALREADY_EXISTS` | 409 | Conflict (returns existing record) |
+| `BUSY` | 423 | Resource locked (e.g. active NFS exports, scrub running) |
+| `METADATA_ERROR` | 500 | Volume/snapshot metadata corrupt or unreadable |
 | `INTERNAL_ERROR` | 500 | Server error |
 
 ## Volumes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@
 | `AGENT_DEFAULT_DIR_MODE` | `0700` | Default mode for volume/snapshot/clone directories |
 | `AGENT_DEFAULT_DATA_MODE` | `2770` | Default mode for data subvolumes (setgid + group rwx) |
 | `AGENT_TASK_CLEANUP_INTERVAL` | `24h` | Remove completed/failed tasks after this duration |
-| `LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
+| `LOG_LEVEL` | `info` | `trace`, `debug`, `info`, `warn`, `error` |
 
 ## CLI Environment Variables
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -107,7 +107,7 @@ Enabled by default (`AGENT_FEATURE_QUOTA_ENABLED=true`).
 
 - Create: `btrfs qgroup limit <bytes> <path>`
 - Usage updater: polls `btrfs qgroup show` at `AGENT_FEATURE_QUOTA_UPDATE_INTERVAL`
-- `NodeGetVolumeStats` reads `metadata.json` for quota-aware reporting
+- `NodeGetVolumeStats` reads `metadata.json` for quota-aware reporting. Falls back to `statfs` when quota is disabled.
 
 ## fsGroup
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
@@ -16,7 +17,7 @@ func Start(ctx context.Context, endpoint, nodeID, nodeIP, metricsAddr, version s
 
 	srv, err := csiserver.New(endpoint, version, metricsInterceptor)
 	if err != nil {
-		return err
+		return fmt.Errorf("create CSI server on %s: %w", endpoint, err)
 	}
 	csi.RegisterNodeServer(srv.GRPC(), &NodeServer{nodeID: nodeID, nodeIP: nodeIP, mounter: mount.New("")})
 	return srv.Run(ctx, "driver")

--- a/driver/metrics.go
+++ b/driver/metrics.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -63,7 +64,7 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	}
 
 	start := time.Now()
-	log.Debug().Str("method", info.FullMethod).Msg("gRPC call")
+	log.Debug().Str("method", info.FullMethod).Str("req", fmt.Sprintf("%+v", req)).Msg("gRPC call")
 
 	resp, err := handler(ctx, req)
 
@@ -73,7 +74,9 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	grpcRequestDuration.WithLabelValues(info.FullMethod).Observe(duration)
 
 	if err != nil {
-		log.Error().Err(err).Str("method", info.FullMethod).Msg("gRPC error")
+		log.Error().Err(err).Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC error")
+	} else {
+		log.Debug().Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC ok")
 	}
 
 	return resp, err

--- a/driver/node.go
+++ b/driver/node.go
@@ -32,13 +32,15 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 
 	stagingPath := req.StagingTargetPath
 
-	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(stagingPath); !notMnt {
-		log.Debug().Str("path", stagingPath).Msg("already mounted at staging path")
+	if notMnt, err := s.mounter.IsLikelyNotMountPoint(stagingPath); err != nil {
+		log.Warn().Err(err).Str("volume", req.VolumeId).Str("path", stagingPath).Msg("failed to check mount point")
+	} else if !notMnt {
+		log.Info().Str("volume", req.VolumeId).Str("path", stagingPath).Msg("already mounted at staging path")
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
 	if err := os.MkdirAll(stagingPath, 0755); err != nil {
-		return nil, status.Errorf(codes.Internal, "mkdir staging: %v", err)
+		return nil, status.Errorf(codes.Internal, "mkdir staging for volume %s: %v", req.VolumeId, err)
 	}
 
 	source := fmt.Sprintf("%s:%s", nfsServer, nfsSharePath)
@@ -56,17 +58,19 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		opts = append(opts, strings.Split(extra, ",")...)
 	}
 
-	log.Info().Str("source", source).Str("target", stagingPath).Msg("mounting NFS")
+	log.Debug().Str("volume", req.VolumeId).Str("source", source).Str("target", stagingPath).Strs("opts", opts).Msg("mounting NFS")
 
 	start := time.Now()
 	err := s.mounter.Mount(source, stagingPath, "nfs", opts)
-	mountDuration.WithLabelValues("nfs_mount").Observe(time.Since(start).Seconds())
+	elapsed := time.Since(start)
+	mountDuration.WithLabelValues("nfs_mount").Observe(elapsed.Seconds())
 	if err != nil {
 		mountOpsTotal.WithLabelValues("nfs_mount", "error").Inc()
-		return nil, status.Errorf(codes.Internal, "mount NFS: %v", err)
+		return nil, status.Errorf(codes.Internal, "mount NFS for volume %s: %v", req.VolumeId, err)
 	}
 	mountOpsTotal.WithLabelValues("nfs_mount", "success").Inc()
 
+	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("source", source).Str("target", stagingPath).Dur("took", elapsed).Msg("stage complete")
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
@@ -78,10 +82,13 @@ func (s *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 	unlock := s.volumeLock(req.VolumeId)
 	defer unlock()
 
+	log.Debug().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.StagingTargetPath).Msg("unstaging volume")
+
 	if err := cleanupMountPoint(ctx, s.mounter, req.StagingTargetPath); err != nil {
-		return nil, status.Errorf(codes.Internal, "cleanup staging: %v", err)
+		return nil, status.Errorf(codes.Internal, "cleanup staging for volume %s at %s: %v", req.VolumeId, req.StagingTargetPath, err)
 	}
 
+	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.StagingTargetPath).Msg("unstage complete")
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
@@ -93,22 +100,27 @@ func (s *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	unlock := s.volumeLock(req.VolumeId)
 	defer unlock()
 
-	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(req.TargetPath); !notMnt {
-		log.Info().Str("path", req.TargetPath).Msg("already mounted, skipping publish")
+	if notMnt, err := s.mounter.IsLikelyNotMountPoint(req.TargetPath); err != nil {
+		log.Warn().Err(err).Str("volume", req.VolumeId).Str("path", req.TargetPath).Msg("failed to check mount point")
+	} else if !notMnt {
+		log.Info().Str("volume", req.VolumeId).Str("path", req.TargetPath).Msg("already mounted, skipping publish")
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
 	if err := os.MkdirAll(req.TargetPath, 0755); err != nil {
-		return nil, status.Errorf(codes.Internal, "mkdir target: %v", err)
+		return nil, status.Errorf(codes.Internal, "mkdir target for volume %s: %v", req.VolumeId, err)
 	}
 
 	dataDir := req.StagingTargetPath + "/" + config.DataDir
+	log.Debug().Str("volume", req.VolumeId).Str("source", dataDir).Str("target", req.TargetPath).Bool("readonly", req.Readonly).Msg("bind mounting")
+
 	start := time.Now()
 	err := s.mounter.Mount(dataDir, req.TargetPath, "", []string{"bind"})
-	mountDuration.WithLabelValues("bind_mount").Observe(time.Since(start).Seconds())
+	elapsed := time.Since(start)
+	mountDuration.WithLabelValues("bind_mount").Observe(elapsed.Seconds())
 	if err != nil {
 		mountOpsTotal.WithLabelValues("bind_mount", "error").Inc()
-		return nil, status.Errorf(codes.Internal, "bind mount: %v", err)
+		return nil, status.Errorf(codes.Internal, "bind mount for volume %s: %v", req.VolumeId, err)
 	}
 	mountOpsTotal.WithLabelValues("bind_mount", "success").Inc()
 
@@ -118,12 +130,15 @@ func (s *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		mountDuration.WithLabelValues("remount_ro").Observe(time.Since(start).Seconds())
 		if err != nil {
 			mountOpsTotal.WithLabelValues("remount_ro", "error").Inc()
-			_ = cleanupMountPoint(ctx, s.mounter, req.TargetPath)
-			return nil, status.Errorf(codes.Internal, "remount ro: %v", err)
+			if cleanErr := cleanupMountPoint(ctx, s.mounter, req.TargetPath); cleanErr != nil {
+				log.Error().Err(cleanErr).Str("volume", req.VolumeId).Str("path", req.TargetPath).Msg("cleanup after remount-ro failure also failed")
+			}
+			return nil, status.Errorf(codes.Internal, "remount ro for volume %s: %v", req.VolumeId, err)
 		}
 		mountOpsTotal.WithLabelValues("remount_ro", "success").Inc()
 	}
 
+	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("target", req.TargetPath).Bool("readonly", req.Readonly).Dur("took", elapsed).Msg("publish complete")
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
@@ -135,9 +150,12 @@ func (s *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 	unlock := s.volumeLock(req.VolumeId)
 	defer unlock()
 
+	log.Debug().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.TargetPath).Msg("unpublishing volume")
+
 	if err := cleanupMountPoint(ctx, s.mounter, req.TargetPath); err != nil {
-		return nil, status.Errorf(codes.Internal, "cleanup target: %v", err)
+		return nil, status.Errorf(codes.Internal, "cleanup target for volume %s at %s: %v", req.VolumeId, req.TargetPath, err)
 	}
 
+	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.TargetPath).Msg("unpublish complete")
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }

--- a/driver/stats.go
+++ b/driver/stats.go
@@ -6,11 +6,13 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -34,47 +36,60 @@ func (s *NodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolum
 		stagingPath = findStagingPath(req.VolumeId)
 	}
 
+	log.Debug().Str("volume", req.VolumeId).Str("volumePath", req.VolumePath).Str("stagingPath", stagingPath).Msg("looking up volume stats")
+
 	if stagingPath != "" {
 		metaPath := stagingPath + "/" + config.MetadataFile
-		if data, err := os.ReadFile(metaPath); err == nil {
+		data, err := os.ReadFile(metaPath)
+		if err != nil {
+			log.Warn().Err(err).Str("volume", req.VolumeId).Str("path", metaPath).Msg("failed to read metadata")
+		} else {
 			var vs volumeStats
-			if err := json.Unmarshal(data, &vs); err == nil && vs.QuotaBytes > 0 {
-				used := int64(vs.UsedBytes)
-				total := int64(vs.QuotaBytes)
-				avail := total - used
-				if avail < 0 {
-					avail = 0
+			if err := json.Unmarshal(data, &vs); err != nil {
+				log.Warn().Err(err).Str("volume", req.VolumeId).Str("path", metaPath).Msg("metadata JSON corrupt")
+			} else {
+				if vs.QuotaBytes > 0 {
+					used := int64(vs.UsedBytes)
+					total := int64(vs.QuotaBytes)
+					avail := total - used
+					if avail < 0 {
+						avail = 0
+					}
+					volumeStatsOpsTotal.WithLabelValues("success").Inc()
+					return &csi.NodeGetVolumeStatsResponse{
+						Usage: []*csi.VolumeUsage{{
+							Available: avail,
+							Total:     total,
+							Used:      used,
+							Unit:      csi.VolumeUsage_BYTES,
+						}},
+					}, nil
 				}
-				volumeStatsOpsTotal.WithLabelValues("success").Inc()
-				return &csi.NodeGetVolumeStatsResponse{
-					Usage: []*csi.VolumeUsage{{
-						Available: avail,
-						Total:     total,
-						Used:      used,
-						Unit:      csi.VolumeUsage_BYTES,
-					}},
-				}, nil
+				// Quota disabled: fallback to statfs
+				log.Debug().Str("volume", req.VolumeId).Msg("quota not configured, falling back to statfs")
+				return statfsResponse(req.VolumePath)
 			}
 		}
 	}
 
-	// No statfs fallback - returns NFS-level data which doesn't reflect per-volume quota.
-	// Better to return an error so kubelet retries than to report misleading capacity.
 	volumeStatsOpsTotal.WithLabelValues("error").Inc()
-	return nil, status.Errorf(codes.Unavailable, "%s not available, agent may be down", config.MetadataFile)
+	if stagingPath == "" {
+		return nil, status.Errorf(codes.NotFound, "staging path not found for volume %s", req.VolumeId)
+	}
+	return nil, status.Errorf(codes.Internal, "failed to read %s for volume %s from %s", config.MetadataFile, req.VolumeId, stagingPath)
 }
 
 // findStagingPath parses /proc/self/mountinfo to find the globalmount staging path for a volume.
-// It extracts the volume name from the volumeId (format "storageClass|pvcName") and matches it
-// against NFS mount sources whose mountpoint contains "globalmount".
 func findStagingPath(volumeId string) string {
 	_, volName, err := utils.ParseVolumeID(volumeId)
 	if err != nil {
+		log.Debug().Err(err).Str("volume", volumeId).Msg("failed to parse volume ID for staging path lookup")
 		return ""
 	}
 
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
+		log.Warn().Err(err).Msg("failed to open /proc/self/mountinfo")
 		return ""
 	}
 	defer func() { _ = f.Close() }()
@@ -105,5 +120,28 @@ func findStagingPath(volumeId string) string {
 			return mountpoint
 		}
 	}
+	if err := sc.Err(); err != nil {
+		log.Warn().Err(err).Msg("error reading /proc/self/mountinfo")
+	}
+	log.Debug().Str("volume", volumeId).Msg("no staging path found in mountinfo")
 	return ""
+}
+
+func statfsResponse(path string) (*csi.NodeGetVolumeStatsResponse, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		volumeStatsOpsTotal.WithLabelValues("error").Inc()
+		return nil, status.Errorf(codes.Internal, "statfs failed on %s: %v", path, err)
+	}
+	total := int64(st.Blocks) * int64(st.Bsize)
+	free := int64(st.Bavail) * int64(st.Bsize)
+	volumeStatsOpsTotal.WithLabelValues("success").Inc()
+	return &csi.NodeGetVolumeStatsResponse{
+		Usage: []*csi.VolumeUsage{{
+			Available: free,
+			Total:     total,
+			Used:      total - free,
+			Unit:      csi.VolumeUsage_BYTES,
+		}},
+	}, nil
 }

--- a/utils/runner.go
+++ b/utils/runner.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 // Runner executes shell commands and returns their combined output.
@@ -17,10 +20,15 @@ type Runner interface {
 type ShellRunner struct{}
 
 func (r *ShellRunner) Run(ctx context.Context, bin string, args ...string) (string, error) {
+	start := time.Now()
 	cmd := exec.CommandContext(ctx, bin, args...)
 	out, err := cmd.CombinedOutput()
+	took := time.Since(start)
+
 	if err != nil {
+		log.Trace().Str("cmd", bin).Strs("args", args).Dur("took", took).Str("stderr", strings.TrimSpace(string(out))).Err(err).Msg("exec failed")
 		return string(out), fmt.Errorf("%s %s: %w: %s", bin, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
+	log.Trace().Str("cmd", bin).Strs("args", args).Dur("took", took).Str("stdout", strings.TrimSpace(string(out))).Msg("exec ok")
 	return string(out), nil
 }


### PR DESCRIPTION
## Summary
- Distinguish file-not-found (404) from corrupt metadata JSON (500 `METADATA_ERROR`) in GetVolume, UpdateVolume, GetSnapshot
- Driver stats: statfs fallback when quota disabled instead of returning error to kubelet. Separate error messages for each failure case.
- Agent startup: port binding verified synchronously before `ready=true`, fatal on bind failure instead of async crash
- Auth failures logged with client IP, path, reason (WARN). Authorization header only at DEBUG.
- Controller operations: all errors include volume name, StorageClass, agent URL. Debug logs at operation start.
- Driver operations: debug logs for mount options, bind mount params, staging path lookup. Info logs with node ID and duration on completion.
- gRPC interceptors: success logging with method, code, duration. Request parameters at debug.
- Shell commands (`btrfs`/`exportfs`): logged at trace level with cmd, args, duration, stdout/stderr
- Reconciler/usage updater: always log scan results, even when no changes found
- Log field consistency: "took" everywhere (was "duration" in task manager)