### PR TITLE
Worker pool for task system with configurable concurrency

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,6 +64,7 @@ func (a *Agent) Start(ctx context.Context) {
 	store := storage.New(
 		a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames,
 		a.cfg.DefaultDirMode, a.cfg.DefaultDataMode, a.cfg.BtrfsBin,
+		a.cfg.TaskMaxConcurrent,
 	)
 	h := &v1.Handler{Store: store}
 
@@ -96,6 +97,7 @@ func (a *Agent) Start(ctx context.Context) {
 
 	api.GET("/tasks", h.ListTasks)
 	api.POST("/tasks/scrub", h.StartScrub)
+	api.POST("/tasks/test", h.StartTestTask)
 	api.GET("/tasks/:id", h.GetTask)
 	api.DELETE("/tasks/:id", h.CancelTask)
 

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -417,7 +417,9 @@ func (h *Handler) StartScrub(c *echo.Context) error {
 
 func (h *Handler) StartTestTask(c *echo.Context) error {
 	var opts storage.TestTaskOpts
-	_ = c.Bind(&opts)
+	if err := c.Bind(&opts); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body: " + err.Error(), Code: storage.ErrInvalid})
+	}
 	taskID, err := h.Store.StartTestTask(c.Request().Context(), opts)
 	if err != nil {
 		return StorageError(c, err)

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -413,6 +413,21 @@ func (h *Handler) StartScrub(c *echo.Context) error {
 	})
 }
 
+// --- Test Task ---
+
+func (h *Handler) StartTestTask(c *echo.Context) error {
+	var opts storage.TestTaskOpts
+	_ = c.Bind(&opts)
+	taskID, err := h.Store.StartTestTask(c.Request().Context(), opts)
+	if err != nil {
+		return StorageError(c, err)
+	}
+	return c.JSON(http.StatusAccepted, map[string]any{
+		"task_id": taskID,
+		"status":  string(task.TaskPending),
+	})
+}
+
 // --- Tasks ---
 
 func (h *Handler) ListTasks(c *echo.Context) error {

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -33,6 +33,7 @@ const (
 	TaskStatusCancelled = string(task.TaskCancelled)
 
 	TaskTypeScrub = string(task.TypeScrub)
+	TaskTypeTest  = string(task.TypeTest)
 )
 
 // request models (HTTP-layer only)

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -41,7 +41,7 @@ type Storage struct {
 	cachedFilesystem atomic.Pointer[btrfs.FilesystemUsage]
 }
 
-func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin string) *Storage {
+func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin string, taskMaxConcurrent int) *Storage {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -112,7 +112,7 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 		initialStates[i] = DeviceState{BTRFSDevice: d}
 	}
 	taskDir := filepath.Join(basePath, config.TasksDir)
-	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, tasks: task.NewManager(taskDir)}
+	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, tasks: task.NewManager(taskDir, taskMaxConcurrent)}
 	s.cachedDevices.Store(&initialStates)
 	return s
 }

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -95,7 +95,7 @@ func (s *StorageIntegrationSuite) SetupSuite() {
 		tenants:         []string{"test"},
 		defaultDirMode:  0o755,
 		defaultDataMode: "2770",
-		tasks:           task.NewManager(taskDir),
+		tasks:           task.NewManager(taskDir, 0),
 	}
 }
 
