### PR TITLE
Task system: opts, timeouts, configurable polling, unified API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ If you run a homelab, a small on-prem cluster, or an edge deployment and want re
 - Dynamic device discovery with live stats, hot-added devices are picked up automatically
 - Prometheus `/metrics` on all components
 - Web dashboard (`/v1/dashboard`)
-- Background task system with progress tracking and persistence
-- Filesystem scrub via API (`POST /v1/tasks/scrub`)
+- Background task system with progress tracking, persistence, and configurable timeouts
+- Filesystem scrub via API
 - NFS mount health checker with auto-heal (detects stale mounts, remounts automatically, heals all pods without restart)
 - TLS support
 - HA via DRBD + Pacemaker (active/passive failover)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,7 +64,7 @@ func (a *Agent) Start(ctx context.Context) {
 	store := storage.New(
 		a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames,
 		a.cfg.DefaultDirMode, a.cfg.DefaultDataMode, a.cfg.BtrfsBin,
-		a.cfg.TaskMaxConcurrent,
+		a.cfg.TaskMaxConcurrent, a.cfg.TaskDefaultTimeout, a.cfg.TaskScrubTimeout, a.cfg.TaskPollInterval,
 	)
 	h := &v1.Handler{Store: store}
 
@@ -96,8 +96,7 @@ func (a *Agent) Start(ctx context.Context) {
 	api.POST("/volumes/clone", h.CloneVolume)
 
 	api.GET("/tasks", h.ListTasks)
-	api.POST("/tasks/scrub", h.StartScrub)
-	api.POST("/tasks/test", h.StartTestTask)
+	api.POST("/tasks/:type", h.CreateTask)
 	api.GET("/tasks/:id", h.GetTask)
 	api.DELETE("/tasks/:id", h.CancelTask)
 

--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -163,9 +163,9 @@ func (c *Client) ListExports(ctx context.Context) (*ExportListResponse, error) {
 	return &resp, nil
 }
 
-func (c *Client) CreateTask(ctx context.Context, taskType string, opts any) (*TaskStartResponse, error) {
-	var resp TaskStartResponse
-	if err := c.do(ctx, http.MethodPost, "/v1/tasks/"+taskType, opts, &resp); err != nil {
+func (c *Client) CreateTask(ctx context.Context, taskType string, req TaskCreateRequest) (*TaskCreateResponse, error) {
+	var resp TaskCreateResponse
+	if err := c.do(ctx, http.MethodPost, "/v1/tasks/"+taskType, req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -2,9 +2,9 @@ package v1
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
-	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/task"
 
 	"github.com/labstack/echo/v5"
 )
@@ -400,37 +400,42 @@ func (h *Handler) CreateClone(c *echo.Context) error {
 	})
 }
 
-// --- Scrub ---
-
-func (h *Handler) StartScrub(c *echo.Context) error {
-	taskID, err := h.Store.StartScrub(c.Request().Context())
-	if err != nil {
-		return StorageError(c, err)
-	}
-	return c.JSON(http.StatusAccepted, map[string]any{
-		"task_id": taskID,
-		"status":  string(task.TaskPending),
-	})
-}
-
-// --- Test Task ---
-
-func (h *Handler) StartTestTask(c *echo.Context) error {
-	var opts storage.TestTaskOpts
-	if err := c.Bind(&opts); err != nil {
-		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body: " + err.Error(), Code: storage.ErrInvalid})
-	}
-	taskID, err := h.Store.StartTestTask(c.Request().Context(), opts)
-	if err != nil {
-		return StorageError(c, err)
-	}
-	return c.JSON(http.StatusAccepted, map[string]any{
-		"task_id": taskID,
-		"status":  string(task.TaskPending),
-	})
-}
-
 // --- Tasks ---
+
+func (h *Handler) CreateTask(c *echo.Context) error {
+	taskType := c.Param("type")
+
+	var req TaskCreateRequest
+	if c.Request().ContentLength > 0 || c.Request().ContentLength == -1 {
+		if err := c.Bind(&req); err != nil {
+			return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body: " + err.Error(), Code: storage.ErrInvalid})
+		}
+	}
+
+	var timeout time.Duration
+	if req.Timeout != "" {
+		var err error
+		timeout, err = time.ParseDuration(req.Timeout)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid timeout: " + req.Timeout, Code: storage.ErrInvalid})
+		}
+	}
+
+	var taskID string
+	var err error
+	switch taskType {
+	case TaskTypeScrub:
+		taskID, err = h.Store.StartScrub(c.Request().Context(), req.Opts, timeout)
+	case TaskTypeTest:
+		taskID, err = h.Store.StartTestTask(c.Request().Context(), req.Opts, timeout)
+	default:
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "unknown task type: " + taskType, Code: storage.ErrInvalid})
+	}
+	if err != nil {
+		return StorageError(c, err)
+	}
+	return c.JSON(http.StatusAccepted, TaskCreateResponse{TaskID: taskID, Status: TaskStatusPending})
+}
 
 func (h *Handler) ListTasks(c *echo.Context) error {
 	tasks := h.Store.Tasks().List(c.QueryParam("type"))

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -180,33 +180,41 @@ type FilesystemStatsResponse struct {
 	Devices            []DeviceStatsResponse `json:"devices"`
 }
 
-type TaskStartResponse struct {
+type TaskCreateRequest struct {
+	Timeout string            `json:"timeout,omitempty"`
+	Opts    map[string]string `json:"opts,omitempty"`
+}
+
+type TaskCreateResponse struct {
 	TaskID string `json:"task_id"`
 	Status string `json:"status"`
 }
 
 type TaskResponse struct {
-	ID          string     `json:"id"`
-	Type        string     `json:"type"`
-	Status      string     `json:"status"`
-	Progress    int        `json:"progress"`
-	Error       string     `json:"error,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
-	StartedAt   *time.Time `json:"started_at,omitempty"`
-	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	ID          string            `json:"id"`
+	Type        string            `json:"type"`
+	Status      string            `json:"status"`
+	Progress    int               `json:"progress"`
+	Opts        map[string]string `json:"opts,omitempty"`
+	Timeout     string            `json:"timeout,omitempty"`
+	Error       string            `json:"error,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	StartedAt   *time.Time        `json:"started_at,omitempty"`
+	CompletedAt *time.Time        `json:"completed_at,omitempty"`
 }
 
 type TaskDetailResponse struct {
-	ID          string          `json:"id"`
-	Type        string          `json:"type"`
-	Status      string          `json:"status"`
-	Progress    int             `json:"progress"`
-	Result      json.RawMessage `json:"result,omitempty"`
-	Info        string          `json:"info,omitempty"`
-	Error       string          `json:"error,omitempty"`
-	CreatedAt   time.Time       `json:"created_at"`
-	StartedAt   *time.Time      `json:"started_at,omitempty"`
-	CompletedAt *time.Time      `json:"completed_at,omitempty"`
+	ID          string            `json:"id"`
+	Type        string            `json:"type"`
+	Status      string            `json:"status"`
+	Progress    int               `json:"progress"`
+	Opts        map[string]string `json:"opts,omitempty"`
+	Timeout     string            `json:"timeout,omitempty"`
+	Result      json.RawMessage   `json:"result,omitempty"`
+	Error       string            `json:"error,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	StartedAt   *time.Time        `json:"started_at,omitempty"`
+	CompletedAt *time.Time        `json:"completed_at,omitempty"`
 }
 
 type TaskListResponse struct {

--- a/agent/api/v1/task.go
+++ b/agent/api/v1/task.go
@@ -1,15 +1,17 @@
 package v1
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/btrfs"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/task"
-	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 )
+
+func formatTimeout(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return d.String()
+}
 
 func taskResponseFrom(t *task.Task) TaskResponse {
 	return TaskResponse{
@@ -17,6 +19,8 @@ func taskResponseFrom(t *task.Task) TaskResponse {
 		Type:        t.Type,
 		Status:      string(t.Status),
 		Progress:    t.Progress,
+		Opts:        t.Opts,
+		Timeout:     formatTimeout(t.Timeout),
 		Error:       t.Error,
 		CreatedAt:   t.CreatedAt,
 		StartedAt:   t.StartedAt,
@@ -30,61 +34,12 @@ func taskDetailResponseFrom(t *task.Task) TaskDetailResponse {
 		Type:        t.Type,
 		Status:      string(t.Status),
 		Progress:    t.Progress,
+		Opts:        t.Opts,
+		Timeout:     formatTimeout(t.Timeout),
 		Result:      t.Result,
-		Info:        taskInfo(t),
 		Error:       t.Error,
 		CreatedAt:   t.CreatedAt,
 		StartedAt:   t.StartedAt,
 		CompletedAt: t.CompletedAt,
-	}
-}
-
-func taskInfo(t *task.Task) string {
-	if len(t.Result) == 0 {
-		return ""
-	}
-	switch t.Type {
-	case string(task.TypeScrub):
-		var s btrfs.ScrubStatus
-		if json.Unmarshal(t.Result, &s) != nil {
-			return ""
-		}
-		errs := s.ReadErrors + s.CSumErrors + s.VerifyErrors + s.UncorrectableErrs
-		switch t.Status {
-		case task.TaskRunning:
-			parts := make([]string, 0, 2)
-			if t.StartedAt != nil {
-				elapsed := float64(int(time.Since(*t.StartedAt).Seconds()))
-				if elapsed > 0 && s.DataBytesScrubbed > 0 {
-					speed := float64(s.DataBytesScrubbed) / elapsed
-					parts = append(parts, utils.FormatBytes(uint64(speed))+"/s")
-				}
-			}
-			if errs > 0 {
-				parts = append(parts, fmt.Sprintf("%d errors", errs))
-			}
-			if len(parts) == 0 {
-				return ""
-			}
-			return strings.Join(parts, ", ")
-		case task.TaskCompleted:
-			speed := ""
-			if s.DataBytesScrubbed > 0 && t.StartedAt != nil && t.CompletedAt != nil {
-				elapsed := t.CompletedAt.Sub(*t.StartedAt).Seconds()
-				if elapsed > 0 {
-					speed = ", " + utils.FormatBytes(uint64(float64(s.DataBytesScrubbed)/elapsed)) + "/s"
-				}
-			}
-			return fmt.Sprintf("%s scrubbed, %d errors%s", utils.FormatBytes(s.DataBytesScrubbed), errs, speed)
-		case task.TaskFailed:
-			if errs > 0 {
-				return fmt.Sprintf("%d errors", errs)
-			}
-			return t.Error
-		default:
-			return ""
-		}
-	default:
-		return ""
 	}
 }

--- a/agent/api/v1/task_test.go
+++ b/agent/api/v1/task_test.go
@@ -21,116 +21,27 @@ func scrubResult(data, tree, readErr, csumErr uint64) json.RawMessage {
 	return raw
 }
 
-func TestTaskInfo_Completed(t *testing.T) {
-	start := time.Now().Add(-10 * time.Second)
-	end := time.Now()
-
-	tk := &task.Task{
-		Type:        string(task.TypeScrub),
-		Status:      task.TaskCompleted,
-		Result:      scrubResult(10737418240, 1048576, 0, 0),
-		StartedAt:   &start,
-		CompletedAt: &end,
-	}
-
-	info := taskInfo(tk)
-	assert.Contains(t, info, "10.0Gi scrubbed")
-	assert.Contains(t, info, "0 errors")
-	assert.Contains(t, info, "/s")
-}
-
-func TestTaskInfo_CompletedWithErrors(t *testing.T) {
-	start := time.Now().Add(-5 * time.Second)
-	end := time.Now()
-
-	tk := &task.Task{
-		Type:        string(task.TypeScrub),
-		Status:      task.TaskCompleted,
-		Result:      scrubResult(1073741824, 0, 2, 1),
-		StartedAt:   &start,
-		CompletedAt: &end,
-	}
-
-	info := taskInfo(tk)
-	assert.Contains(t, info, "1.0Gi scrubbed")
-	assert.Contains(t, info, "3 errors")
-}
-
-func TestTaskInfo_Failed(t *testing.T) {
-	tk := &task.Task{
-		Type:   string(task.TypeScrub),
-		Status: task.TaskFailed,
-		Result: scrubResult(0, 0, 5, 0),
-		Error:  "scrub failed",
-	}
-
-	info := taskInfo(tk)
-	assert.Equal(t, "5 errors", info)
-}
-
-func TestTaskInfo_FailedNoErrors(t *testing.T) {
-	tk := &task.Task{
-		Type:   string(task.TypeScrub),
-		Status: task.TaskFailed,
-		Result: scrubResult(0, 0, 0, 0),
-		Error:  "scrub failed",
-	}
-
-	info := taskInfo(tk)
-	assert.Equal(t, "scrub failed", info)
-}
-
-func TestTaskInfo_EmptyResult(t *testing.T) {
-	tk := &task.Task{
-		Type:   string(task.TypeScrub),
-		Status: task.TaskCompleted,
-	}
-
-	info := taskInfo(tk)
-	assert.Equal(t, "", info)
-}
-
-func TestTaskInfo_UnknownType(t *testing.T) {
-	tk := &task.Task{
-		Type:   "unknown",
-		Status: task.TaskCompleted,
-		Result: json.RawMessage(`{"foo": "bar"}`),
-	}
-
-	info := taskInfo(tk)
-	assert.Equal(t, "", info)
-}
-
-func TestTaskInfo_Running(t *testing.T) {
-	start := time.Now().Add(-10 * time.Second)
-
-	tk := &task.Task{
-		Type:      string(task.TypeScrub),
-		Status:    task.TaskRunning,
-		Result:    scrubResult(5368709120, 0, 0, 0),
-		StartedAt: &start,
-	}
-
-	info := taskInfo(tk)
-	assert.Contains(t, info, "/s")
-}
-
-func TestTaskInfo_RunningWithErrors(t *testing.T) {
-	start := time.Now().Add(-10 * time.Second)
-
-	tk := &task.Task{
-		Type:      string(task.TypeScrub),
-		Status:    task.TaskRunning,
-		Result:    scrubResult(5368709120, 0, 1, 2),
-		StartedAt: &start,
-	}
-
-	info := taskInfo(tk)
-	assert.Contains(t, info, "/s")
-	assert.Contains(t, info, "3 errors")
-}
-
 func TestTaskResponseFrom(t *testing.T) {
+	now := time.Now()
+	tk := &task.Task{
+		ID:        "abc123",
+		Type:      "scrub",
+		Status:    task.TaskCompleted,
+		Progress:  100,
+		Opts:      map[string]string{"sleep": "5s"},
+		Timeout:   24 * time.Hour,
+		CreatedAt: now,
+	}
+
+	resp := taskResponseFrom(tk)
+	assert.Equal(t, "abc123", resp.ID)
+	assert.Equal(t, "completed", resp.Status)
+	assert.Equal(t, 100, resp.Progress)
+	assert.Equal(t, map[string]string{"sleep": "5s"}, resp.Opts)
+	assert.Equal(t, "24h0m0s", resp.Timeout)
+}
+
+func TestTaskResponseFrom_NoOptsNoTimeout(t *testing.T) {
 	now := time.Now()
 	tk := &task.Task{
 		ID:        "abc123",
@@ -141,9 +52,8 @@ func TestTaskResponseFrom(t *testing.T) {
 	}
 
 	resp := taskResponseFrom(tk)
-	assert.Equal(t, "abc123", resp.ID)
-	assert.Equal(t, "completed", resp.Status)
-	assert.Equal(t, 100, resp.Progress)
+	assert.Nil(t, resp.Opts)
+	assert.Empty(t, resp.Timeout)
 }
 
 func TestTaskDetailResponseFrom(t *testing.T) {
@@ -154,6 +64,8 @@ func TestTaskDetailResponseFrom(t *testing.T) {
 		Type:        string(task.TypeScrub),
 		Status:      task.TaskCompleted,
 		Progress:    100,
+		Opts:        map[string]string{"key": "val"},
+		Timeout:     6 * time.Hour,
 		Result:      scrubResult(1073741824, 0, 0, 0),
 		CreatedAt:   now,
 		StartedAt:   &start,
@@ -163,6 +75,7 @@ func TestTaskDetailResponseFrom(t *testing.T) {
 	resp := taskDetailResponseFrom(tk)
 	assert.Equal(t, "abc123", resp.ID)
 	assert.Equal(t, "completed", resp.Status)
-	assert.NotEmpty(t, resp.Info)
 	assert.NotNil(t, resp.Result)
+	assert.Equal(t, map[string]string{"key": "val"}, resp.Opts)
+	assert.Equal(t, "6h0m0s", resp.Timeout)
 }

--- a/agent/storage/scrub.go
+++ b/agent/storage/scrub.go
@@ -9,12 +9,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const (
-	scrubPollInterval = 2 * time.Second
-)
-
 // StartScrub starts a btrfs scrub as a background task and returns the task ID.
-func (s *Storage) StartScrub(ctx context.Context) (string, error) {
+func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, timeout time.Duration) (string, error) {
 	for _, t := range s.tasks.List(string(task.TypeScrub)) {
 		if t.Status == task.TaskRunning || t.Status == task.TaskPending {
 			return "", &StorageError{Code: ErrBusy, Message: "scrub already running"}
@@ -25,7 +21,11 @@ func (s *Storage) StartScrub(ctx context.Context) (string, error) {
 		return "", &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
 	}
 
-	id := s.tasks.Create(string(task.TypeScrub), func(ctx context.Context, update *task.Update) error {
+	t := s.taskScrubTimeout
+	if timeout > 0 {
+		t = timeout
+	}
+	id := s.tasks.Create(string(task.TypeScrub), task.TaskOpts{Opts: opts, Timeout: t}, func(ctx context.Context, update *task.Update) error {
 		return s.runScrub(ctx, update)
 	})
 
@@ -34,36 +34,25 @@ func (s *Storage) StartScrub(ctx context.Context) (string, error) {
 }
 
 func (s *Storage) runScrub(ctx context.Context, update *task.Update) error {
-	stopProgress := make(chan struct{})
-	go func() {
-		ticker := time.NewTicker(scrubPollInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stopProgress:
-				return
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				status, err := s.btrfs.ScrubStatus(ctx, s.mountPoint)
-				if err != nil {
-					continue
-				}
-				scrubbed := status.DataBytesScrubbed + status.TreeBytesScrubbed
-				if total := s.filesystemUsedBytes(); total > 0 {
-					pct := int(scrubbed * 100 / total)
-					if pct > 100 {
-						pct = 100
-					}
-					update.SetProgress(pct)
-				}
-				_ = update.SetResult(status)
-			}
+	stop := update.PollProgress(ctx, func() int {
+		status, err := s.btrfs.ScrubStatus(ctx, s.mountPoint)
+		if err != nil {
+			return -1
 		}
-	}()
+		_ = update.SetResult(status)
+		scrubbed := status.DataBytesScrubbed + status.TreeBytesScrubbed
+		if total := s.filesystemUsedBytes(); total > 0 {
+			pct := int(scrubbed * 100 / total)
+			if pct > 100 {
+				return 100
+			}
+			return pct
+		}
+		return 0
+	})
 
 	err := s.btrfs.ScrubStart(ctx, s.mountPoint)
-	close(stopProgress)
+	stop()
 
 	if err != nil {
 		return fmt.Errorf("btrfs scrub: %w", err)

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -21,15 +21,17 @@ import (
 
 // Storage encapsulates all btrfs volume, snapshot, and clone operations.
 type Storage struct {
-	basePath        string
-	mountPoint      string
-	quotaEnabled    bool
-	btrfs           *btrfs.Manager
-	exporter        nfs.Exporter
-	tenants         []string
-	defaultDirMode  os.FileMode
-	defaultDataMode string
-	tasks           *task.Manager
+	basePath           string
+	mountPoint         string
+	quotaEnabled       bool
+	btrfs              *btrfs.Manager
+	exporter           nfs.Exporter
+	tenants            []string
+	defaultDirMode     os.FileMode
+	defaultDataMode    string
+	tasks              *task.Manager
+	taskDefaultTimeout time.Duration
+	taskScrubTimeout   time.Duration
 
 	// cachedDevices is written by both the IO poller (5s) and btrfs stats poller (1m).
 	// Each poller loads the current state, updates its own fields (IO or Errors),
@@ -41,7 +43,7 @@ type Storage struct {
 	cachedFilesystem atomic.Pointer[btrfs.FilesystemUsage]
 }
 
-func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin string, taskMaxConcurrent int) *Storage {
+func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin string, taskMaxConcurrent int, taskDefaultTimeout, taskScrubTimeout, taskPollInterval time.Duration) *Storage {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -112,7 +114,7 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 		initialStates[i] = DeviceState{BTRFSDevice: d}
 	}
 	taskDir := filepath.Join(basePath, config.TasksDir)
-	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, tasks: task.NewManager(taskDir, taskMaxConcurrent)}
+	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, tasks: task.NewManager(taskDir, taskMaxConcurrent, taskPollInterval), taskDefaultTimeout: taskDefaultTimeout, taskScrubTimeout: taskScrubTimeout}
 	s.cachedDevices.Store(&initialStates)
 	return s
 }

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -95,7 +95,7 @@ func (s *StorageIntegrationSuite) SetupSuite() {
 		tenants:         []string{"test"},
 		defaultDirMode:  0o755,
 		defaultDataMode: "2770",
-		tasks:           task.NewManager(taskDir, 0),
+		tasks:           task.NewManager(taskDir, 0, 0),
 	}
 }
 
@@ -396,7 +396,7 @@ func (s *StorageIntegrationSuite) TestStartScrub() {
 	s.Require().NoError(err)
 
 	// start scrub via storage layer
-	taskID, err := s.storage.StartScrub(s.ctx)
+	taskID, err := s.storage.StartScrub(s.ctx, nil, 0)
 	s.Require().NoError(err)
 	s.Assert().NotEmpty(taskID)
 
@@ -419,7 +419,7 @@ func (s *StorageIntegrationSuite) TestStartScrub() {
 func (s *StorageIntegrationSuite) TestStartScrubDuplicate() {
 	// start a blocking scrub in background
 	started := make(chan struct{})
-	s.storage.Tasks().Create(string(task.TypeScrub), func(ctx context.Context, update *task.Update) error {
+	s.storage.Tasks().Create(string(task.TypeScrub), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
 		close(started)
 		<-ctx.Done()
 		return ctx.Err()
@@ -427,7 +427,7 @@ func (s *StorageIntegrationSuite) TestStartScrubDuplicate() {
 	<-started
 
 	// second scrub should be rejected
-	_, err := s.storage.StartScrub(s.ctx)
+	_, err := s.storage.StartScrub(s.ctx, nil, 0)
 	s.Require().Error(err)
 	var se *StorageError
 	s.Require().ErrorAs(err, &se)
@@ -438,7 +438,7 @@ func (s *StorageIntegrationSuite) TestTaskPersistence() {
 	taskDir := filepath.Join(s.mnt, config.TasksDir)
 
 	// submit a task that completes
-	id := s.storage.Tasks().Create("test", func(ctx context.Context, update *task.Update) error {
+	id := s.storage.Tasks().Create("test", task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
 		return update.SetResult(map[string]string{"key": "value"})
 	})
 	time.Sleep(100 * time.Millisecond)
@@ -468,7 +468,7 @@ func (s *StorageIntegrationSuite) TestTaskLoadFromDisk() {
 	s.Require().NoError(writeMetadataAtomic(filepath.Join(taskDir, "stale-task-123.json"), &staleTask))
 
 	// create new TaskManager (triggers loadFromDisk)
-	tm := task.NewManager(taskDir, 0)
+	tm := task.NewManager(taskDir, 0, 0)
 
 	// stale task should be marked failed
 	tsk, err := tm.Get("stale-task-123")
@@ -481,7 +481,7 @@ func (s *StorageIntegrationSuite) TestTaskLoadFromDisk() {
 func (s *StorageIntegrationSuite) TestTaskCleanupRemovesFiles() {
 	taskDir := filepath.Join(s.mnt, config.TasksDir)
 
-	id := s.storage.Tasks().Create("test", func(ctx context.Context, update *task.Update) error {
+	id := s.storage.Tasks().Create("test", task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
 		return nil
 	})
 	time.Sleep(100 * time.Millisecond)
@@ -505,7 +505,7 @@ func (s *StorageIntegrationSuite) TestTaskCleanupRemovesFiles() {
 
 func (s *StorageIntegrationSuite) TestScrubOnEmptyFilesystem() {
 	// no volumes, no data -- scrub should still work
-	taskID, err := s.storage.StartScrub(s.ctx)
+	taskID, err := s.storage.StartScrub(s.ctx, nil, 0)
 	s.Require().NoError(err)
 
 	for i := 0; i < 30; i++ {
@@ -531,7 +531,7 @@ func (s *StorageIntegrationSuite) TestScrubRestartRecovery() {
 	s.Require().NoError(writeMetadataAtomic(filepath.Join(taskDir, "stale-scrub.json"), &staleTask))
 
 	// create new TaskManager (simulates agent restart)
-	tm := task.NewManager(taskDir, 0)
+	tm := task.NewManager(taskDir, 0, 0)
 
 	// stale scrub should be failed
 	tsk, err := tm.Get("stale-scrub")
@@ -541,7 +541,7 @@ func (s *StorageIntegrationSuite) TestScrubRestartRecovery() {
 
 	// should be able to start a new scrub (stale one doesn't block)
 	s.storage.tasks = tm
-	newID, err := s.storage.StartScrub(s.ctx)
+	newID, err := s.storage.StartScrub(s.ctx, nil, 0)
 	s.Require().NoError(err)
 	s.Assert().NotEmpty(newID)
 

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -13,21 +14,26 @@ import (
 
 // Manager manages async tasks as goroutines with progress tracking.
 type Manager struct {
-	mu      sync.Mutex
-	tasks   map[string]*runningTask
-	taskDir string
-	sem     chan struct{}
+	mu           sync.Mutex
+	tasks        map[string]*runningTask
+	taskDir      string
+	sem          chan struct{}
+	pollInterval time.Duration
 }
 
 // NewManager creates a new Manager with persistence under taskDir.
 // maxConcurrent limits the number of tasks running simultaneously.
-func NewManager(taskDir string, maxConcurrent int) *Manager {
+func NewManager(taskDir string, maxConcurrent int, pollInterval time.Duration) *Manager {
 	if err := os.MkdirAll(taskDir, 0o755); err != nil {
 		log.Fatal().Err(err).Str("path", taskDir).Msg("failed to create tasks directory")
 	}
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
 	tm := &Manager{
-		tasks:   make(map[string]*runningTask),
-		taskDir: taskDir,
+		tasks:        make(map[string]*runningTask),
+		taskDir:      taskDir,
+		pollInterval: pollInterval,
 	}
 	if maxConcurrent > 0 {
 		tm.sem = make(chan struct{}, maxConcurrent)
@@ -42,7 +48,7 @@ func NewManager(taskDir string, maxConcurrent int) *Manager {
 }
 
 // Create starts a task as a background goroutine and returns its ID.
-func (tm *Manager) Create(taskType string, fn TaskFunc) string {
+func (tm *Manager) Create(taskType string, opts TaskOpts, fn TaskFunc) string {
 	id := generateID()
 	now := time.Now().UTC()
 
@@ -50,10 +56,18 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 		ID:        id,
 		Type:      taskType,
 		Status:    TaskPending,
+		Opts:      opts.Opts,
+		Timeout:   opts.Timeout,
 		CreatedAt: now,
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if opts.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
 	rt := &runningTask{cancel: cancel}
 	rt.state.Store(t)
 	tm.persist(t)
@@ -62,7 +76,7 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 	tm.tasks[id] = rt
 	tm.mu.Unlock()
 
-	log.Info().Str("task", id).Str("type", taskType).Msg("task submitted")
+	log.Info().Str("task", id).Str("type", taskType).Dur("timeout", opts.Timeout).Msg("task submitted")
 
 	go func() {
 		// Wait for a worker slot (nil sem = unlimited)
@@ -90,6 +104,7 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 		}
 
 		tasksRunning.WithLabelValues(taskType).Inc()
+		defer cancel()
 
 		start := time.Now()
 		startUTC := start.UTC()
@@ -100,12 +115,15 @@ func (tm *Manager) Create(taskType string, fn TaskFunc) string {
 		tm.persist(&running)
 		rt.state.Store(&running)
 
-		err := fn(ctx, &Update{rt: rt, persist: tm.persist})
+		err := fn(ctx, &Update{rt: rt, persist: tm.persist, pollInterval: tm.pollInterval})
 
 		now := time.Now().UTC()
 		final := *rt.state.Load()
 		final.CompletedAt = &now
 		switch {
+		case ctx.Err() == context.DeadlineExceeded:
+			final.Status = TaskFailed
+			final.Error = fmt.Sprintf("task timed out after %s", opts.Timeout)
 		case ctx.Err() != nil:
 			final.Status = TaskCancelled
 		case err != nil:

--- a/agent/storage/task/manager_test.go
+++ b/agent/storage/task/manager_test.go
@@ -46,11 +46,11 @@ func awaitDone(t *testing.T, tm *Manager, id string) *Task {
 }
 
 func TestManager_SubmitAndGet(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	started := make(chan struct{})
 	done := make(chan struct{})
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		close(started)
 		<-done
 		return nil
@@ -74,9 +74,9 @@ func TestManager_SubmitAndGet(t *testing.T) {
 }
 
 func TestManager_SubmitWithError(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return fmt.Errorf("something broke")
 	})
 
@@ -86,10 +86,10 @@ func TestManager_SubmitWithError(t *testing.T) {
 }
 
 func TestManager_Cancel(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	started := make(chan struct{})
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		close(started)
 		<-ctx.Done()
 		return ctx.Err()
@@ -103,9 +103,9 @@ func TestManager_Cancel(t *testing.T) {
 }
 
 func TestManager_CancelFinished(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -114,26 +114,26 @@ func TestManager_CancelFinished(t *testing.T) {
 }
 
 func TestManager_CancelUnknown(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	err := tm.Cancel("nonexistent")
 	assert.Error(t, err)
 }
 
 func TestManager_GetUnknown(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	_, err := tm.Get("nonexistent")
 	assert.Error(t, err)
 }
 
 func TestManager_List(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
-	id1 := tm.Create("scrub", func(ctx context.Context, update *Update) error {
+	id1 := tm.Create("scrub", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
-	id2 := tm.Create("transfer", func(ctx context.Context, update *Update) error {
+	id2 := tm.Create("transfer", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -156,9 +156,9 @@ func TestManager_List(t *testing.T) {
 }
 
 func TestManager_ListReturnsCopies(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -175,10 +175,10 @@ func TestManager_ListReturnsCopies(t *testing.T) {
 }
 
 func TestManager_ProgressUpdate(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	checkpoint := make(chan struct{})
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		update.SetProgress(50)
 		close(checkpoint)
 		<-ctx.Done()
@@ -201,9 +201,9 @@ func TestManager_ResultStruct(t *testing.T) {
 		Name  string `json:"name"`
 	}
 
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return update.SetResult(TestResult{Count: 42, Name: "hello"})
 	})
 
@@ -217,9 +217,9 @@ func TestManager_ResultStruct(t *testing.T) {
 }
 
 func TestManager_Cleanup(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -231,10 +231,10 @@ func TestManager_Cleanup(t *testing.T) {
 }
 
 func TestManager_CleanupKeepsRunning(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	done := make(chan struct{})
-	id := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		<-done
 		return nil
 	})
@@ -259,7 +259,7 @@ func TestManager_CorruptTaskFile(t *testing.T) {
 	valid, _ := json.MarshalIndent(Task{ID: "good", Type: "test", Status: TaskCompleted}, "", "  ")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "good.json"), valid, 0o644))
 
-	tm := NewManager(dir, 0)
+	tm := NewManager(dir, 0, 0)
 
 	tasks := tm.List("")
 	assert.Len(t, tasks, 1)
@@ -271,13 +271,13 @@ func TestManager_EmptyTaskFile(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.json"), []byte(""), 0o644))
 
-	tm := NewManager(dir, 0)
+	tm := NewManager(dir, 0, 0)
 	tasks := tm.List("")
 	assert.Empty(t, tasks)
 }
 
 func TestManager_ConcurrentSubmit(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	ids := make([]string, 50)
 	var wg sync.WaitGroup
@@ -285,7 +285,7 @@ func TestManager_ConcurrentSubmit(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			ids[idx] = tm.Create("test", func(ctx context.Context, update *Update) error {
+			ids[idx] = tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 				return nil
 			})
 		}(i)
@@ -304,18 +304,18 @@ func TestManager_ConcurrentSubmit(t *testing.T) {
 }
 
 func TestManager_WorkerPoolBlocksSecondTask(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1)
+	tm := NewManager(t.TempDir(), 1, 0)
 
 	started := make(chan struct{})
 	blocker := make(chan struct{})
-	first := tm.Create("test", func(ctx context.Context, update *Update) error {
+	first := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		close(started)
 		<-blocker
 		return nil
 	})
 	<-started
 
-	second := tm.Create("test", func(ctx context.Context, update *Update) error {
+	second := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -331,18 +331,18 @@ func TestManager_WorkerPoolBlocksSecondTask(t *testing.T) {
 }
 
 func TestManager_WorkerPoolMaxTwo(t *testing.T) {
-	tm := NewManager(t.TempDir(), 2)
+	tm := NewManager(t.TempDir(), 2, 0)
 
 	started1 := make(chan struct{})
 	started2 := make(chan struct{})
 	blocker := make(chan struct{})
 
-	id1 := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id1 := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		close(started1)
 		<-blocker
 		return nil
 	})
-	id2 := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id2 := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		close(started2)
 		<-blocker
 		return nil
@@ -351,7 +351,7 @@ func TestManager_WorkerPoolMaxTwo(t *testing.T) {
 	<-started1
 	<-started2
 
-	id3 := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id3 := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -367,13 +367,13 @@ func TestManager_WorkerPoolMaxTwo(t *testing.T) {
 }
 
 func TestManager_WorkerPoolUnlimited(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0)
+	tm := NewManager(t.TempDir(), 0, 0)
 
 	started := make(chan struct{}, 10)
 	blocker := make(chan struct{})
 	var ids []string
 	for i := 0; i < 10; i++ {
-		id := tm.Create("test", func(ctx context.Context, update *Update) error {
+		id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 			started <- struct{}{}
 			<-blocker
 			return nil
@@ -398,18 +398,18 @@ func TestManager_WorkerPoolUnlimited(t *testing.T) {
 }
 
 func TestManager_CancelPending(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1)
+	tm := NewManager(t.TempDir(), 1, 0)
 
 	started := make(chan struct{})
 	blocker := make(chan struct{})
-	first := tm.Create("test", func(ctx context.Context, update *Update) error {
+	first := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		close(started)
 		<-blocker
 		return nil
 	})
 	<-started
 
-	second := tm.Create("test", func(ctx context.Context, update *Update) error {
+	second := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -427,7 +427,7 @@ func TestManager_CancelPending(t *testing.T) {
 }
 
 func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1)
+	tm := NewManager(t.TempDir(), 1, 0)
 
 	order := make([]string, 0, 3)
 	var mu sync.Mutex
@@ -440,7 +440,7 @@ func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
 
 	started := make(chan struct{})
 	blocker := make(chan struct{})
-	tm.Create("test", func(ctx context.Context, update *Update) error {
+	tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		record("first-start")
 		close(started)
 		<-blocker
@@ -449,7 +449,7 @@ func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
 	})
 	<-started
 
-	second := tm.Create("test", func(ctx context.Context, update *Update) error {
+	second := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		record("second-start")
 		return nil
 	})
@@ -466,15 +466,15 @@ func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
 }
 
 func TestManager_WorkerPoolTaskError(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1)
+	tm := NewManager(t.TempDir(), 1, 0)
 
-	id1 := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id1 := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return fmt.Errorf("boom")
 	})
 
 	awaitStatus(t, tm, id1, TaskFailed)
 
-	id2 := tm.Create("test", func(ctx context.Context, update *Update) error {
+	id2 := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
 	})
 
@@ -482,7 +482,7 @@ func TestManager_WorkerPoolTaskError(t *testing.T) {
 }
 
 func TestManager_Stress(t *testing.T) {
-	tm := NewManager(t.TempDir(), 4)
+	tm := NewManager(t.TempDir(), 4, 0)
 
 	const total = 1000
 	var running atomic.Int32
@@ -494,7 +494,7 @@ func TestManager_Stress(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			ids[idx] = tm.Create("test", func(ctx context.Context, update *Update) error {
+			ids[idx] = tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 				cur := running.Add(1)
 				for {
 					old := maxRunning.Load()
@@ -533,4 +533,60 @@ func TestManager_Stress(t *testing.T) {
 	assert.Equal(t, 0, failed, "no tasks should fail")
 	assert.LessOrEqual(t, int(maxRunning.Load()), 4, "max concurrency should not exceed 4")
 	t.Logf("peak concurrency: %d/4, completed: %d/%d", maxRunning.Load(), completed, total)
+}
+
+func TestManager_CreateWithOpts(t *testing.T) {
+	tm := NewManager(t.TempDir(), 0, 0)
+
+	id := tm.Create("test", TaskOpts{
+		Opts:    map[string]string{"sleep": "5s"},
+		Timeout: 10 * time.Minute,
+	}, func(ctx context.Context, update *Update) error {
+		return nil
+	})
+
+	tsk := awaitStatus(t, tm, id, TaskCompleted)
+	require.NotNil(t, tsk.Opts)
+	assert.Equal(t, 10*time.Minute, tsk.Timeout)
+	assert.Equal(t, "5s", tsk.Opts["sleep"])
+}
+
+func TestManager_Timeout(t *testing.T) {
+	tm := NewManager(t.TempDir(), 0, 0)
+
+	id := tm.Create("test", TaskOpts{
+		Timeout: 50 * time.Millisecond,
+	}, func(ctx context.Context, update *Update) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	tsk := awaitStatus(t, tm, id, TaskFailed)
+	assert.Contains(t, tsk.Error, "timed out")
+	assert.NotNil(t, tsk.CompletedAt)
+}
+
+func TestManager_TimeoutCompletesBeforeDeadline(t *testing.T) {
+	tm := NewManager(t.TempDir(), 0, 0)
+
+	id := tm.Create("test", TaskOpts{
+		Timeout: 10 * time.Second,
+	}, func(ctx context.Context, update *Update) error {
+		return nil
+	})
+
+	tsk := awaitStatus(t, tm, id, TaskCompleted)
+	assert.Empty(t, tsk.Error)
+}
+
+func TestManager_ZeroTimeoutMeansNoTimeout(t *testing.T) {
+	tm := NewManager(t.TempDir(), 0, 0)
+
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
+		return nil
+	})
+
+	tsk := awaitStatus(t, tm, id, TaskCompleted)
+	assert.Equal(t, time.Duration(0), tsk.Timeout)
+	assert.Nil(t, tsk.Opts)
 }

--- a/agent/storage/task/model.go
+++ b/agent/storage/task/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -32,15 +33,23 @@ var ErrNotFound = fmt.Errorf("task not found")
 
 // Task represents an async long-running operation with progress tracking.
 type Task struct {
-	ID          string          `json:"id"`
-	Type        string          `json:"type"`
-	Status      TaskStatus      `json:"status"`
-	Progress    int             `json:"progress"`
-	Result      json.RawMessage `json:"result,omitempty"`
-	Error       string          `json:"error,omitempty"`
-	CreatedAt   time.Time       `json:"created_at"`
-	StartedAt   *time.Time      `json:"started_at,omitempty"`
-	CompletedAt *time.Time      `json:"completed_at,omitempty"`
+	ID          string            `json:"id"`
+	Type        string            `json:"type"`
+	Status      TaskStatus        `json:"status"`
+	Progress    int               `json:"progress"`
+	Opts        map[string]string `json:"opts,omitempty"`
+	Timeout     time.Duration     `json:"timeout,omitempty"`
+	Result      json.RawMessage   `json:"result,omitempty"`
+	Error       string            `json:"error,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	StartedAt   *time.Time        `json:"started_at,omitempty"`
+	CompletedAt *time.Time        `json:"completed_at,omitempty"`
+}
+
+// TaskOpts configures a new task.
+type TaskOpts struct {
+	Opts    map[string]string
+	Timeout time.Duration
 }
 
 // TaskFunc is the function executed by a task.
@@ -48,8 +57,35 @@ type TaskFunc func(ctx context.Context, update *Update) error
 
 // Update is passed to TaskFunc for safe progress/result updates.
 type Update struct {
-	rt      *runningTask
-	persist func(*Task)
+	rt           *runningTask
+	persist      func(*Task)
+	pollInterval time.Duration
+}
+
+// PollProgress runs fn every pollInterval until stopped or ctx is cancelled.
+// fn returns the current progress (0-100). Negative values are ignored (skip update).
+// Returns a stop function that must be called when polling is no longer needed.
+// The stop function is safe to call multiple times.
+func (u *Update) PollProgress(ctx context.Context, fn func() int) (stop func()) {
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		ticker := time.NewTicker(u.pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if pct := fn(); pct >= 0 {
+					u.SetProgress(pct)
+				}
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
 }
 
 // SetProgress atomically updates the task's progress (0-100) and persists to disk.

--- a/agent/storage/testtask.go
+++ b/agent/storage/testtask.go
@@ -8,34 +8,39 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// TestTaskOpts configures the test task behavior.
-type TestTaskOpts struct {
-	Sleep string `json:"sleep,omitempty"`
-}
-
 // StartTestTask creates a test task that sleeps for the given duration and returns "Hallo Welt".
-func (s *Storage) StartTestTask(ctx context.Context, opts TestTaskOpts) (string, error) {
+func (s *Storage) StartTestTask(ctx context.Context, opts map[string]string, timeout time.Duration) (string, error) {
 	var sleep time.Duration
-	if opts.Sleep != "" {
+	if v := opts["sleep"]; v != "" {
 		var err error
-		sleep, err = time.ParseDuration(opts.Sleep)
+		sleep, err = time.ParseDuration(v)
 		if err != nil {
-			return "", &StorageError{Code: ErrInvalid, Message: "invalid sleep duration: " + opts.Sleep}
+			return "", &StorageError{Code: ErrInvalid, Message: "invalid sleep duration: " + v}
 		}
 	}
 
-	id := s.tasks.Create(string(task.TypeTest), func(ctx context.Context, update *task.Update) error {
+	t := s.taskDefaultTimeout
+	if timeout > 0 {
+		t = timeout
+	}
+	id := s.tasks.Create(string(task.TypeTest), task.TaskOpts{Opts: opts, Timeout: t}, func(ctx context.Context, update *task.Update) error {
 		if sleep > 0 {
 			log.Debug().Dur("sleep", sleep).Msg("test task sleeping")
+			start := time.Now()
+			stop := update.PollProgress(ctx, func() int {
+				return int(time.Since(start) * 100 / sleep)
+			})
 			select {
 			case <-time.After(sleep):
+				stop()
 			case <-ctx.Done():
+				stop()
 				return ctx.Err()
 			}
 		}
 		return update.SetResult(map[string]string{"message": "Hallo Welt"})
 	})
 
-	log.Info().Str("task", id).Str("sleep", opts.Sleep).Msg("test task started")
+	log.Info().Str("task", id).Str("sleep", opts["sleep"]).Msg("test task started")
 	return id, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,9 @@ type AgentConfig struct {
 	DefaultDataMode      string        `env:"AGENT_DEFAULT_DATA_MODE" envDefault:"2770"`
 	TaskCleanupInterval  time.Duration `env:"AGENT_TASK_CLEANUP_INTERVAL" envDefault:"24h"`
 	TaskMaxConcurrent    int           `env:"AGENT_TASK_MAX_CONCURRENT" envDefault:"2"`
+	TaskDefaultTimeout   time.Duration `env:"AGENT_TASK_DEFAULT_TIMEOUT" envDefault:"6h"`
+	TaskScrubTimeout     time.Duration `env:"AGENT_TASK_SCRUB_TIMEOUT" envDefault:"24h"`
+	TaskPollInterval     time.Duration `env:"AGENT_TASK_POLL_INTERVAL" envDefault:"5s"`
 }
 
 type ControllerConfig struct {

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -2,13 +2,88 @@ package ctl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/btrfs"
+	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/urfave/cli/v3"
 )
+
+func taskResultSummary(resp *v1.TaskDetailResponse) string {
+	if len(resp.Result) == 0 {
+		return ""
+	}
+	switch resp.Type {
+	case v1.TaskTypeScrub:
+		return scrubResultSummary(resp)
+	default:
+		return genericResultSummary(resp.Result)
+	}
+}
+
+func scrubResultSummary(resp *v1.TaskDetailResponse) string {
+	var s btrfs.ScrubStatus
+	if json.Unmarshal(resp.Result, &s) != nil {
+		return genericResultSummary(resp.Result)
+	}
+	errs := s.ReadErrors + s.CSumErrors + s.VerifyErrors + s.UncorrectableErrs
+	switch resp.Status {
+	case v1.TaskStatusRunning:
+		parts := make([]string, 0, 2)
+		if resp.StartedAt != nil {
+			elapsed := time.Since(*resp.StartedAt).Seconds()
+			if elapsed > 0 && s.DataBytesScrubbed > 0 {
+				speed := float64(s.DataBytesScrubbed) / elapsed
+				parts = append(parts, utils.FormatBytes(uint64(speed))+"/s")
+			}
+		}
+		if errs > 0 {
+			parts = append(parts, fmt.Sprintf("%d errors", errs))
+		}
+		if len(parts) == 0 {
+			return ""
+		}
+		return strings.Join(parts, ", ")
+	case v1.TaskStatusCompleted:
+		speed := ""
+		if s.DataBytesScrubbed > 0 && resp.StartedAt != nil && resp.CompletedAt != nil {
+			elapsed := resp.CompletedAt.Sub(*resp.StartedAt).Seconds()
+			if elapsed > 0 {
+				speed = ", " + utils.FormatBytes(uint64(float64(s.DataBytesScrubbed)/elapsed)) + "/s"
+			}
+		}
+		return fmt.Sprintf("%s scrubbed, %d errors%s", utils.FormatBytes(s.DataBytesScrubbed), errs, speed)
+	case v1.TaskStatusFailed:
+		if errs > 0 {
+			return fmt.Sprintf("%d errors", errs)
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+func genericResultSummary(result json.RawMessage) string {
+	var m map[string]any
+	if json.Unmarshal(result, &m) != nil {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s: %v", k, m[k]))
+	}
+	return strings.Join(parts, ", ")
+}
 
 func taskCmd() *cli.Command {
 	return &cli.Command{
@@ -36,7 +111,7 @@ func taskCmd() *cli.Command {
 						})
 						return output(cmd, resp, func() {
 							w := tab()
-							_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tTOOK\tCREATED\tINFO")
+							_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tTIMEOUT\tTOOK\tCREATED\tRESULT\tERROR")
 							for _, t := range resp.Tasks {
 								took := "-"
 								if t.CompletedAt != nil {
@@ -44,12 +119,20 @@ func taskCmd() *cli.Command {
 								} else if t.StartedAt != nil {
 									took = fmtDuration(time.Since(*t.StartedAt))
 								}
-								info := t.Info
-								if info == "" {
-									info = "-"
+								result := taskResultSummary(&t)
+								if result == "" {
+									result = "-"
 								}
-								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\t%s\n",
-									t.ID, t.Type, t.Status, t.Progress, took, t.CreatedAt.Format(timeFmt), info)
+								timeout := "-"
+								if t.Timeout != "" {
+									timeout = t.Timeout
+								}
+								errMsg := "-"
+								if t.Error != "" {
+									errMsg = t.Error
+								}
+								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\t%s\t%s\t%s\n",
+									t.ID, t.Type, t.Status, t.Progress, timeout, took, t.CreatedAt.Format(timeFmt), result, errMsg)
 							}
 							_ = w.Flush()
 						})
@@ -63,7 +146,7 @@ func taskCmd() *cli.Command {
 					})
 					return output(cmd, resp, func() {
 						w := tab()
-						_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tTOOK\tCREATED")
+						_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tTIMEOUT\tTOOK\tCREATED")
 						for _, t := range resp.Tasks {
 							took := "-"
 							if t.CompletedAt != nil {
@@ -71,8 +154,12 @@ func taskCmd() *cli.Command {
 							} else if t.StartedAt != nil {
 								took = fmtDuration(time.Since(*t.StartedAt))
 							}
-							_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\n",
-								t.ID, t.Type, t.Status, t.Progress, took, t.CreatedAt.Format(timeFmt))
+							timeout := "-"
+							if t.Timeout != "" {
+								timeout = t.Timeout
+							}
+							_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\t%s\n",
+								t.ID, t.Type, t.Status, t.Progress, timeout, took, t.CreatedAt.Format(timeFmt))
 						}
 						_ = w.Flush()
 					})
@@ -94,6 +181,16 @@ func taskCmd() *cli.Command {
 					return output(cmd, resp, func() {
 						fmt.Printf("ID:         %s\n", resp.ID)
 						fmt.Printf("Type:       %s\n", resp.Type)
+						if len(resp.Opts) > 0 {
+							parts := make([]string, 0, len(resp.Opts))
+							for k, v := range resp.Opts {
+								parts = append(parts, k+"="+v)
+							}
+							fmt.Printf("Opts:       %s\n", strings.Join(parts, ", "))
+						}
+						if resp.Timeout != "" {
+							fmt.Printf("Timeout:    %s\n", resp.Timeout)
+						}
 						fmt.Printf("Status:     %s\n", resp.Status)
 						fmt.Printf("Progress:   %d%%\n", resp.Progress)
 						if resp.Error != "" {
@@ -107,8 +204,8 @@ func taskCmd() *cli.Command {
 							fmt.Printf("Completed:  %s\n", resp.CompletedAt.Format(timeFmt))
 							fmt.Printf("Took:       %s\n", fmtDuration(resp.CompletedAt.Sub(resp.CreatedAt)))
 						}
-						if resp.Info != "" {
-							fmt.Printf("Result:     %s\n", resp.Info)
+						if s := taskResultSummary(resp); s != "" {
+							fmt.Printf("Result:     %s\n", s)
 						}
 					})
 				},
@@ -136,11 +233,16 @@ func taskCmd() *cli.Command {
 						Name:  v1.TaskTypeScrub,
 						Usage: "start a btrfs scrub",
 						Flags: []cli.Flag{
+							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
 							&cli.BoolFlag{Name: "wait", Aliases: []string{"w"}, Usage: "wait for completion"},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							c := clientFrom(cmd)
-							resp, err := c.CreateTask(ctx, v1.TaskTypeScrub, nil)
+							req := v1.TaskCreateRequest{}
+							if t := cmd.Duration("timeout"); t > 0 {
+								req.Timeout = t.String()
+							}
+							resp, err := c.CreateTask(ctx, v1.TaskTypeScrub, req)
 							if err != nil {
 								return err
 							}
@@ -158,15 +260,19 @@ func taskCmd() *cli.Command {
 						Usage: "start a test task",
 						Flags: []cli.Flag{
 							&cli.DurationFlag{Name: "sleep", Aliases: []string{"s"}, Usage: "sleep duration (e.g. 10s, 1m)"},
+							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
 							&cli.BoolFlag{Name: "wait", Aliases: []string{"w"}, Usage: "wait for completion"},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							c := clientFrom(cmd)
-							var opts any
+							req := v1.TaskCreateRequest{}
 							if s := cmd.Duration("sleep"); s > 0 {
-								opts = map[string]string{"sleep": s.String()}
+								req.Opts = map[string]string{"sleep": s.String()}
 							}
-							resp, err := c.CreateTask(ctx, v1.TaskTypeTest, opts)
+							if t := cmd.Duration("timeout"); t > 0 {
+								req.Timeout = t.String()
+							}
+							resp, err := c.CreateTask(ctx, v1.TaskTypeTest, req)
 							if err != nil {
 								return err
 							}
@@ -203,8 +309,8 @@ func waitForTask(ctx context.Context, c *v1.Client, id string) error {
 				if t.CompletedAt != nil {
 					took = fmtDuration(t.CompletedAt.Sub(t.CreatedAt))
 				}
-				if t.Info != "" {
-					fmt.Printf("completed (took %s, %s)\n", took, t.Info)
+				if s := taskResultSummary(t); s != "" {
+					fmt.Printf("completed (took %s, %s)\n", took, s)
 				} else {
 					fmt.Printf("completed (took %s)\n", took)
 				}
@@ -215,8 +321,8 @@ func waitForTask(ctx context.Context, c *v1.Client, id string) error {
 				fmt.Println("cancelled")
 				return nil
 			default:
-				if t.Info != "" {
-					fmt.Printf("%s %d%% (%s)\n", t.Status, t.Progress, t.Info)
+				if s := taskResultSummary(t); s != "" {
+					fmt.Printf("%s %d%% (%s)\n", t.Status, t.Progress, s)
 				} else {
 					fmt.Printf("%s %d%%\n", t.Status, t.Progress)
 				}

--- a/ctl/task_test.go
+++ b/ctl/task_test.go
@@ -1,0 +1,132 @@
+package ctl
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/btrfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func scrubResult(data, tree, readErr, csumErr uint64) json.RawMessage {
+	s := btrfs.ScrubStatus{
+		DataBytesScrubbed: data,
+		TreeBytesScrubbed: tree,
+		ReadErrors:        readErr,
+		CSumErrors:        csumErr,
+	}
+	raw, _ := json.Marshal(s)
+	return raw
+}
+
+func TestScrubResultSummary_Completed(t *testing.T) {
+	start := time.Now().Add(-10 * time.Second)
+	end := time.Now()
+	resp := &v1.TaskDetailResponse{
+		Type:        v1.TaskTypeScrub,
+		Status:      v1.TaskStatusCompleted,
+		Result:      scrubResult(10737418240, 1048576, 0, 0),
+		StartedAt:   &start,
+		CompletedAt: &end,
+	}
+	s := scrubResultSummary(resp)
+	assert.Contains(t, s, "10.0Gi scrubbed")
+	assert.Contains(t, s, "0 errors")
+	assert.Contains(t, s, "/s")
+}
+
+func TestScrubResultSummary_CompletedWithErrors(t *testing.T) {
+	start := time.Now().Add(-5 * time.Second)
+	end := time.Now()
+	resp := &v1.TaskDetailResponse{
+		Type:        v1.TaskTypeScrub,
+		Status:      v1.TaskStatusCompleted,
+		Result:      scrubResult(1073741824, 0, 2, 1),
+		StartedAt:   &start,
+		CompletedAt: &end,
+	}
+	s := scrubResultSummary(resp)
+	assert.Contains(t, s, "1.0Gi scrubbed")
+	assert.Contains(t, s, "3 errors")
+}
+
+func TestScrubResultSummary_Running(t *testing.T) {
+	start := time.Now().Add(-10 * time.Second)
+	resp := &v1.TaskDetailResponse{
+		Type:      v1.TaskTypeScrub,
+		Status:    v1.TaskStatusRunning,
+		Result:    scrubResult(5368709120, 0, 0, 0),
+		StartedAt: &start,
+	}
+	s := scrubResultSummary(resp)
+	assert.Contains(t, s, "/s")
+}
+
+func TestScrubResultSummary_RunningWithErrors(t *testing.T) {
+	start := time.Now().Add(-10 * time.Second)
+	resp := &v1.TaskDetailResponse{
+		Type:      v1.TaskTypeScrub,
+		Status:    v1.TaskStatusRunning,
+		Result:    scrubResult(5368709120, 0, 1, 2),
+		StartedAt: &start,
+	}
+	s := scrubResultSummary(resp)
+	assert.Contains(t, s, "/s")
+	assert.Contains(t, s, "3 errors")
+}
+
+func TestScrubResultSummary_Failed(t *testing.T) {
+	resp := &v1.TaskDetailResponse{
+		Type:   v1.TaskTypeScrub,
+		Status: v1.TaskStatusFailed,
+		Result: scrubResult(0, 0, 5, 0),
+		Error:  "scrub failed",
+	}
+	s := scrubResultSummary(resp)
+	assert.Equal(t, "5 errors", s)
+}
+
+func TestScrubResultSummary_FailedNoErrors(t *testing.T) {
+	resp := &v1.TaskDetailResponse{
+		Type:   v1.TaskTypeScrub,
+		Status: v1.TaskStatusFailed,
+		Result: scrubResult(0, 0, 0, 0),
+		Error:  "scrub failed",
+	}
+	s := scrubResultSummary(resp)
+	assert.Empty(t, s)
+}
+
+func TestTaskResultSummary_EmptyResult(t *testing.T) {
+	resp := &v1.TaskDetailResponse{
+		Type:   v1.TaskTypeScrub,
+		Status: v1.TaskStatusCompleted,
+	}
+	assert.Empty(t, taskResultSummary(resp))
+}
+
+func TestTaskResultSummary_UnknownType(t *testing.T) {
+	resp := &v1.TaskDetailResponse{
+		Type:   "unknown",
+		Status: v1.TaskStatusCompleted,
+		Result: json.RawMessage(`{"foo":"bar"}`),
+	}
+	assert.Equal(t, "foo: bar", taskResultSummary(resp))
+}
+
+func TestGenericResultSummary(t *testing.T) {
+	result := json.RawMessage(`{"message":"Hallo Welt"}`)
+	assert.Equal(t, "message: Hallo Welt", genericResultSummary(result))
+}
+
+func TestGenericResultSummary_MultipleKeys(t *testing.T) {
+	result := json.RawMessage(`{"b":"2","a":"1"}`)
+	assert.Equal(t, "a: 1, b: 2", genericResultSummary(result))
+}
+
+func TestGenericResultSummary_Invalid(t *testing.T) {
+	assert.Empty(t, genericResultSummary(json.RawMessage(`{corrupt`)))
+	assert.Empty(t, genericResultSummary(nil))
+}

--- a/ctl/utils.go
+++ b/ctl/utils.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
-	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/urfave/cli/v3"
 )
 
@@ -193,8 +192,4 @@ func usedPct(used, total uint64) float64 {
 		return 0
 	}
 	return float64(used) / float64(total) * 100
-}
-
-func parseSize(s string) (uint64, error) {
-	return utils.ParseSize(s)
 }

--- a/ctl/utils_test.go
+++ b/ctl/utils_test.go
@@ -4,50 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestParseSize(t *testing.T) {
-	tests := []struct {
-		input string
-		want  uint64
-	}{
-		{"0", 0},
-		{"1024", 1024},
-		{"1Ki", 1024},
-		{"10Ki", 10240},
-		{"1Mi", 1048576},
-		{"1Gi", 1073741824},
-		{"5Gi", 5368709120},
-		{"1K", 1000},
-		{"1M", 1000000},
-		{"1G", 1000000000},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got, err := parseSize(tt.input)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestParseSizeErrors(t *testing.T) {
-	tests := []string{
-		"",
-		"abc",
-		"-1Gi",
-		"1.5Gi",
-	}
-
-	for _, input := range tests {
-		t.Run(input, func(t *testing.T) {
-			_, err := parseSize(input)
-			assert.Error(t, err)
-		})
-	}
-}
 
 func TestUsedPct(t *testing.T) {
 	assert.Equal(t, 0.0, usedPct(0, 0))

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -126,7 +126,7 @@ func volumeCmd() *cli.Command {
 						return fmt.Errorf("usage: volume create <name> <size>")
 					}
 
-					size, err := parseSize(cmd.Args().Get(1))
+					size, err := utils.ParseSize(cmd.Args().Get(1))
 					if err != nil {
 						return err
 					}
@@ -210,7 +210,7 @@ func volumeCmd() *cli.Command {
 						return fmt.Errorf("usage: volume expand <name> <new-size>")
 					}
 
-					size, err := parseSize(cmd.Args().Get(1))
+					size, err := utils.ParseSize(cmd.Args().Get(1))
 					if err != nil {
 						return err
 					}

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -346,9 +346,19 @@ Filesystem space usage, per-device IO counters (from sysfs), per-device btrfs er
 
 Background task system for long-running operations (scrub, future: transfers). Tasks are persisted to disk and survive agent restarts. Running tasks that were interrupted by an agent restart are marked as `failed`.
 
-### POST /v1/tasks/scrub
+### POST /v1/tasks/:type
 
-Starts a btrfs scrub on the filesystem. Returns 423 if a scrub is already running.
+Starts a background task. `type` is `scrub` or `test`. Returns 423 if a scrub is already running.
+
+```json
+// Request (all fields optional)
+{
+  "timeout": "1h",
+  "opts": {"sleep": "10s"}
+}
+```
+
+`timeout` overrides the server default (scrub: 24h, test: 6h). `opts` is task-type-specific: scrub has no opts, test accepts `{"sleep": "10s"}`.
 
 ```json
 // Response 202
@@ -359,25 +369,21 @@ Starts a btrfs scrub on the filesystem. Returns 423 if a scrub is already runnin
 ```
 
 ```bash
+# Start scrub
 curl -X POST http://10.0.0.5:8080/v1/tasks/scrub \
   -H "Authorization: Bearer changeme"
-```
 
-### POST /v1/tasks/test
+# Start scrub with 30m timeout
+curl -X POST http://10.0.0.5:8080/v1/tasks/scrub \
+  -H "Authorization: Bearer changeme" \
+  -H "Content-Type: application/json" \
+  -d '{"timeout": "30m"}'
 
-Starts a test task for debugging. Optional `sleep` parameter. Result is always `{"message": "Hallo Welt"}`.
-
-```json
-// Request (optional)
-{
-  "sleep": "10s"
-}
-
-// Response 202
-{
-  "task_id": "abc123",
-  "status": "pending"
-}
+# Start test task with sleep
+curl -X POST http://10.0.0.5:8080/v1/tasks/test \
+  -H "Authorization: Bearer changeme" \
+  -H "Content-Type: application/json" \
+  -d '{"opts": {"sleep": "10s"}, "timeout": "1m"}'
 ```
 
 ### GET /v1/tasks
@@ -392,6 +398,7 @@ List all tasks. Optional `?type=` filter (e.g. `scrub`, `test`). Returns a summa
       "type": "scrub",
       "status": "completed",
       "progress": 100,
+      "timeout": "24h0m0s",
       "created_at": "2025-01-15T02:00:00Z",
       "started_at": "2025-01-15T02:00:00Z",
       "completed_at": "2025-01-15T02:00:05Z"
@@ -401,11 +408,11 @@ List all tasks. Optional `?type=` filter (e.g. `scrub`, `test`). Returns a summa
 }
 ```
 
-With `?detail=true`, each task includes the `result` field containing task-type-specific data (e.g. scrub statistics).
+With `?detail=true`, each task includes `result` and `opts` fields.
 
 ### GET /v1/tasks/:id
 
-Returns a single task with full details including `result`. 404 if not found.
+Returns a single task with full details including `result` and `opts`. 404 if not found.
 
 ```json
 {
@@ -413,6 +420,7 @@ Returns a single task with full details including `result`. 404 if not found.
   "type": "scrub",
   "status": "completed",
   "progress": 100,
+  "timeout": "24h0m0s",
   "result": {
     "data_bytes_scrubbed": 3145728000,
     "tree_bytes_scrubbed": 6979584,
@@ -428,6 +436,7 @@ Returns a single task with full details including `result`. 404 if not found.
   "started_at": "2025-01-15T02:00:00Z",
   "completed_at": "2025-01-15T02:00:05Z"
 }
+```
 
 ### DELETE /v1/tasks/:id
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,9 @@
 | `AGENT_DEFAULT_DATA_MODE` | `2770` | Default mode for data subvolumes (setgid + group rwx) |
 | `AGENT_TASK_CLEANUP_INTERVAL` | `24h` | Remove completed/failed tasks after this duration |
 | `AGENT_TASK_MAX_CONCURRENT` | `2` | Max concurrent tasks (`0` = unlimited) |
+| `AGENT_TASK_DEFAULT_TIMEOUT` | `6h` | Default timeout for tasks (e.g. test). `0` = no timeout |
+| `AGENT_TASK_SCRUB_TIMEOUT` | `24h` | Timeout for btrfs scrub tasks. `0` = no timeout |
+| `AGENT_TASK_POLL_INTERVAL` | `5s` | Progress update interval for background tasks |
 | `LOG_LEVEL` | `info` | `trace`, `debug`, `info`, `warn`, `error` |
 
 ## CLI Environment Variables


### PR DESCRIPTION
## Summary
- Store task input opts (`map[string]string`) and configurable timeout on tasks
- Unified `POST /v1/tasks/:type` endpoint with `TaskCreateRequest` (replaces separate scrub/test handlers)
- Configurable task timeouts: `AGENT_TASK_DEFAULT_TIMEOUT` (6h), `AGENT_TASK_SCRUB_TIMEOUT` (24h)
- Configurable progress poll interval: `AGENT_TASK_POLL_INTERVAL` (5s)
- `Update.PollProgress()` helper replaces duplicate ticker patterns in scrub and test tasks
- CLI `--timeout` flag on `task create scrub` and `task create test`
- CLI formats task results client-side (removed `info` field from API)
- `task list -o wide` shows TIMEOUT, RESULT, ERROR columns
- Context timeout with `DeadlineExceeded` detection, `defer cancel()` for cleanup
- Test task shows progress updates during sleep