@@ -468,7 +468,7 @@ func (s *StorageIntegrationSuite) TestTaskLoadFromDisk() {
 	s.Require().NoError(writeMetadataAtomic(filepath.Join(taskDir, "stale-task-123.json"), &staleTask))
 
 	// create new TaskManager (triggers loadFromDisk)
-	tm := task.NewManager(taskDir)
+	tm := task.NewManager(taskDir, 0)
 
 	// stale task should be marked failed
 	tsk, err := tm.Get("stale-task-123")
@@ -531,7 +531,7 @@ func (s *StorageIntegrationSuite) TestScrubRestartRecovery() {
 	s.Require().NoError(writeMetadataAtomic(filepath.Join(taskDir, "stale-scrub.json"), &staleTask))
 
 	// create new TaskManager (simulates agent restart)
-	tm := task.NewManager(taskDir)
+	tm := task.NewManager(taskDir, 0)
 
 	// stale scrub should be failed
 	tsk, err := tm.Get("stale-scrub")

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -56,12 +56,12 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 	ctx, cancel := context.WithCancel(context.Background())
 	rt := &runningTask{cancel: cancel}
 	rt.state.Store(t)
+	tm.persist(t)
 
 	tm.mu.Lock()
 	tm.tasks[id] = rt
 	tm.mu.Unlock()
 
-	tm.persist(t)
 	log.Info().Str("task", id).Str("type", taskType).Msg("task submitted")
 
 	go func() {

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -81,8 +81,8 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 				final := *rt.state.Load()
 				final.Status = TaskCancelled
 				final.CompletedAt = &now
-				rt.state.Store(&final)
 				tm.persist(&final)
+				rt.state.Store(&final)
 				tasksTotal.WithLabelValues(taskType, string(TaskCancelled)).Inc()
 				log.Info().Str("task", id).Str("type", taskType).Msg("task cancelled while pending")
 				return
@@ -97,8 +97,8 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 		running := *rt.state.Load()
 		running.Status = TaskRunning
 		running.StartedAt = &startUTC
-		rt.state.Store(&running)
 		tm.persist(&running)
+		rt.state.Store(&running)
 
 		err := fn(ctx, &Update{rt: rt, persist: tm.persist})
 
@@ -115,8 +115,8 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 			final.Status = TaskCompleted
 			final.Progress = 100
 		}
-		rt.state.Store(&final)
 		tm.persist(&final)
+		rt.state.Store(&final)
 
 		elapsed := time.Since(start)
 		tasksTotal.WithLabelValues(taskType, string(final.Status)).Inc()

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -16,17 +16,26 @@ type Manager struct {
 	mu      sync.Mutex
 	tasks   map[string]*runningTask
 	taskDir string
+	sem     chan struct{}
 }
 
 // NewManager creates a new Manager with persistence under taskDir.
-func NewManager(taskDir string) *Manager {
+// maxConcurrent limits the number of tasks running simultaneously.
+func NewManager(taskDir string, maxConcurrent int) *Manager {
 	if err := os.MkdirAll(taskDir, 0o755); err != nil {
 		log.Fatal().Err(err).Str("path", taskDir).Msg("failed to create tasks directory")
 	}
-
 	tm := &Manager{
 		tasks:   make(map[string]*runningTask),
 		taskDir: taskDir,
+	}
+	if maxConcurrent > 0 {
+		tm.sem = make(chan struct{}, maxConcurrent)
+		tasksWorkers.Set(float64(maxConcurrent))
+		log.Info().Int("workers", maxConcurrent).Msg("task manager initialized")
+	} else {
+		tasksWorkers.Set(0)
+		log.Warn().Msg("task manager initialized with unlimited concurrency")
 	}
 	tm.loadFromDisk()
 	return tm
@@ -52,13 +61,40 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 	tm.tasks[id] = rt
 	tm.mu.Unlock()
 
+	tm.persist(t)
 	log.Info().Str("task", id).Str("type", taskType).Msg("task submitted")
 
 	go func() {
+		// Wait for a worker slot (nil sem = unlimited)
+		if tm.sem != nil {
+			tasksQueued.WithLabelValues(taskType).Inc()
+			select {
+			case tm.sem <- struct{}{}:
+				tasksQueued.WithLabelValues(taskType).Dec()
+				defer func() {
+					<-tm.sem
+					tasksRunning.WithLabelValues(taskType).Dec()
+				}()
+			case <-ctx.Done():
+				tasksQueued.WithLabelValues(taskType).Dec()
+				now := time.Now().UTC()
+				final := *rt.state.Load()
+				final.Status = TaskCancelled
+				final.CompletedAt = &now
+				rt.state.Store(&final)
+				tm.persist(&final)
+				tasksTotal.WithLabelValues(taskType, string(TaskCancelled)).Inc()
+				log.Info().Str("task", id).Str("type", taskType).Msg("task cancelled while pending")
+				return
+			}
+		}
+
+		tasksRunning.WithLabelValues(taskType).Inc()
+
 		start := time.Now()
 		startUTC := start.UTC()
 
-		running := *t
+		running := *rt.state.Load()
 		running.Status = TaskRunning
 		running.StartedAt = &startUTC
 		rt.state.Store(&running)

--- a/agent/storage/task/manager_test.go
+++ b/agent/storage/task/manager_test.go
@@ -18,7 +18,7 @@ import (
 // awaitStatus polls until a task reaches the expected status or times out.
 func awaitStatus(t *testing.T, tm *Manager, id string, status TaskStatus) *Task {
 	t.Helper()
-	for i := 0; i < 400; i++ {
+	for i := 0; i < 2000; i++ {
 		tsk, err := tm.Get(id)
 		if err == nil && tsk.Status == status {
 			return tsk
@@ -33,7 +33,7 @@ func awaitStatus(t *testing.T, tm *Manager, id string, status TaskStatus) *Task 
 // awaitDone polls until a task is completed, failed, or cancelled.
 func awaitDone(t *testing.T, tm *Manager, id string) *Task {
 	t.Helper()
-	for i := 0; i < 400; i++ {
+	for i := 0; i < 2000; i++ {
 		tsk, err := tm.Get(id)
 		if err == nil && (tsk.Status == TaskCompleted || tsk.Status == TaskFailed || tsk.Status == TaskCancelled) {
 			return tsk

--- a/agent/storage/task/manager_test.go
+++ b/agent/storage/task/manager_test.go
@@ -192,7 +192,7 @@ func TestManager_ProgressUpdate(t *testing.T) {
 	assert.Equal(t, 50, tsk.Progress)
 
 	require.NoError(t, tm.Cancel(id))
-	awaitStatus(t, tm, id, TaskCancelled)
+	awaitDone(t, tm, id)
 }
 
 func TestManager_ResultStruct(t *testing.T) {
@@ -402,7 +402,7 @@ func TestManager_CancelPending(t *testing.T) {
 
 	started := make(chan struct{})
 	blocker := make(chan struct{})
-	tm.Create("test", func(ctx context.Context, update *Update) error {
+	first := tm.Create("test", func(ctx context.Context, update *Update) error {
 		close(started)
 		<-blocker
 		return nil
@@ -423,6 +423,7 @@ func TestManager_CancelPending(t *testing.T) {
 	assert.NotNil(t, tsk.CompletedAt, "cancelled pending should have CompletedAt")
 
 	close(blocker)
+	awaitDone(t, tm, first)
 }
 
 func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {

--- a/agent/storage/task/manager_test.go
+++ b/agent/storage/task/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func TestManager_SubmitAndGet(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	started := make(chan struct{})
 	done := make(chan struct{})
@@ -46,7 +47,7 @@ func TestManager_SubmitAndGet(t *testing.T) {
 }
 
 func TestManager_SubmitWithError(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	id := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return fmt.Errorf("something broke")
@@ -62,7 +63,7 @@ func TestManager_SubmitWithError(t *testing.T) {
 }
 
 func TestManager_Cancel(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	started := make(chan struct{})
 	id := tm.Create("test", func(ctx context.Context, update *Update) error {
@@ -82,7 +83,7 @@ func TestManager_Cancel(t *testing.T) {
 }
 
 func TestManager_CancelFinished(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	id := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
@@ -95,21 +96,21 @@ func TestManager_CancelFinished(t *testing.T) {
 }
 
 func TestManager_CancelUnknown(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	err := tm.Cancel("nonexistent")
 	assert.Error(t, err)
 }
 
 func TestManager_GetUnknown(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	_, err := tm.Get("nonexistent")
 	assert.Error(t, err)
 }
 
 func TestManager_List(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	tm.Create("scrub", func(ctx context.Context, update *Update) error {
 		return nil
@@ -136,7 +137,7 @@ func TestManager_List(t *testing.T) {
 }
 
 func TestManager_ListReturnsCopies(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
@@ -155,7 +156,7 @@ func TestManager_ListReturnsCopies(t *testing.T) {
 }
 
 func TestManager_ProgressUpdate(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	checkpoint := make(chan struct{})
 	id := tm.Create("test", func(ctx context.Context, update *Update) error {
@@ -181,7 +182,7 @@ func TestManager_ResultStruct(t *testing.T) {
 		Name  string `json:"name"`
 	}
 
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	id := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return update.SetResult(TestResult{Count: 42, Name: "hello"})
@@ -200,7 +201,7 @@ func TestManager_ResultStruct(t *testing.T) {
 }
 
 func TestManager_Cleanup(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	id := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
@@ -218,7 +219,7 @@ func TestManager_Cleanup(t *testing.T) {
 }
 
 func TestManager_CleanupKeepsRunning(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	done := make(chan struct{})
 	id := tm.Create("test", func(ctx context.Context, update *Update) error {
@@ -247,7 +248,7 @@ func TestManager_CorruptTaskFile(t *testing.T) {
 	valid, _ := json.MarshalIndent(Task{ID: "good", Type: "test", Status: TaskCompleted}, "", "  ")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "good.json"), valid, 0o644))
 
-	tm := NewManager(dir)
+	tm := NewManager(dir, 0)
 
 	tasks := tm.List("")
 	assert.Len(t, tasks, 1)
@@ -259,13 +260,13 @@ func TestManager_EmptyTaskFile(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.json"), []byte(""), 0o644))
 
-	tm := NewManager(dir)
+	tm := NewManager(dir, 0)
 	tasks := tm.List("")
 	assert.Empty(t, tasks)
 }
 
 func TestManager_ConcurrentSubmit(t *testing.T) {
-	tm := NewManager(t.TempDir())
+	tm := NewManager(t.TempDir(), 0)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
@@ -286,4 +287,252 @@ func TestManager_ConcurrentSubmit(t *testing.T) {
 	for _, task := range tasks {
 		assert.Equal(t, TaskCompleted, task.Status)
 	}
+}
+
+func TestManager_WorkerPoolBlocksSecondTask(t *testing.T) {
+	tm := NewManager(t.TempDir(), 1)
+
+	blocker := make(chan struct{})
+	first := tm.Create("test", func(ctx context.Context, update *Update) error {
+		<-blocker
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	second := tm.Create("test", func(ctx context.Context, update *Update) error {
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	t1, _ := tm.Get(first)
+	t2, _ := tm.Get(second)
+	assert.Equal(t, TaskRunning, t1.Status)
+	assert.Equal(t, TaskPending, t2.Status)
+
+	close(blocker)
+	time.Sleep(100 * time.Millisecond)
+
+	t1, _ = tm.Get(first)
+	t2, _ = tm.Get(second)
+	assert.Equal(t, TaskCompleted, t1.Status)
+	assert.Equal(t, TaskCompleted, t2.Status)
+}
+
+func TestManager_WorkerPoolMaxTwo(t *testing.T) {
+	tm := NewManager(t.TempDir(), 2)
+
+	started1 := make(chan struct{})
+	started2 := make(chan struct{})
+	blocker := make(chan struct{})
+
+	id1 := tm.Create("test", func(ctx context.Context, update *Update) error {
+		close(started1)
+		<-blocker
+		return nil
+	})
+	id2 := tm.Create("test", func(ctx context.Context, update *Update) error {
+		close(started2)
+		<-blocker
+		return nil
+	})
+
+	// Wait until both are confirmed running
+	<-started1
+	<-started2
+
+	id3 := tm.Create("test", func(ctx context.Context, update *Update) error {
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	t1, _ := tm.Get(id1)
+	t2, _ := tm.Get(id2)
+	t3, _ := tm.Get(id3)
+	assert.Equal(t, TaskRunning, t1.Status, "first should run")
+	assert.Equal(t, TaskRunning, t2.Status, "second should run")
+	assert.Equal(t, TaskPending, t3.Status, "third should wait")
+
+	close(blocker)
+	time.Sleep(100 * time.Millisecond)
+
+	t3, _ = tm.Get(id3)
+	assert.Equal(t, TaskCompleted, t3.Status, "third should complete after slots free")
+}
+
+func TestManager_WorkerPoolUnlimited(t *testing.T) {
+	tm := NewManager(t.TempDir(), 0)
+
+	blocker := make(chan struct{})
+	var ids []string
+	for i := 0; i < 10; i++ {
+		id := tm.Create("test", func(ctx context.Context, update *Update) error {
+			<-blocker
+			return nil
+		})
+		ids = append(ids, id)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// All 10 should be running simultaneously
+	for _, id := range ids {
+		tsk, _ := tm.Get(id)
+		assert.Equal(t, TaskRunning, tsk.Status, "all should run with unlimited concurrency")
+	}
+
+	close(blocker)
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestManager_CancelPending(t *testing.T) {
+	tm := NewManager(t.TempDir(), 1)
+
+	blocker := make(chan struct{})
+	tm.Create("test", func(ctx context.Context, update *Update) error {
+		<-blocker
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	second := tm.Create("test", func(ctx context.Context, update *Update) error {
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	t2, _ := tm.Get(second)
+	assert.Equal(t, TaskPending, t2.Status)
+
+	require.NoError(t, tm.Cancel(second))
+	time.Sleep(50 * time.Millisecond)
+
+	t2, _ = tm.Get(second)
+	assert.Equal(t, TaskCancelled, t2.Status)
+	assert.NotNil(t, t2.CompletedAt, "cancelled pending should have CompletedAt")
+
+	close(blocker)
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
+	tm := NewManager(t.TempDir(), 1)
+
+	order := make([]string, 0, 3)
+	var mu sync.Mutex
+
+	record := func(name string) {
+		mu.Lock()
+		order = append(order, name)
+		mu.Unlock()
+	}
+
+	blocker := make(chan struct{})
+	tm.Create("test", func(ctx context.Context, update *Update) error {
+		record("first-start")
+		<-blocker
+		record("first-end")
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	tm.Create("test", func(ctx context.Context, update *Update) error {
+		record("second-start")
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	close(blocker)
+	time.Sleep(150 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, order, 3)
+	assert.Equal(t, "first-start", order[0])
+	assert.Equal(t, "first-end", order[1])
+	assert.Equal(t, "second-start", order[2])
+}
+
+func TestManager_WorkerPoolTaskError(t *testing.T) {
+	tm := NewManager(t.TempDir(), 1)
+
+	// First task fails, slot should still be freed
+	id1 := tm.Create("test", func(ctx context.Context, update *Update) error {
+		return fmt.Errorf("boom")
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	t1, _ := tm.Get(id1)
+	assert.Equal(t, TaskFailed, t1.Status)
+
+	// Second task should still run (slot freed after failure)
+	id2 := tm.Create("test", func(ctx context.Context, update *Update) error {
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	t2, _ := tm.Get(id2)
+	assert.Equal(t, TaskCompleted, t2.Status)
+}
+
+func TestManager_Stress(t *testing.T) {
+	tm := NewManager(t.TempDir(), 4)
+
+	const total = 1000
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < total; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tm.Create("test", func(ctx context.Context, update *Update) error {
+				cur := running.Add(1)
+				// Track peak concurrency
+				for {
+					old := maxRunning.Load()
+					if cur <= old || maxRunning.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				time.Sleep(time.Millisecond)
+				running.Add(-1)
+				return update.SetResult(map[string]string{"ok": "true"})
+			})
+		}()
+	}
+	wg.Wait()
+
+	// Wait for all tasks to finish
+	for i := 0; i < 300; i++ {
+		tasks := tm.List("")
+		done := 0
+		for _, tsk := range tasks {
+			if tsk.Status == TaskCompleted || tsk.Status == TaskFailed {
+				done++
+			}
+		}
+		if done == total {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	tasks := tm.List("")
+	assert.Len(t, tasks, total)
+
+	var completed, failed int
+	for _, tsk := range tasks {
+		switch tsk.Status {
+		case TaskCompleted:
+			completed++
+		case TaskFailed:
+			failed++
+		}
+		assert.NotNil(t, tsk.CompletedAt, "task %s should have CompletedAt", tsk.ID)
+		assert.NotNil(t, tsk.StartedAt, "task %s should have StartedAt", tsk.ID)
+	}
+
+	assert.Equal(t, total, completed, "all tasks should complete")
+	assert.Equal(t, 0, failed, "no tasks should fail")
+	assert.LessOrEqual(t, int(maxRunning.Load()), 4, "max concurrency should not exceed 4")
+	t.Logf("peak concurrency: %d/4, completed: %d/%d", maxRunning.Load(), completed, total)
 }

--- a/agent/storage/task/manager_test.go
+++ b/agent/storage/task/manager_test.go
@@ -15,6 +15,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// awaitStatus polls until a task reaches the expected status or times out.
+func awaitStatus(t *testing.T, tm *Manager, id string, status TaskStatus) *Task {
+	t.Helper()
+	for i := 0; i < 400; i++ {
+		tsk, err := tm.Get(id)
+		if err == nil && tsk.Status == status {
+			return tsk
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	tsk, _ := tm.Get(id)
+	require.Failf(t, "timeout", "task %s: wanted %s, got %s", id, status, tsk.Status)
+	return nil
+}
+
+// awaitDone polls until a task is completed, failed, or cancelled.
+func awaitDone(t *testing.T, tm *Manager, id string) *Task {
+	t.Helper()
+	for i := 0; i < 400; i++ {
+		tsk, err := tm.Get(id)
+		if err == nil && (tsk.Status == TaskCompleted || tsk.Status == TaskFailed || tsk.Status == TaskCancelled) {
+			return tsk
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	tsk, _ := tm.Get(id)
+	require.Failf(t, "timeout", "task %s not done, status: %s", id, tsk.Status)
+	return nil
+}
+
 func TestManager_SubmitAndGet(t *testing.T) {
 	tm := NewManager(t.TempDir(), 0)
 
@@ -28,22 +58,19 @@ func TestManager_SubmitAndGet(t *testing.T) {
 
 	<-started
 
-	task, err := tm.Get(id)
+	tsk, err := tm.Get(id)
 	require.NoError(t, err)
-	assert.Equal(t, TaskRunning, task.Status)
-	assert.Equal(t, "test", task.Type)
-	assert.NotNil(t, task.StartedAt)
-	assert.Nil(t, task.CompletedAt)
+	assert.Equal(t, TaskRunning, tsk.Status)
+	assert.Equal(t, "test", tsk.Type)
+	assert.NotNil(t, tsk.StartedAt)
+	assert.Nil(t, tsk.CompletedAt)
 
 	close(done)
-	time.Sleep(50 * time.Millisecond)
 
-	task, err = tm.Get(id)
-	require.NoError(t, err)
-	assert.Equal(t, TaskCompleted, task.Status)
-	assert.Equal(t, 100, task.Progress)
-	assert.NotNil(t, task.CompletedAt)
-	assert.Empty(t, task.Error)
+	tsk = awaitStatus(t, tm, id, TaskCompleted)
+	assert.Equal(t, 100, tsk.Progress)
+	assert.NotNil(t, tsk.CompletedAt)
+	assert.Empty(t, tsk.Error)
 }
 
 func TestManager_SubmitWithError(t *testing.T) {
@@ -53,13 +80,9 @@ func TestManager_SubmitWithError(t *testing.T) {
 		return fmt.Errorf("something broke")
 	})
 
-	time.Sleep(50 * time.Millisecond)
-
-	task, err := tm.Get(id)
-	require.NoError(t, err)
-	assert.Equal(t, TaskFailed, task.Status)
-	assert.Equal(t, "something broke", task.Error)
-	assert.NotNil(t, task.CompletedAt)
+	tsk := awaitStatus(t, tm, id, TaskFailed)
+	assert.Equal(t, "something broke", tsk.Error)
+	assert.NotNil(t, tsk.CompletedAt)
 }
 
 func TestManager_Cancel(t *testing.T) {
@@ -75,11 +98,8 @@ func TestManager_Cancel(t *testing.T) {
 	<-started
 	require.NoError(t, tm.Cancel(id))
 
-	time.Sleep(50 * time.Millisecond)
-
-	task, err := tm.Get(id)
-	require.NoError(t, err)
-	assert.Equal(t, TaskCancelled, task.Status)
+	tsk := awaitStatus(t, tm, id, TaskCancelled)
+	assert.NotNil(t, tsk.CompletedAt)
 }
 
 func TestManager_CancelFinished(t *testing.T) {
@@ -89,10 +109,8 @@ func TestManager_CancelFinished(t *testing.T) {
 		return nil
 	})
 
-	time.Sleep(50 * time.Millisecond)
-
-	err := tm.Cancel(id)
-	assert.NoError(t, err)
+	awaitStatus(t, tm, id, TaskCompleted)
+	assert.NoError(t, tm.Cancel(id))
 }
 
 func TestManager_CancelUnknown(t *testing.T) {
@@ -112,14 +130,15 @@ func TestManager_GetUnknown(t *testing.T) {
 func TestManager_List(t *testing.T) {
 	tm := NewManager(t.TempDir(), 0)
 
-	tm.Create("scrub", func(ctx context.Context, update *Update) error {
+	id1 := tm.Create("scrub", func(ctx context.Context, update *Update) error {
 		return nil
 	})
-	tm.Create("transfer", func(ctx context.Context, update *Update) error {
+	id2 := tm.Create("transfer", func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
-	time.Sleep(50 * time.Millisecond)
+	awaitDone(t, tm, id1)
+	awaitDone(t, tm, id2)
 
 	all := tm.List("")
 	assert.Len(t, all, 2)
@@ -139,11 +158,11 @@ func TestManager_List(t *testing.T) {
 func TestManager_ListReturnsCopies(t *testing.T) {
 	tm := NewManager(t.TempDir(), 0)
 
-	tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
-	time.Sleep(50 * time.Millisecond)
+	awaitDone(t, tm, id)
 
 	tasks := tm.List("")
 	require.Len(t, tasks, 1)
@@ -168,12 +187,12 @@ func TestManager_ProgressUpdate(t *testing.T) {
 
 	<-checkpoint
 
-	task, err := tm.Get(id)
+	tsk, err := tm.Get(id)
 	require.NoError(t, err)
-	assert.Equal(t, 50, task.Progress)
+	assert.Equal(t, 50, tsk.Progress)
 
 	require.NoError(t, tm.Cancel(id))
-	time.Sleep(50 * time.Millisecond)
+	awaitStatus(t, tm, id, TaskCancelled)
 }
 
 func TestManager_ResultStruct(t *testing.T) {
@@ -188,14 +207,11 @@ func TestManager_ResultStruct(t *testing.T) {
 		return update.SetResult(TestResult{Count: 42, Name: "hello"})
 	})
 
-	time.Sleep(50 * time.Millisecond)
-
-	task, err := tm.Get(id)
-	require.NoError(t, err)
-	require.NotNil(t, task.Result)
+	tsk := awaitStatus(t, tm, id, TaskCompleted)
+	require.NotNil(t, tsk.Result)
 
 	var result TestResult
-	require.NoError(t, json.Unmarshal(task.Result, &result))
+	require.NoError(t, json.Unmarshal(tsk.Result, &result))
 	assert.Equal(t, 42, result.Count)
 	assert.Equal(t, "hello", result.Name)
 }
@@ -207,14 +223,10 @@ func TestManager_Cleanup(t *testing.T) {
 		return nil
 	})
 
-	time.Sleep(50 * time.Millisecond)
-
-	_, err := tm.Get(id)
-	require.NoError(t, err)
-
+	awaitDone(t, tm, id)
 	tm.Cleanup(0)
 
-	_, err = tm.Get(id)
+	_, err := tm.Get(id)
 	assert.Error(t, err)
 }
 
@@ -227,16 +239,15 @@ func TestManager_CleanupKeepsRunning(t *testing.T) {
 		return nil
 	})
 
-	time.Sleep(50 * time.Millisecond)
-
+	awaitStatus(t, tm, id, TaskRunning)
 	tm.Cleanup(0)
 
-	task, err := tm.Get(id)
+	tsk, err := tm.Get(id)
 	require.NoError(t, err)
-	assert.Equal(t, TaskRunning, task.Status)
+	assert.Equal(t, TaskRunning, tsk.Status)
 
 	close(done)
-	time.Sleep(50 * time.Millisecond)
+	awaitDone(t, tm, id)
 }
 
 func TestManager_CorruptTaskFile(t *testing.T) {
@@ -268,54 +279,55 @@ func TestManager_EmptyTaskFile(t *testing.T) {
 func TestManager_ConcurrentSubmit(t *testing.T) {
 	tm := NewManager(t.TempDir(), 0)
 
+	ids := make([]string, 50)
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
-		go func() {
+		go func(idx int) {
 			defer wg.Done()
-			tm.Create("test", func(ctx context.Context, update *Update) error {
+			ids[idx] = tm.Create("test", func(ctx context.Context, update *Update) error {
 				return nil
 			})
-		}()
+		}(i)
 	}
 	wg.Wait()
 
-	time.Sleep(100 * time.Millisecond)
+	for _, id := range ids {
+		awaitDone(t, tm, id)
+	}
 
 	tasks := tm.List("")
 	assert.Len(t, tasks, 50)
-	for _, task := range tasks {
-		assert.Equal(t, TaskCompleted, task.Status)
+	for _, tsk := range tasks {
+		assert.Equal(t, TaskCompleted, tsk.Status)
 	}
 }
 
 func TestManager_WorkerPoolBlocksSecondTask(t *testing.T) {
 	tm := NewManager(t.TempDir(), 1)
 
+	started := make(chan struct{})
 	blocker := make(chan struct{})
 	first := tm.Create("test", func(ctx context.Context, update *Update) error {
+		close(started)
 		<-blocker
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
+	<-started
 
 	second := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
 
-	t1, _ := tm.Get(first)
-	t2, _ := tm.Get(second)
-	assert.Equal(t, TaskRunning, t1.Status)
-	assert.Equal(t, TaskPending, t2.Status)
+	// First running, second must be pending (pool full)
+	awaitStatus(t, tm, first, TaskRunning)
+	tsk, _ := tm.Get(second)
+	assert.Equal(t, TaskPending, tsk.Status)
 
 	close(blocker)
-	time.Sleep(100 * time.Millisecond)
 
-	t1, _ = tm.Get(first)
-	t2, _ = tm.Get(second)
-	assert.Equal(t, TaskCompleted, t1.Status)
-	assert.Equal(t, TaskCompleted, t2.Status)
+	awaitStatus(t, tm, first, TaskCompleted)
+	awaitStatus(t, tm, second, TaskCompleted)
 }
 
 func TestManager_WorkerPoolMaxTwo(t *testing.T) {
@@ -336,80 +348,81 @@ func TestManager_WorkerPoolMaxTwo(t *testing.T) {
 		return nil
 	})
 
-	// Wait until both are confirmed running
 	<-started1
 	<-started2
 
 	id3 := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
 
-	t1, _ := tm.Get(id1)
-	t2, _ := tm.Get(id2)
-	t3, _ := tm.Get(id3)
-	assert.Equal(t, TaskRunning, t1.Status, "first should run")
-	assert.Equal(t, TaskRunning, t2.Status, "second should run")
-	assert.Equal(t, TaskPending, t3.Status, "third should wait")
+	// Both slots taken, third must be pending
+	tsk, _ := tm.Get(id3)
+	assert.Equal(t, TaskPending, tsk.Status, "third should wait")
 
 	close(blocker)
-	time.Sleep(100 * time.Millisecond)
 
-	t3, _ = tm.Get(id3)
-	assert.Equal(t, TaskCompleted, t3.Status, "third should complete after slots free")
+	awaitStatus(t, tm, id1, TaskCompleted)
+	awaitStatus(t, tm, id2, TaskCompleted)
+	awaitStatus(t, tm, id3, TaskCompleted)
 }
 
 func TestManager_WorkerPoolUnlimited(t *testing.T) {
 	tm := NewManager(t.TempDir(), 0)
 
+	started := make(chan struct{}, 10)
 	blocker := make(chan struct{})
 	var ids []string
 	for i := 0; i < 10; i++ {
 		id := tm.Create("test", func(ctx context.Context, update *Update) error {
+			started <- struct{}{}
 			<-blocker
 			return nil
 		})
 		ids = append(ids, id)
 	}
-	time.Sleep(50 * time.Millisecond)
 
-	// All 10 should be running simultaneously
+	// Wait for all 10 to confirm running
+	for i := 0; i < 10; i++ {
+		<-started
+	}
+
 	for _, id := range ids {
 		tsk, _ := tm.Get(id)
 		assert.Equal(t, TaskRunning, tsk.Status, "all should run with unlimited concurrency")
 	}
 
 	close(blocker)
-	time.Sleep(100 * time.Millisecond)
+	for _, id := range ids {
+		awaitDone(t, tm, id)
+	}
 }
 
 func TestManager_CancelPending(t *testing.T) {
 	tm := NewManager(t.TempDir(), 1)
 
+	started := make(chan struct{})
 	blocker := make(chan struct{})
 	tm.Create("test", func(ctx context.Context, update *Update) error {
+		close(started)
 		<-blocker
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
+	<-started
 
 	second := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
 
-	t2, _ := tm.Get(second)
-	assert.Equal(t, TaskPending, t2.Status)
+	// Confirm pending
+	tsk, _ := tm.Get(second)
+	assert.Equal(t, TaskPending, tsk.Status)
 
 	require.NoError(t, tm.Cancel(second))
-	time.Sleep(50 * time.Millisecond)
 
-	t2, _ = tm.Get(second)
-	assert.Equal(t, TaskCancelled, t2.Status)
-	assert.NotNil(t, t2.CompletedAt, "cancelled pending should have CompletedAt")
+	tsk = awaitStatus(t, tm, second, TaskCancelled)
+	assert.NotNil(t, tsk.CompletedAt, "cancelled pending should have CompletedAt")
 
 	close(blocker)
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
@@ -424,23 +437,24 @@ func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
 		mu.Unlock()
 	}
 
+	started := make(chan struct{})
 	blocker := make(chan struct{})
 	tm.Create("test", func(ctx context.Context, update *Update) error {
 		record("first-start")
+		close(started)
 		<-blocker
 		record("first-end")
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
+	<-started
 
-	tm.Create("test", func(ctx context.Context, update *Update) error {
+	second := tm.Create("test", func(ctx context.Context, update *Update) error {
 		record("second-start")
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
 
 	close(blocker)
-	time.Sleep(150 * time.Millisecond)
+	awaitDone(t, tm, second)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -453,23 +467,17 @@ func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
 func TestManager_WorkerPoolTaskError(t *testing.T) {
 	tm := NewManager(t.TempDir(), 1)
 
-	// First task fails, slot should still be freed
 	id1 := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return fmt.Errorf("boom")
 	})
-	time.Sleep(50 * time.Millisecond)
 
-	t1, _ := tm.Get(id1)
-	assert.Equal(t, TaskFailed, t1.Status)
+	awaitStatus(t, tm, id1, TaskFailed)
 
-	// Second task should still run (slot freed after failure)
 	id2 := tm.Create("test", func(ctx context.Context, update *Update) error {
 		return nil
 	})
-	time.Sleep(50 * time.Millisecond)
 
-	t2, _ := tm.Get(id2)
-	assert.Equal(t, TaskCompleted, t2.Status)
+	awaitStatus(t, tm, id2, TaskCompleted)
 }
 
 func TestManager_Stress(t *testing.T) {
@@ -479,14 +487,14 @@ func TestManager_Stress(t *testing.T) {
 	var running atomic.Int32
 	var maxRunning atomic.Int32
 
+	ids := make([]string, total)
 	var wg sync.WaitGroup
 	for i := 0; i < total; i++ {
 		wg.Add(1)
-		go func() {
+		go func(idx int) {
 			defer wg.Done()
-			tm.Create("test", func(ctx context.Context, update *Update) error {
+			ids[idx] = tm.Create("test", func(ctx context.Context, update *Update) error {
 				cur := running.Add(1)
-				// Track peak concurrency
 				for {
 					old := maxRunning.Load()
 					if cur <= old || maxRunning.CompareAndSwap(old, cur) {
@@ -497,23 +505,12 @@ func TestManager_Stress(t *testing.T) {
 				running.Add(-1)
 				return update.SetResult(map[string]string{"ok": "true"})
 			})
-		}()
+		}(i)
 	}
 	wg.Wait()
 
-	// Wait for all tasks to finish
-	for i := 0; i < 300; i++ {
-		tasks := tm.List("")
-		done := 0
-		for _, tsk := range tasks {
-			if tsk.Status == TaskCompleted || tsk.Status == TaskFailed {
-				done++
-			}
-		}
-		if done == total {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
+	for _, id := range ids {
+		awaitDone(t, tm, id)
 	}
 
 	tasks := tm.List("")

--- a/agent/storage/task/metrics.go
+++ b/agent/storage/task/metrics.go
@@ -15,8 +15,26 @@ var (
 		Name:      "task_duration_seconds",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 15),
 	}, []string{"type"})
+
+	tasksRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "btrfs_nfs_csi",
+		Subsystem: "agent",
+		Name:      "tasks_running",
+	}, []string{"type"})
+
+	tasksQueued = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "btrfs_nfs_csi",
+		Subsystem: "agent",
+		Name:      "tasks_queued",
+	}, []string{"type"})
+
+	tasksWorkers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "btrfs_nfs_csi",
+		Subsystem: "agent",
+		Name:      "tasks_workers",
+	})
 )
 
 func init() {
-	prometheus.MustRegister(tasksTotal, taskDuration)
+	prometheus.MustRegister(tasksTotal, taskDuration, tasksRunning, tasksQueued, tasksWorkers)
 }

--- a/agent/storage/task/model.go
+++ b/agent/storage/task/model.go
@@ -24,6 +24,7 @@ type TaskType string
 
 const (
 	TypeScrub TaskType = "scrub"
+	TypeTest  TaskType = "test"
 )
 
 // ErrNotFound is returned when a task ID doesn't exist.

--- a/agent/storage/testtask.go
+++ b/agent/storage/testtask.go
@@ -10,16 +10,25 @@ import (
 
 // TestTaskOpts configures the test task behavior.
 type TestTaskOpts struct {
-	Sleep time.Duration `json:"sleep,omitempty"`
+	Sleep string `json:"sleep,omitempty"`
 }
 
 // StartTestTask creates a test task that sleeps for the given duration and returns "Hallo Welt".
 func (s *Storage) StartTestTask(ctx context.Context, opts TestTaskOpts) (string, error) {
+	var sleep time.Duration
+	if opts.Sleep != "" {
+		var err error
+		sleep, err = time.ParseDuration(opts.Sleep)
+		if err != nil {
+			return "", &StorageError{Code: ErrInvalid, Message: "invalid sleep duration: " + opts.Sleep}
+		}
+	}
+
 	id := s.tasks.Create(string(task.TypeTest), func(ctx context.Context, update *task.Update) error {
-		if opts.Sleep > 0 {
-			log.Debug().Dur("sleep", opts.Sleep).Msg("test task sleeping")
+		if sleep > 0 {
+			log.Debug().Dur("sleep", sleep).Msg("test task sleeping")
 			select {
-			case <-time.After(opts.Sleep):
+			case <-time.After(sleep):
 			case <-ctx.Done():
 				return ctx.Err()
 			}
@@ -27,6 +36,6 @@ func (s *Storage) StartTestTask(ctx context.Context, opts TestTaskOpts) (string,
 		return update.SetResult(map[string]string{"message": "Hallo Welt"})
 	})
 
-	log.Info().Str("task", id).Dur("sleep", opts.Sleep).Msg("test task started")
+	log.Info().Str("task", id).Str("sleep", opts.Sleep).Msg("test task started")
 	return id, nil
 }

--- a/agent/storage/testtask.go
+++ b/agent/storage/testtask.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/task"
+	"github.com/rs/zerolog/log"
+)
+
+// TestTaskOpts configures the test task behavior.
+type TestTaskOpts struct {
+	Sleep time.Duration `json:"sleep,omitempty"`
+}
+
+// StartTestTask creates a test task that sleeps for the given duration and returns "Hallo Welt".
+func (s *Storage) StartTestTask(ctx context.Context, opts TestTaskOpts) (string, error) {
+	id := s.tasks.Create(string(task.TypeTest), func(ctx context.Context, update *task.Update) error {
+		if opts.Sleep > 0 {
+			log.Debug().Dur("sleep", opts.Sleep).Msg("test task sleeping")
+			select {
+			case <-time.After(opts.Sleep):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return update.SetResult(map[string]string{"message": "Hallo Welt"})
+	})
+
+	log.Info().Str("task", id).Dur("sleep", opts.Sleep).Msg("test task started")
+	return id, nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ type AgentConfig struct {
 	DefaultDirMode       string        `env:"AGENT_DEFAULT_DIR_MODE" envDefault:"0700"`
 	DefaultDataMode      string        `env:"AGENT_DEFAULT_DATA_MODE" envDefault:"2770"`
 	TaskCleanupInterval  time.Duration `env:"AGENT_TASK_CLEANUP_INTERVAL" envDefault:"24h"`
+	TaskMaxConcurrent    int           `env:"AGENT_TASK_MAX_CONCURRENT" envDefault:"2"`
 }
 
 type ControllerConfig struct {

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -153,6 +153,32 @@ func taskCmd() *cli.Command {
 							return waitForTask(ctx, c, resp.TaskID)
 						},
 					},
+					{
+						Name:  v1.TaskTypeTest,
+						Usage: "start a test task",
+						Flags: []cli.Flag{
+							&cli.DurationFlag{Name: "sleep", Aliases: []string{"s"}, Usage: "sleep duration (e.g. 10s, 1m)"},
+							&cli.BoolFlag{Name: "wait", Aliases: []string{"w"}, Usage: "wait for completion"},
+						},
+						Action: func(ctx context.Context, cmd *cli.Command) error {
+							c := clientFrom(cmd)
+							var opts any
+							if s := cmd.Duration("sleep"); s > 0 {
+								opts = map[string]string{"sleep": s.String()}
+							}
+							resp, err := c.CreateTask(ctx, v1.TaskTypeTest, opts)
+							if err != nil {
+								return err
+							}
+							if !cmd.Bool("wait") {
+								return output(cmd, resp, func() {
+									fmt.Printf("test task started (task %s)\n", resp.TaskID)
+								})
+							}
+							fmt.Printf("test task started (task %s)\n", resp.TaskID)
+							return waitForTask(ctx, c, resp.TaskID)
+						},
+					},
 				},
 			},
 		},

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -363,9 +363,26 @@ curl -X POST http://10.0.0.5:8080/v1/tasks/scrub \
   -H "Authorization: Bearer changeme"
 ```
 
+### POST /v1/tasks/test
+
+Starts a test task for debugging. Optional `sleep` parameter. Result is always `{"message": "Hallo Welt"}`.
+
+```json
+// Request (optional)
+{
+  "sleep": "10s"
+}
+
+// Response 202
+{
+  "task_id": "abc123",
+  "status": "pending"
+}
+```
+
 ### GET /v1/tasks
 
-List all tasks. Optional `?type=scrub` filter. Returns a summary without the `result` field. Append `?detail=true` to include `result`.
+List all tasks. Optional `?type=` filter (e.g. `scrub`, `test`). Returns a summary without the `result` field. Append `?detail=true` to include `result`.
 
 ```json
 {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,8 @@ DeleteVolume   → DELETE /v1/volumes/:name (subvolume delete)
 
 Long-running operations (scrub, future: cross-agent transfers) run as background tasks with progress tracking.
 
+- Worker pool limits concurrent tasks (`AGENT_TASK_MAX_CONCURRENT`, default 2, 0 = unlimited)
+- Tasks that exceed the limit queue as `pending` until a slot frees up
 - Tasks are persisted as JSON files under `{AGENT_BASE_PATH}/tasks/`
 - Progress is tracked in-memory via atomic pointers (no disk IO per update)
 - Status transitions (pending, running, completed, failed, cancelled) are persisted to disk

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@
 | `AGENT_DEFAULT_DIR_MODE` | `0700` | Default mode for volume/snapshot/clone directories |
 | `AGENT_DEFAULT_DATA_MODE` | `2770` | Default mode for data subvolumes (setgid + group rwx) |
 | `AGENT_TASK_CLEANUP_INTERVAL` | `24h` | Remove completed/failed tasks after this duration |
+| `AGENT_TASK_MAX_CONCURRENT` | `2` | Max concurrent tasks (`0` = unlimited) |
 | `LOG_LEVEL` | `info` | `trace`, `debug`, `info`, `warn`, `error` |
 
 ## CLI Environment Variables

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,8 +1,8 @@
 # Metrics
 
-40 metrics across 3 components.
+43 metrics across 3 components.
 
-## Agent (31) - port 9090
+## Agent (34) - port 9090
 
 | Metric | Type | Labels |
 |---|---|---|
@@ -37,6 +37,9 @@
 | `btrfs_nfs_csi_agent_filesystem_data_ratio` | Gauge | `path` |
 | `btrfs_nfs_csi_agent_tasks_total` | Counter | `type`, `status` |
 | `btrfs_nfs_csi_agent_task_duration_seconds` | Histogram | `type` |
+| `btrfs_nfs_csi_agent_tasks_running` | Gauge | `type` |
+| `btrfs_nfs_csi_agent_tasks_queued` | Gauge | `type` |
+| `btrfs_nfs_csi_agent_tasks_workers` | Gauge | - |
 
 **Buckets (http_request_duration):** `[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5]`
 
@@ -113,4 +116,10 @@ rate(btrfs_nfs_csi_controller_agent_ops_total{operation="health_check",status="e
 
 # P99 mount latency
 histogram_quantile(0.99, rate(btrfs_nfs_csi_node_mount_duration_seconds_bucket{operation="nfs_mount"}[5m]))
+
+# Task queue depth (tasks waiting for a worker slot)
+sum(btrfs_nfs_csi_agent_tasks_queued)
+
+# Worker pool utilization
+sum(btrfs_nfs_csi_agent_tasks_running) / btrfs_nfs_csi_agent_tasks_workers
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -207,6 +207,8 @@ btrfs-nfs-csi task get <id>
 btrfs-nfs-csi task cancel <id>
 btrfs-nfs-csi task create scrub
 btrfs-nfs-csi task create scrub --wait
+btrfs-nfs-csi task create test
+btrfs-nfs-csi task create test --sleep 10s --wait
 btrfs-nfs-csi stats
 btrfs-nfs-csi stats -o wide                 # per-device IO and error details
 btrfs-nfs-csi health


### PR DESCRIPTION
Tasks now run through a worker pool instead of spawning unlimited goroutines. A buffered channel acts as a semaphore, tasks that exceed the limit queue as `pending` until a slot frees up. Cancelling a pending task removes it from the queue without running it.

## Summary
- Worker pool with `AGENT_TASK_MAX_CONCURRENT` (default 2, 0 = unlimited)
- Pending tasks queue and start in order when slots free up
- Cancel on pending tasks works immediately (no need to wait for slot)
- Failed/cancelled tasks correctly release their slot
- Test task type (`POST /v1/tasks/test`) with optional `sleep` parameter, returns `{"message": "Hallo Welt"}`
- CLI: `task create test --sleep 10s --wait`
- New metrics: `tasks_running{type}`, `tasks_queued{type}`, `tasks_workers`
