### PR TITLE
Add user-defined labels for volumes, snapshots, clones, and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you run a homelab, a small on-prem cluster, or an edge deployment and want re
 - Instant snapshots and writable clones (btrfs CoW)
 - Online volume expansion
 - Per-volume quota enforcement and usage reporting
+- User-defined labels on volumes, snapshots, clones, and tasks (with filtering)
 - Per-volume tuning via StorageClass parameters or PVC annotations:
   - Compression (`zstd`, `lzo`, `zlib` with levels)
   - NoCOW mode (`chattr +C`) for databases

--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -7,8 +7,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
+
+func generateLabelQuery(labels []string) url.Values {
+	v := make(url.Values)
+	for _, l := range labels {
+		v.Add("label", l)
+	}
+	return v
+}
 
 type Client struct {
 	url   string
@@ -91,17 +100,20 @@ func (c *Client) UnexportVolume(ctx context.Context, name string, cl string) err
 	return c.do(ctx, http.MethodDelete, "/v1/volumes/"+name+"/export", ExportRequest{Client: cl}, nil)
 }
 
-func (c *Client) ListVolumes(ctx context.Context) (*VolumeListResponse, error) {
+func (c *Client) ListVolumes(ctx context.Context, labels ...string) (*VolumeListResponse, error) {
 	var resp VolumeListResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/volumes", nil, &resp); err != nil {
+	q := generateLabelQuery(labels)
+	if err := c.do(ctx, http.MethodGet, "/v1/volumes?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListVolumesDetail(ctx context.Context) (*VolumeDetailListResponse, error) {
+func (c *Client) ListVolumesDetail(ctx context.Context, labels ...string) (*VolumeDetailListResponse, error) {
 	var resp VolumeDetailListResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/volumes?detail=true", nil, &resp); err != nil {
+	q := generateLabelQuery(labels)
+	q.Set("detail", "true")
+	if err := c.do(ctx, http.MethodGet, "/v1/volumes?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -115,33 +127,39 @@ func (c *Client) GetVolume(ctx context.Context, name string) (*VolumeDetailRespo
 	return &resp, nil
 }
 
-func (c *Client) ListSnapshots(ctx context.Context) (*SnapshotListResponse, error) {
+func (c *Client) ListSnapshots(ctx context.Context, labels ...string) (*SnapshotListResponse, error) {
 	var resp SnapshotListResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/snapshots", nil, &resp); err != nil {
+	q := generateLabelQuery(labels)
+	if err := c.do(ctx, http.MethodGet, "/v1/snapshots?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListVolumeSnapshots(ctx context.Context, volume string) (*SnapshotListResponse, error) {
+func (c *Client) ListVolumeSnapshots(ctx context.Context, volume string, labels ...string) (*SnapshotListResponse, error) {
 	var resp SnapshotListResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/volumes/"+volume+"/snapshots", nil, &resp); err != nil {
+	q := generateLabelQuery(labels)
+	if err := c.do(ctx, http.MethodGet, "/v1/volumes/"+volume+"/snapshots?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListVolumeSnapshotsDetail(ctx context.Context, volume string) (*SnapshotDetailListResponse, error) {
+func (c *Client) ListVolumeSnapshotsDetail(ctx context.Context, volume string, labels ...string) (*SnapshotDetailListResponse, error) {
 	var resp SnapshotDetailListResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/volumes/"+volume+"/snapshots?detail=true", nil, &resp); err != nil {
+	q := generateLabelQuery(labels)
+	q.Set("detail", "true")
+	if err := c.do(ctx, http.MethodGet, "/v1/volumes/"+volume+"/snapshots?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListSnapshotsDetail(ctx context.Context) (*SnapshotDetailListResponse, error) {
+func (c *Client) ListSnapshotsDetail(ctx context.Context, labels ...string) (*SnapshotDetailListResponse, error) {
 	var resp SnapshotDetailListResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/snapshots?detail=true", nil, &resp); err != nil {
+	q := generateLabelQuery(labels)
+	q.Set("detail", "true")
+	if err := c.do(ctx, http.MethodGet, "/v1/snapshots?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -171,25 +189,26 @@ func (c *Client) CreateTask(ctx context.Context, taskType string, req TaskCreate
 	return &resp, nil
 }
 
-func (c *Client) ListTasks(ctx context.Context, taskType string) (*TaskListResponse, error) {
+func (c *Client) ListTasks(ctx context.Context, taskType string, labels ...string) (*TaskListResponse, error) {
 	var resp TaskListResponse
-	path := "/v1/tasks"
+	q := generateLabelQuery(labels)
 	if taskType != "" {
-		path += "?type=" + taskType
+		q.Set("type", taskType)
 	}
-	if err := c.do(ctx, http.MethodGet, path, nil, &resp); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/v1/tasks?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListTasksDetail(ctx context.Context, taskType string) (*TaskDetailListResponse, error) {
+func (c *Client) ListTasksDetail(ctx context.Context, taskType string, labels ...string) (*TaskDetailListResponse, error) {
 	var resp TaskDetailListResponse
-	path := "/v1/tasks?detail=true"
+	q := generateLabelQuery(labels)
+	q.Set("detail", "true")
 	if taskType != "" {
-		path += "&type=" + taskType
+		q.Set("type", taskType)
 	}
-	if err := c.do(ctx, http.MethodGet, path, nil, &resp); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/v1/tasks?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -52,6 +52,10 @@ func (h *Handler) ListVolumes(c *echo.Context) error {
 		return StorageError(c, err)
 	}
 
+	if filters := c.QueryParams()["label"]; len(filters) > 0 {
+		vols = filterByLabels(vols, filters)
+	}
+
 	if c.QueryParam("detail") == "true" {
 		resp := make([]VolumeDetailResponse, len(vols))
 		for i := range vols {
@@ -84,6 +88,7 @@ func volumeDetailResponseFrom(meta *storage.VolumeMetadata) VolumeDetailResponse
 		UID:          meta.UID,
 		GID:          meta.GID,
 		Mode:         meta.Mode,
+		Labels:       meta.Labels,
 		Clients:      clients,
 		CreatedAt:    meta.CreatedAt,
 		UpdatedAt:    meta.UpdatedAt,
@@ -273,6 +278,10 @@ func (h *Handler) ListSnapshots(c *echo.Context) error {
 		return StorageError(c, err)
 	}
 
+	if filters := c.QueryParams()["label"]; len(filters) > 0 {
+		snaps = filterByLabels(snaps, filters)
+	}
+
 	if c.QueryParam("detail") == "true" {
 		resp := make([]SnapshotDetailResponse, len(snaps))
 		for i := range snaps {
@@ -295,6 +304,10 @@ func (h *Handler) ListVolumeSnapshots(c *echo.Context) error {
 	snaps, err := h.Store.ListSnapshots(tenant, c.Param("name"))
 	if err != nil {
 		return StorageError(c, err)
+	}
+
+	if filters := c.QueryParams()["label"]; len(filters) > 0 {
+		snaps = filterByLabels(snaps, filters)
 	}
 
 	if c.QueryParam("detail") == "true" {
@@ -322,6 +335,7 @@ func snapshotDetailResponseFrom(meta *storage.SnapshotMetadata) SnapshotDetailRe
 		UsedBytes:      meta.UsedBytes,
 		ExclusiveBytes: meta.ExclusiveBytes,
 		ReadOnly:       meta.ReadOnly,
+		Labels:         meta.Labels,
 		CreatedAt:      meta.CreatedAt,
 		UpdatedAt:      meta.UpdatedAt,
 	}
@@ -382,22 +396,22 @@ func (h *Handler) CreateClone(c *echo.Context) error {
 	meta, err := h.Store.CreateClone(c.Request().Context(), tenant, req)
 	if err != nil {
 		if meta != nil {
-			return c.JSON(http.StatusConflict, CloneResponse{
-				Name:           meta.Name,
-				SourceSnapshot: meta.SourceSnapshot,
-				Path:           meta.Path,
-				CreatedAt:      meta.CreatedAt,
-			})
+			return c.JSON(http.StatusConflict, cloneResponseFrom(meta))
 		}
 		return StorageError(c, err)
 	}
 
-	return c.JSON(http.StatusCreated, CloneResponse{
+	return c.JSON(http.StatusCreated, cloneResponseFrom(meta))
+}
+
+func cloneResponseFrom(meta *storage.CloneMetadata) CloneResponse {
+	return CloneResponse{
 		Name:           meta.Name,
 		SourceSnapshot: meta.SourceSnapshot,
 		Path:           meta.Path,
+		Labels:         meta.Labels,
 		CreatedAt:      meta.CreatedAt,
-	})
+	}
 }
 
 // --- Tasks ---
@@ -425,9 +439,9 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 	var err error
 	switch taskType {
 	case TaskTypeScrub:
-		taskID, err = h.Store.StartScrub(c.Request().Context(), req.Opts, timeout)
+		taskID, err = h.Store.StartScrub(c.Request().Context(), req.Opts, req.Labels, timeout)
 	case TaskTypeTest:
-		taskID, err = h.Store.StartTestTask(c.Request().Context(), req.Opts, timeout)
+		taskID, err = h.Store.StartTestTask(c.Request().Context(), req.Opts, req.Labels, timeout)
 	default:
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "unknown task type: " + taskType, Code: storage.ErrInvalid})
 	}
@@ -439,6 +453,10 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 
 func (h *Handler) ListTasks(c *echo.Context) error {
 	tasks := h.Store.Tasks().List(c.QueryParam("type"))
+
+	if filters := c.QueryParams()["label"]; len(filters) > 0 {
+		tasks = filterByLabels(tasks, filters)
+	}
 
 	if c.QueryParam("detail") == "true" {
 		detail := make([]TaskDetailResponse, len(tasks))

--- a/agent/api/v1/labels.go
+++ b/agent/api/v1/labels.go
@@ -1,0 +1,37 @@
+package v1
+
+import "strings"
+
+type labeled interface {
+	GetLabels() map[string]string
+}
+
+func filterByLabels[T labeled](items []T, filters []string) []T {
+	filtered := items[:0]
+	for i := range items {
+		if matchLabels(items[i].GetLabels(), filters) {
+			filtered = append(filtered, items[i])
+		}
+	}
+	return filtered
+}
+
+func matchLabels(labels map[string]string, filters []string) bool {
+	if len(labels) == 0 {
+		return len(filters) == 0
+	}
+	for _, f := range filters {
+		k, v, hasValue := strings.Cut(f, "=")
+		if !hasValue {
+			if _, exists := labels[k]; !exists {
+				return false
+			}
+			continue
+		}
+		got, exists := labels[k]
+		if !exists || got != v {
+			return false
+		}
+	}
+	return true
+}

--- a/agent/api/v1/labels_test.go
+++ b/agent/api/v1/labels_test.go
@@ -1,0 +1,57 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		filters []string
+		want    bool
+	}{
+		{"nil_labels_no_filters", nil, nil, true},
+		{"nil_labels_with_filter", nil, []string{"env=prod"}, false},
+		{"empty_labels_no_filters", map[string]string{}, nil, true},
+		{"empty_labels_with_filter", map[string]string{}, []string{"env=prod"}, false},
+		{"exact_match", map[string]string{"env": "prod"}, []string{"env=prod"}, true},
+		{"no_match_value", map[string]string{"env": "dev"}, []string{"env=prod"}, false},
+		{"no_match_key", map[string]string{"team": "backend"}, []string{"env=prod"}, false},
+		{"multiple_filters_all_match", map[string]string{"env": "prod", "team": "be"}, []string{"env=prod", "team=be"}, true},
+		{"multiple_filters_partial", map[string]string{"env": "prod"}, []string{"env=prod", "team=be"}, false},
+		{"bare_key_exists", map[string]string{"env": "prod"}, []string{"env"}, true},
+		{"bare_key_missing", map[string]string{"team": "be"}, []string{"env"}, false},
+		{"bare_key_empty_value", map[string]string{"env": ""}, []string{"env"}, true},
+		{"empty_value_filter", map[string]string{"env": ""}, []string{"env="}, true},
+		{"empty_value_no_match", map[string]string{"env": "prod"}, []string{"env="}, false},
+		{"extra_labels_ok", map[string]string{"env": "prod", "team": "be", "x": "y"}, []string{"env=prod"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchLabels(tt.labels, tt.filters))
+		})
+	}
+}
+
+func TestGenerateLabelQuery(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   string
+	}{
+		{"empty", nil, ""},
+		{"empty_slice", []string{}, ""},
+		{"single", []string{"env=prod"}, "label=env%3Dprod"},
+		{"multiple", []string{"env=prod", "team=be"}, "label=env%3Dprod&label=team%3Dbe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, generateLabelQuery(tt.labels).Encode())
+		})
+	}
+}

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -53,20 +53,21 @@ type VolumeResponse struct {
 }
 
 type VolumeDetailResponse struct {
-	Name         string     `json:"name"`
-	Path         string     `json:"path"`
-	SizeBytes    uint64     `json:"size_bytes"`
-	NoCOW        bool       `json:"nocow"`
-	Compression  string     `json:"compression"`
-	QuotaBytes   uint64     `json:"quota_bytes"`
-	UsedBytes    uint64     `json:"used_bytes"`
-	UID          int        `json:"uid"`
-	GID          int        `json:"gid"`
-	Mode         string     `json:"mode"`
-	Clients      []string   `json:"clients"`
-	CreatedAt    time.Time  `json:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at"`
-	LastAttachAt *time.Time `json:"last_attach_at,omitempty"`
+	Name         string            `json:"name"`
+	Path         string            `json:"path"`
+	SizeBytes    uint64            `json:"size_bytes"`
+	NoCOW        bool              `json:"nocow"`
+	Compression  string            `json:"compression"`
+	QuotaBytes   uint64            `json:"quota_bytes"`
+	UsedBytes    uint64            `json:"used_bytes"`
+	UID          int               `json:"uid"`
+	GID          int               `json:"gid"`
+	Mode         string            `json:"mode"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	Clients      []string          `json:"clients"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+	LastAttachAt *time.Time        `json:"last_attach_at,omitempty"`
 }
 
 type VolumeListResponse struct {
@@ -88,15 +89,16 @@ type SnapshotResponse struct {
 }
 
 type SnapshotDetailResponse struct {
-	Name           string    `json:"name"`
-	Volume         string    `json:"volume"`
-	Path           string    `json:"path"`
-	SizeBytes      uint64    `json:"size_bytes"`
-	UsedBytes      uint64    `json:"used_bytes"`
-	ExclusiveBytes uint64    `json:"exclusive_bytes"`
-	ReadOnly       bool      `json:"readonly"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	Name           string            `json:"name"`
+	Volume         string            `json:"volume"`
+	Path           string            `json:"path"`
+	SizeBytes      uint64            `json:"size_bytes"`
+	UsedBytes      uint64            `json:"used_bytes"`
+	ExclusiveBytes uint64            `json:"exclusive_bytes"`
+	ReadOnly       bool              `json:"readonly"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
 }
 
 type SnapshotListResponse struct {
@@ -110,10 +112,11 @@ type SnapshotDetailListResponse struct {
 }
 
 type CloneResponse struct {
-	Name           string    `json:"name"`
-	SourceSnapshot string    `json:"source_snapshot"`
-	Path           string    `json:"path"`
-	CreatedAt      time.Time `json:"created_at"`
+	Name           string            `json:"name"`
+	SourceSnapshot string            `json:"source_snapshot"`
+	Path           string            `json:"path"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
 }
 
 type ExportListResponse struct {
@@ -183,6 +186,7 @@ type FilesystemStatsResponse struct {
 type TaskCreateRequest struct {
 	Timeout string            `json:"timeout,omitempty"`
 	Opts    map[string]string `json:"opts,omitempty"`
+	Labels  map[string]string `json:"labels,omitempty"`
 }
 
 type TaskCreateResponse struct {
@@ -209,6 +213,7 @@ type TaskDetailResponse struct {
 	Status      string            `json:"status"`
 	Progress    int               `json:"progress"`
 	Opts        map[string]string `json:"opts,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	Timeout     string            `json:"timeout,omitempty"`
 	Result      json.RawMessage   `json:"result,omitempty"`
 	Error       string            `json:"error,omitempty"`

--- a/agent/api/v1/task.go
+++ b/agent/api/v1/task.go
@@ -35,6 +35,7 @@ func taskDetailResponseFrom(t *task.Task) TaskDetailResponse {
 		Status:      string(t.Status),
 		Progress:    t.Progress,
 		Opts:        t.Opts,
+		Labels:      t.Labels,
 		Timeout:     formatTimeout(t.Timeout),
 		Result:      t.Result,
 		Error:       t.Error,

--- a/agent/api/v1/task_test.go
+++ b/agent/api/v1/task_test.go
@@ -79,3 +79,20 @@ func TestTaskDetailResponseFrom(t *testing.T) {
 	assert.Equal(t, map[string]string{"key": "val"}, resp.Opts)
 	assert.Equal(t, "6h0m0s", resp.Timeout)
 }
+
+func TestTaskDetailResponseFrom_WithLabels(t *testing.T) {
+	labels := map[string]string{"created-by": "cli", "env": "prod"}
+	tk := &task.Task{
+		ID:        "abc",
+		Type:      "test",
+		Status:    task.TaskCompleted,
+		Labels:    labels,
+		CreatedAt: time.Now(),
+	}
+
+	detail := taskDetailResponseFrom(tk)
+	assert.Equal(t, labels, detail.Labels)
+
+	summary := taskResponseFrom(tk)
+	assert.Nil(t, summary.Opts)
+}

--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -25,6 +25,9 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 	if err := validateName(req.Snapshot); err != nil {
 		return nil, err
 	}
+	if err := validateLabels(req.Labels); err != nil {
+		return nil, err
+	}
 	snapDir := filepath.Join(bp, config.SnapshotsDir, req.Snapshot)
 	srcData := filepath.Join(snapDir, config.DataDir)
 	if _, err := os.Stat(srcData); os.IsNotExist(err) {
@@ -52,11 +55,20 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 		return nil, fmt.Errorf("btrfs snapshot failed: %w", err)
 	}
 
+	labels := req.Labels
+	if labels == nil {
+		var snapMeta SnapshotMetadata
+		if err := ReadMetadata(filepath.Join(snapDir, config.MetadataFile), &snapMeta); err == nil {
+			labels = snapMeta.Labels
+		}
+	}
+
 	now := time.Now().UTC()
 	meta := CloneMetadata{
 		Name:           req.Name,
 		SourceSnapshot: req.Snapshot,
 		Path:           cloneDir,
+		Labels:         labels,
 		CreatedAt:      now,
 	}
 

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -5,77 +5,89 @@ import "time"
 // Persisted metadata types
 
 type VolumeMetadata struct {
-	Name         string     `json:"name"`
-	Path         string     `json:"path"`
-	SizeBytes    uint64     `json:"size_bytes"`
-	NoCOW        bool       `json:"nocow"`
-	Compression  string     `json:"compression"`
-	QuotaBytes   uint64     `json:"quota_bytes"`
-	UsedBytes    uint64     `json:"used_bytes"`
-	UID          int        `json:"uid"`
-	GID          int        `json:"gid"`
-	Mode         string     `json:"mode"`
-	Clients      []string   `json:"clients,omitempty"`
-	CreatedAt    time.Time  `json:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at"`
-	LastAttachAt *time.Time `json:"last_attach_at,omitempty"`
+	Name         string            `json:"name"`
+	Path         string            `json:"path"`
+	SizeBytes    uint64            `json:"size_bytes"`
+	NoCOW        bool              `json:"nocow"`
+	Compression  string            `json:"compression"`
+	QuotaBytes   uint64            `json:"quota_bytes"`
+	UsedBytes    uint64            `json:"used_bytes"`
+	UID          int               `json:"uid"`
+	GID          int               `json:"gid"`
+	Mode         string            `json:"mode"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	Clients      []string          `json:"clients,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+	LastAttachAt *time.Time        `json:"last_attach_at,omitempty"`
 }
 
 type SnapshotMetadata struct {
-	Name           string    `json:"name"`
-	Volume         string    `json:"volume"`
-	Path           string    `json:"path"`
-	SizeBytes      uint64    `json:"size_bytes"`
-	UsedBytes      uint64    `json:"used_bytes"`
-	ExclusiveBytes uint64    `json:"exclusive_bytes"`
-	ReadOnly       bool      `json:"readonly"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	Name           string            `json:"name"`
+	Volume         string            `json:"volume"`
+	Path           string            `json:"path"`
+	SizeBytes      uint64            `json:"size_bytes"`
+	UsedBytes      uint64            `json:"used_bytes"`
+	ExclusiveBytes uint64            `json:"exclusive_bytes"`
+	ReadOnly       bool              `json:"readonly"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
 }
 
 type CloneMetadata struct {
-	Name           string    `json:"name"`
-	SourceSnapshot string    `json:"source_snapshot"`
-	Path           string    `json:"path"`
-	CreatedAt      time.Time `json:"created_at"`
+	Name           string            `json:"name"`
+	SourceSnapshot string            `json:"source_snapshot"`
+	Path           string            `json:"path"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
 }
 
 // Request types
 
 type VolumeCreateRequest struct {
-	Name        string `json:"name"`
-	SizeBytes   uint64 `json:"size_bytes"`
-	NoCOW       bool   `json:"nocow"`
-	Compression string `json:"compression"`
-	QuotaBytes  uint64 `json:"quota_bytes"`
-	UID         int    `json:"uid"`
-	GID         int    `json:"gid"`
-	Mode        string `json:"mode"`
+	Name        string            `json:"name"`
+	SizeBytes   uint64            `json:"size_bytes"`
+	NoCOW       bool              `json:"nocow"`
+	Compression string            `json:"compression"`
+	QuotaBytes  uint64            `json:"quota_bytes"`
+	UID         int               `json:"uid"`
+	GID         int               `json:"gid"`
+	Mode        string            `json:"mode"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 type VolumeUpdateRequest struct {
-	SizeBytes   *uint64 `json:"size_bytes,omitempty"`
-	NoCOW       *bool   `json:"nocow,omitempty"`
-	Compression *string `json:"compression,omitempty"`
-	UID         *int    `json:"uid,omitempty"`
-	GID         *int    `json:"gid,omitempty"`
-	Mode        *string `json:"mode,omitempty"`
+	SizeBytes   *uint64            `json:"size_bytes,omitempty"`
+	NoCOW       *bool              `json:"nocow,omitempty"`
+	Compression *string            `json:"compression,omitempty"`
+	UID         *int               `json:"uid,omitempty"`
+	GID         *int               `json:"gid,omitempty"`
+	Mode        *string            `json:"mode,omitempty"`
+	Labels      *map[string]string `json:"labels,omitempty"`
 }
 
 type SnapshotCreateRequest struct {
-	Volume string `json:"volume"`
-	Name   string `json:"name"`
+	Volume string            `json:"volume"`
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type CloneCreateRequest struct {
-	Snapshot string `json:"snapshot"`
-	Name     string `json:"name"`
+	Snapshot string            `json:"snapshot"`
+	Name     string            `json:"name"`
+	Labels   map[string]string `json:"labels,omitempty"`
 }
 
 type VolumeCloneRequest struct {
-	Source string `json:"source"`
-	Name   string `json:"name"`
+	Source string            `json:"source"`
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
+
+func (m VolumeMetadata) GetLabels() map[string]string  { return m.Labels }
+func (m SnapshotMetadata) GetLabels() map[string]string { return m.Labels }
+func (m CloneMetadata) GetLabels() map[string]string    { return m.Labels }
 
 type ExportEntry struct {
 	Path   string `json:"path"`

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -85,7 +85,7 @@ type VolumeCloneRequest struct {
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
-func (m VolumeMetadata) GetLabels() map[string]string  { return m.Labels }
+func (m VolumeMetadata) GetLabels() map[string]string   { return m.Labels }
 func (m SnapshotMetadata) GetLabels() map[string]string { return m.Labels }
 func (m CloneMetadata) GetLabels() map[string]string    { return m.Labels }
 

--- a/agent/storage/scrub.go
+++ b/agent/storage/scrub.go
@@ -10,7 +10,7 @@ import (
 )
 
 // StartScrub starts a btrfs scrub as a background task and returns the task ID.
-func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, timeout time.Duration) (string, error) {
+func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
 	for _, t := range s.tasks.List(string(task.TypeScrub)) {
 		if t.Status == task.TaskRunning || t.Status == task.TaskPending {
 			return "", &StorageError{Code: ErrBusy, Message: "scrub already running"}
@@ -21,11 +21,15 @@ func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, timeou
 		return "", &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
 	}
 
+	if err := validateLabels(labels); err != nil {
+		return "", err
+	}
+
 	t := s.taskScrubTimeout
 	if timeout > 0 {
 		t = timeout
 	}
-	id := s.tasks.Create(string(task.TypeScrub), task.TaskOpts{Opts: opts, Timeout: t}, func(ctx context.Context, update *task.Update) error {
+	id := s.tasks.Create(string(task.TypeScrub), task.TaskOpts{Opts: opts, Labels: labels, Timeout: t}, func(ctx context.Context, update *task.Update) error {
 		return s.runScrub(ctx, update)
 	})
 

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -25,6 +25,9 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	if err := validateName(req.Volume); err != nil {
 		return nil, err
 	}
+	if err := validateLabels(req.Labels); err != nil {
+		return nil, err
+	}
 	volDir := filepath.Join(bp, req.Volume)
 	srcData := filepath.Join(volDir, config.DataDir)
 	if _, err := os.Stat(srcData); os.IsNotExist(err) {
@@ -60,6 +63,7 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 		Path:      filepath.Join(filepath.Dir(volMeta.Path), config.SnapshotsDir, req.Name),
 		SizeBytes: volMeta.SizeBytes,
 		ReadOnly:  true,
+		Labels:    req.Labels,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -396,7 +396,7 @@ func (s *StorageIntegrationSuite) TestStartScrub() {
 	s.Require().NoError(err)
 
 	// start scrub via storage layer
-	taskID, err := s.storage.StartScrub(s.ctx, nil, 0)
+	taskID, err := s.storage.StartScrub(s.ctx, nil, nil, 0)
 	s.Require().NoError(err)
 	s.Assert().NotEmpty(taskID)
 
@@ -427,7 +427,7 @@ func (s *StorageIntegrationSuite) TestStartScrubDuplicate() {
 	<-started
 
 	// second scrub should be rejected
-	_, err := s.storage.StartScrub(s.ctx, nil, 0)
+	_, err := s.storage.StartScrub(s.ctx, nil, nil, 0)
 	s.Require().Error(err)
 	var se *StorageError
 	s.Require().ErrorAs(err, &se)
@@ -505,7 +505,7 @@ func (s *StorageIntegrationSuite) TestTaskCleanupRemovesFiles() {
 
 func (s *StorageIntegrationSuite) TestScrubOnEmptyFilesystem() {
 	// no volumes, no data -- scrub should still work
-	taskID, err := s.storage.StartScrub(s.ctx, nil, 0)
+	taskID, err := s.storage.StartScrub(s.ctx, nil, nil, 0)
 	s.Require().NoError(err)
 
 	for i := 0; i < 30; i++ {
@@ -541,7 +541,7 @@ func (s *StorageIntegrationSuite) TestScrubRestartRecovery() {
 
 	// should be able to start a new scrub (stale one doesn't block)
 	s.storage.tasks = tm
-	newID, err := s.storage.StartScrub(s.ctx, nil, 0)
+	newID, err := s.storage.StartScrub(s.ctx, nil, nil, 0)
 	s.Require().NoError(err)
 	s.Assert().NotEmpty(newID)
 

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -57,6 +57,7 @@ func (tm *Manager) Create(taskType string, opts TaskOpts, fn TaskFunc) string {
 		Type:      taskType,
 		Status:    TaskPending,
 		Opts:      opts.Opts,
+		Labels:    opts.Labels,
 		Timeout:   opts.Timeout,
 		CreatedAt: now,
 	}

--- a/agent/storage/task/manager_test.go
+++ b/agent/storage/task/manager_test.go
@@ -551,6 +551,39 @@ func TestManager_CreateWithOpts(t *testing.T) {
 	assert.Equal(t, "5s", tsk.Opts["sleep"])
 }
 
+func TestManager_CreateWithLabels(t *testing.T) {
+	dir := t.TempDir()
+	tm := NewManager(dir, 0, 0)
+
+	labels := map[string]string{"env": "prod", "team": "storage"}
+	id := tm.Create("test", TaskOpts{
+		Labels: labels,
+	}, func(ctx context.Context, update *Update) error {
+		return nil
+	})
+
+	tsk := awaitStatus(t, tm, id, TaskCompleted)
+	assert.Equal(t, labels, tsk.Labels)
+
+	// verify persisted to disk
+	data, err := os.ReadFile(filepath.Join(dir, id+".json"))
+	require.NoError(t, err)
+	var ondisk Task
+	require.NoError(t, json.Unmarshal(data, &ondisk))
+	assert.Equal(t, labels, ondisk.Labels)
+}
+
+func TestManager_CreateWithoutLabels(t *testing.T) {
+	tm := NewManager(t.TempDir(), 0, 0)
+
+	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
+		return nil
+	})
+
+	tsk := awaitStatus(t, tm, id, TaskCompleted)
+	assert.Nil(t, tsk.Labels)
+}
+
 func TestManager_Timeout(t *testing.T) {
 	tm := NewManager(t.TempDir(), 0, 0)
 

--- a/agent/storage/task/model.go
+++ b/agent/storage/task/model.go
@@ -38,6 +38,7 @@ type Task struct {
 	Status      TaskStatus        `json:"status"`
 	Progress    int               `json:"progress"`
 	Opts        map[string]string `json:"opts,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	Timeout     time.Duration     `json:"timeout,omitempty"`
 	Result      json.RawMessage   `json:"result,omitempty"`
 	Error       string            `json:"error,omitempty"`
@@ -46,9 +47,12 @@ type Task struct {
 	CompletedAt *time.Time        `json:"completed_at,omitempty"`
 }
 
+func (t Task) GetLabels() map[string]string { return t.Labels }
+
 // TaskOpts configures a new task.
 type TaskOpts struct {
 	Opts    map[string]string
+	Labels  map[string]string
 	Timeout time.Duration
 }
 

--- a/agent/storage/testtask.go
+++ b/agent/storage/testtask.go
@@ -9,7 +9,7 @@ import (
 )
 
 // StartTestTask creates a test task that sleeps for the given duration and returns "Hallo Welt".
-func (s *Storage) StartTestTask(ctx context.Context, opts map[string]string, timeout time.Duration) (string, error) {
+func (s *Storage) StartTestTask(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
 	var sleep time.Duration
 	if v := opts["sleep"]; v != "" {
 		var err error
@@ -19,11 +19,15 @@ func (s *Storage) StartTestTask(ctx context.Context, opts map[string]string, tim
 		}
 	}
 
+	if err := validateLabels(labels); err != nil {
+		return "", err
+	}
+
 	t := s.taskDefaultTimeout
 	if timeout > 0 {
 		t = timeout
 	}
-	id := s.tasks.Create(string(task.TypeTest), task.TaskOpts{Opts: opts, Timeout: t}, func(ctx context.Context, update *task.Update) error {
+	id := s.tasks.Create(string(task.TypeTest), task.TaskOpts{Opts: opts, Labels: labels, Timeout: t}, func(ctx context.Context, update *task.Update) error {
 		if sleep > 0 {
 			log.Debug().Dur("sleep", sleep).Msg("test task sleeping")
 			start := time.Now()

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -3,7 +3,8 @@ package storage
 import (
 	"fmt"
 	"os"
-	"regexp"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 )
 
 // --- Error types ---
@@ -25,11 +26,24 @@ func (e *StorageError) Error() string { return e.Message }
 
 // --- Validation ---
 
-var validName = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
-
 func validateName(name string) error {
-	if !validName.MatchString(name) {
+	if !config.ValidName.MatchString(name) {
 		return &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("invalid name: %q (must be 1-128 chars, only a-z A-Z 0-9 _ -)", name)}
+	}
+	return nil
+}
+
+func validateLabels(labels map[string]string) error {
+	if len(labels) > config.MaxLabels {
+		return &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("too many labels: %d (max %d)", len(labels), config.MaxLabels)}
+	}
+	for k, v := range labels {
+		if !config.ValidLabelKey.MatchString(k) {
+			return &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("invalid label key: %q", k)}
+		}
+		if !config.ValidLabelVal.MatchString(v) {
+			return &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("invalid label value: %q", v)}
+		}
 	}
 	return nil
 }

--- a/agent/storage/utils_test.go
+++ b/agent/storage/utils_test.go
@@ -132,6 +132,46 @@ func TestValidateName(t *testing.T) {
 	}
 }
 
+func TestValidateLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		wantErr bool
+	}{
+		{"nil", nil, false},
+		{"empty", map[string]string{}, false},
+		{"valid_single", map[string]string{"env": "prod"}, false},
+		{"valid_multiple", map[string]string{"env": "prod", "team": "backend"}, false},
+		{"valid_dots_dashes", map[string]string{"app.kubernetes.io": "my-app"}, false},
+		{"empty_value", map[string]string{"env": ""}, false},
+		{"too_many", map[string]string{
+			"a": "1", "b": "2", "c": "3", "d": "4",
+			"e": "5", "f": "6", "g": "7", "h": "8",
+			"i": "9", "j": "10", "k": "11", "l": "12",
+			"m": "13",
+		}, true},
+		{"key_uppercase", map[string]string{"Env": "prod"}, true},
+		{"key_starts_with_dash", map[string]string{"-env": "prod"}, true},
+		{"key_empty", map[string]string{"": "prod"}, true},
+		{"key_too_long", map[string]string{strings.Repeat("a", 64): "v"}, true},
+		{"value_has_slash", map[string]string{"env": "a/b"}, true},
+		{"value_has_comma", map[string]string{"env": "a,b"}, true},
+		{"value_has_space", map[string]string{"env": "a b"}, true},
+		{"value_too_long", map[string]string{"env": strings.Repeat("x", 129)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLabels(tt.labels)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			requireStorageError(t, err, ErrInvalid)
+		})
+	}
+}
+
 func TestFileMode(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -36,6 +36,9 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 	if req.QuotaBytes == 0 {
 		req.QuotaBytes = req.SizeBytes
 	}
+	if err := validateLabels(req.Labels); err != nil {
+		return nil, err
+	}
 	if req.Mode == "" {
 		req.Mode = s.defaultDataMode
 	}
@@ -118,6 +121,7 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 		UID:         req.UID,
 		GID:         req.GID,
 		Mode:        req.Mode,
+		Labels:      req.Labels,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -202,6 +206,11 @@ func (s *Storage) UpdateVolume(ctx context.Context, tenant, name string, req Vol
 	}
 
 	// validation
+	if req.Labels != nil {
+		if err := validateLabels(*req.Labels); err != nil {
+			return nil, err
+		}
+	}
 	if req.SizeBytes != nil && *req.SizeBytes <= cur.SizeBytes {
 		return nil, &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("new size %d must be larger than current size %d", *req.SizeBytes, cur.SizeBytes)}
 	}
@@ -290,6 +299,9 @@ func (s *Storage) UpdateVolume(ctx context.Context, tenant, name string, req Vol
 		if req.Mode != nil {
 			meta.Mode = *req.Mode
 		}
+		if req.Labels != nil {
+			meta.Labels = *req.Labels
+		}
 		meta.UpdatedAt = time.Now().UTC()
 		updated = *meta
 	}); err != nil {
@@ -307,6 +319,10 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 		return nil, err
 	}
 	if err := validateName(req.Name); err != nil {
+		return nil, err
+	}
+
+	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
 
@@ -353,6 +369,11 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 		}
 	}
 
+	labels := req.Labels
+	if labels == nil {
+		labels = src.Labels
+	}
+
 	now := time.Now().UTC()
 	meta := VolumeMetadata{
 		Name:        req.Name,
@@ -364,6 +385,7 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 		UID:         src.UID,
 		GID:         src.GID,
 		Mode:        src.Mode,
+		Labels:      labels,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/agent/storage/volume_test.go
+++ b/agent/storage/volume_test.go
@@ -55,6 +55,30 @@ func TestCreateVolume(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid_labels", func(t *testing.T) {
+		s, _, _, _ := newTestStorage(t)
+		_, err := s.CreateVolume(ctx, "test", VolumeCreateRequest{
+			Name: "vol", SizeBytes: 1024,
+			Labels: map[string]string{"BAD": "val"},
+		})
+		requireStorageError(t, err, ErrInvalid)
+	})
+
+	t.Run("success_with_labels", func(t *testing.T) {
+		s, bp, _, _ := newTestStorage(t)
+
+		labels := map[string]string{"env": "prod", "team": "backend"}
+		meta, err := s.CreateVolume(ctx, "test", VolumeCreateRequest{
+			Name: "labelvol", SizeBytes: 1024,
+			Labels: labels,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, labels, meta.Labels)
+
+		ondisk := readVolumeMeta(t, filepath.Join(bp, "labelvol"))
+		assert.Equal(t, labels, ondisk.Labels)
+	})
+
 	t.Run("nocow_with_compression_none_allowed", func(t *testing.T) {
 		s, _, _, _ := newTestStorage(t)
 
@@ -464,6 +488,44 @@ func TestUpdateVolume(t *testing.T) {
 		info, err := os.Stat(dataDir)
 		require.NoError(t, err, "Stat data dir")
 		assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "permissions should be updated")
+	})
+
+	t.Run("update_labels", func(t *testing.T) {
+		s, bp, _, _ := newTestStorage(t)
+		setupVol(t, bp, "vol", VolumeMetadata{Name: "vol", SizeBytes: 1024, Labels: map[string]string{"env": "dev"}})
+
+		newLabels := map[string]string{"env": "prod", "team": "platform"}
+		meta, err := s.UpdateVolume(ctx, "test", "vol", VolumeUpdateRequest{
+			Labels: &newLabels,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, newLabels, meta.Labels)
+
+		ondisk := readVolumeMeta(t, filepath.Join(bp, "vol"))
+		assert.Equal(t, newLabels, ondisk.Labels)
+	})
+
+	t.Run("update_labels_invalid", func(t *testing.T) {
+		s, bp, _, _ := newTestStorage(t)
+		setupVol(t, bp, "vol", VolumeMetadata{Name: "vol", SizeBytes: 1024})
+
+		bad := map[string]string{"BAD KEY": "val"}
+		_, err := s.UpdateVolume(ctx, "test", "vol", VolumeUpdateRequest{
+			Labels: &bad,
+		})
+		requireStorageError(t, err, ErrInvalid)
+	})
+
+	t.Run("update_labels_clear", func(t *testing.T) {
+		s, bp, _, _ := newTestStorage(t)
+		setupVol(t, bp, "vol", VolumeMetadata{Name: "vol", SizeBytes: 1024, Labels: map[string]string{"env": "dev"}})
+
+		empty := map[string]string{}
+		meta, err := s.UpdateVolume(ctx, "test", "vol", VolumeUpdateRequest{
+			Labels: &empty,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, meta.Labels)
 	})
 
 	t.Run("qgroup_limit_fails", func(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,15 @@
 package config
 
-import "time"
+import (
+	"regexp"
+	"time"
+)
+
+var (
+	ValidName     = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
+	ValidLabelKey = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,62}$`)
+	ValidLabelVal = regexp.MustCompile(`^[a-zA-Z0-9._-]{0,128}$`)
+)
 
 const DriverName = "btrfs-nfs-csi"
 
@@ -19,6 +28,12 @@ const (
 	ParamUID         = "uid"
 	ParamGID         = "gid"
 	ParamMode        = "mode"
+	ParamLabels   = "labels"
+	MaxUserLabels = 4
+
+	// MaxLabels caps total labels per resource, trying to keep metadata JSON below 4KB (one filesystem block).
+	// Worst case: 12 * (63 + 128 + 6) = ~2.4KB labels + ~500B other fields = ~2.9KB.
+	MaxLabels = 12
 
 	ParamNFSServer       = "nfsServer"
 	ParamNFSMountOptions = "nfsMountOptions"
@@ -63,8 +78,9 @@ type AgentConfig struct {
 }
 
 type ControllerConfig struct {
-	Endpoint    string `env:"DRIVER_ENDPOINT" envDefault:"unix:///csi/csi.sock"`
-	MetricsAddr string `env:"DRIVER_METRICS_ADDR" envDefault:":9090"`
+	Endpoint      string `env:"DRIVER_ENDPOINT" envDefault:"unix:///csi/csi.sock"`
+	MetricsAddr   string `env:"DRIVER_METRICS_ADDR" envDefault:":9090"`
+	DefaultLabels string `env:"DRIVER_DEFAULT_LABELS"`
 }
 
 type NodeConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -28,8 +28,8 @@ const (
 	ParamUID         = "uid"
 	ParamGID         = "gid"
 	ParamMode        = "mode"
-	ParamLabels   = "labels"
-	MaxUserLabels = 4
+	ParamLabels      = "labels"
+	MaxUserLabels    = 4
 
 	// MaxLabels caps total labels per resource, trying to keep metadata JSON below 4KB (one filesystem block).
 	// Worst case: 12 * (63 + 128 + 6) = ~2.4KB labels + ~500B other fields = ~2.9KB.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -10,7 +10,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func Start(ctx context.Context, endpoint, metricsAddr, version, commit string) error {
+func Start(ctx context.Context, endpoint, metricsAddr, version, commit, defaultLabels string) error {
+	initDefaultLabels(defaultLabels)
 	startMetricsServer(metricsAddr)
 
 	agents := NewAgentTracker(version, commit)

--- a/controller/pvc.go
+++ b/controller/pvc.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
+	"strings"
 
 	agentAPI "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
@@ -13,6 +15,30 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var envDefaultLabels map[string]string
+
+func initDefaultLabels(raw string) {
+	if raw == "" {
+		return
+	}
+	parsed := parseLabels(raw)
+	envDefaultLabels = make(map[string]string, len(parsed))
+	for k, v := range parsed {
+		if reservedLabelKeys[k] {
+			log.Warn().Str("key", k).Msg("ignoring reserved key in DRIVER_DEFAULT_LABELS")
+			continue
+		}
+		if !config.ValidLabelKey.MatchString(k) || !config.ValidLabelVal.MatchString(v) {
+			log.Warn().Str("key", k).Str("value", v).Msg("ignoring invalid label in DRIVER_DEFAULT_LABELS")
+			continue
+		}
+		envDefaultLabels[k] = v
+	}
+	if len(envDefaultLabels) > 0 {
+		log.Info().Int("count", len(envDefaultLabels)).Msg("loaded default labels from env")
+	}
+}
+
 type volumeParams struct {
 	StorageClass string
 	NoCOW        string
@@ -20,6 +46,7 @@ type volumeParams struct {
 	UID          string
 	GID          string
 	Mode         string
+	Labels       map[string]string
 }
 
 func resolveVolumeParams(ctx context.Context, params map[string]string) volumeParams {
@@ -54,6 +81,17 @@ func resolveVolumeParams(ctx context.Context, params map[string]string) volumePa
 	ctrlK8sOpsTotal.WithLabelValues("success").Inc()
 
 	vp.StorageClass = obj.Spec.StorageClassName
+	vp.Labels = map[string]string{
+		"kubernetes.pvc.name":         pvcName,
+		"kubernetes.pvc.namespace":    pvcNamespace,
+		"kubernetes.pvc.storageclass": obj.Spec.StorageClassName,
+		"created-by":                  "csi",
+	}
+	for k, v := range envDefaultLabels {
+		if _, exists := vp.Labels[k]; !exists {
+			vp.Labels[k] = v
+		}
+	}
 
 	annos := obj.Metadata.Annotations
 	if v, ok := annos[config.AnnoPrefix+config.ParamNoCOW]; ok {
@@ -71,8 +109,52 @@ func resolveVolumeParams(ctx context.Context, params map[string]string) volumePa
 	if v, ok := annos[config.AnnoPrefix+config.ParamMode]; ok {
 		vp.Mode = v
 	}
+	if v, ok := annos[config.AnnoPrefix+config.ParamLabels]; ok && v != "" {
+		mergeUserLabels(vp.Labels, parseLabels(v), config.MaxUserLabels)
+	}
 
 	return vp
+}
+
+var reservedLabelKeys = map[string]bool{
+	"kubernetes.pvc.name":         true,
+	"kubernetes.pvc.namespace":    true,
+	"kubernetes.pvc.storageclass": true,
+}
+
+func mergeUserLabels(dst, user map[string]string, maxUser int) {
+	keys := make([]string, 0, len(user))
+	for k := range user {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	merged := 0
+	for _, k := range keys {
+		if reservedLabelKeys[k] {
+			log.Warn().Str("key", k).Msg("skipping reserved label key from PVC annotation")
+			continue
+		}
+		if merged >= maxUser {
+			log.Warn().Int("max", maxUser).Msg("too many user labels in PVC annotation, truncating")
+			break
+		}
+		dst[k] = user[k]
+		merged++
+	}
+}
+
+func parseLabels(raw string) map[string]string {
+	labels := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		k, v, _ := strings.Cut(pair, "=")
+		labels[k] = v
+	}
+	return labels
 }
 
 func (vp *volumeParams) validate() error {
@@ -124,6 +206,10 @@ func (vp *volumeParams) toUpdateRequest() (agentAPI.VolumeUpdateRequest, bool) {
 	}
 	if vp.Compression != "" {
 		update.Compression = &vp.Compression
+		changed = true
+	}
+	if vp.Labels != nil {
+		update.Labels = &vp.Labels
 		changed = true
 	}
 	return update, changed

--- a/controller/pvc_test.go
+++ b/controller/pvc_test.go
@@ -83,4 +83,92 @@ func TestToUpdateRequest(t *testing.T) {
 		require.NotNil(t, req.Mode)
 		assert.Equal(t, "0750", *req.Mode)
 	})
+
+	t.Run("labels", func(t *testing.T) {
+		labels := map[string]string{"env": "prod"}
+		vp := volumeParams{Labels: labels}
+		req, changed := vp.toUpdateRequest()
+		require.True(t, changed)
+		require.NotNil(t, req.Labels)
+		assert.Equal(t, labels, *req.Labels)
+	})
+}
+
+// --- TestMergeUserLabels ---
+
+func TestMergeUserLabels(t *testing.T) {
+	t.Run("basic_merge", func(t *testing.T) {
+		dst := map[string]string{"created-by": "csi"}
+		user := map[string]string{"env": "prod", "team": "be"}
+		mergeUserLabels(dst, user, 4)
+		assert.Equal(t, "csi", dst["created-by"])
+		assert.Equal(t, "prod", dst["env"])
+		assert.Equal(t, "be", dst["team"])
+	})
+
+	t.Run("reserved_keys_skipped", func(t *testing.T) {
+		dst := map[string]string{"kubernetes.pvc.name": "my-pvc"}
+		user := map[string]string{"kubernetes.pvc.name": "hacked", "env": "prod"}
+		mergeUserLabels(dst, user, 4)
+		assert.Equal(t, "my-pvc", dst["kubernetes.pvc.name"])
+		assert.Equal(t, "prod", dst["env"])
+	})
+
+	t.Run("max_user_labels", func(t *testing.T) {
+		dst := map[string]string{}
+		user := map[string]string{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5"}
+		mergeUserLabels(dst, user, 4)
+		assert.Len(t, dst, 4)
+	})
+
+	t.Run("deterministic_truncation", func(t *testing.T) {
+		dst1 := map[string]string{}
+		dst2 := map[string]string{}
+		user := map[string]string{"z": "1", "a": "2", "m": "3", "b": "4", "x": "5"}
+		mergeUserLabels(dst1, user, 3)
+		mergeUserLabels(dst2, user, 3)
+		assert.Equal(t, dst1, dst2)
+		// alphabetically first 3: a, b, m
+		assert.Contains(t, dst1, "a")
+		assert.Contains(t, dst1, "b")
+		assert.Contains(t, dst1, "m")
+	})
+
+	t.Run("user_overrides_non_reserved", func(t *testing.T) {
+		dst := map[string]string{"created-by": "csi"}
+		user := map[string]string{"created-by": "terraform"}
+		mergeUserLabels(dst, user, 4)
+		assert.Equal(t, "terraform", dst["created-by"])
+	})
+}
+
+// --- TestInitDefaultLabels ---
+
+func TestInitDefaultLabels(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		envDefaultLabels = nil
+		initDefaultLabels("")
+		assert.Nil(t, envDefaultLabels)
+	})
+
+	t.Run("valid_labels", func(t *testing.T) {
+		envDefaultLabels = nil
+		initDefaultLabels("env=prod,team=backend")
+		assert.Equal(t, "prod", envDefaultLabels["env"])
+		assert.Equal(t, "backend", envDefaultLabels["team"])
+	})
+
+	t.Run("reserved_keys_filtered", func(t *testing.T) {
+		envDefaultLabels = nil
+		initDefaultLabels("kubernetes.pvc.name=hacked,env=prod")
+		assert.NotContains(t, envDefaultLabels, "kubernetes.pvc.name")
+		assert.Equal(t, "prod", envDefaultLabels["env"])
+	})
+
+	t.Run("invalid_labels_filtered", func(t *testing.T) {
+		envDefaultLabels = nil
+		initDefaultLabels("BADKEY=val,env=prod")
+		assert.NotContains(t, envDefaultLabels, "BADKEY")
+		assert.Equal(t, "prod", envDefaultLabels["env"])
+	})
 }

--- a/controller/volumes.go
+++ b/controller/volumes.go
@@ -115,6 +115,7 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			cloneResp, err := client.CloneVolume(ctx, agentAPI.VolumeCloneRequest{
 				Source: srcName,
 				Name:   req.Name,
+				Labels: vp.Labels,
 			})
 			agentDuration.WithLabelValues("clone_volume", sc).Observe(time.Since(start).Seconds())
 			if err != nil {
@@ -160,6 +161,7 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		cloneResp, err := client.CreateClone(ctx, agentAPI.CloneCreateRequest{
 			Snapshot: snapName,
 			Name:     req.Name,
+			Labels:   vp.Labels,
 		})
 		agentDuration.WithLabelValues("create_clone", sc).Observe(time.Since(start).Seconds())
 		if err != nil {
@@ -207,6 +209,7 @@ func (s *Server) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		UID:         uid,
 		GID:         gid,
 		Mode:        vp.Mode,
+		Labels:      vp.Labels,
 	})
 	agentDuration.WithLabelValues("create_volume", sc).Observe(time.Since(start).Seconds())
 	if err != nil {

--- a/ctl/snapshot.go
+++ b/ctl/snapshot.go
@@ -16,11 +16,12 @@ func snapshotCloneCmd() *cli.Command {
 		Name:      "clone",
 		Usage:     "create writable clone from snapshot",
 		ArgsUsage: "<snapshot> <name>",
+		Flags:     []cli.Flag{labelFlag()},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() < 2 {
 				return fmt.Errorf("usage: snapshot clone <snapshot> <name>")
 			}
-			resp, err := clientFrom(cmd).CreateClone(ctx, v1.CloneCreateRequest{Snapshot: cmd.Args().Get(0), Name: cmd.Args().Get(1)})
+			resp, err := clientFrom(cmd).CreateClone(ctx, v1.CloneCreateRequest{Snapshot: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
 			if err != nil {
 				return wrapErr(err, "clone", cmd.Args().Get(1))
 			}
@@ -40,7 +41,7 @@ func snapshotCmd() *cli.Command {
 				Aliases:   []string{"ls"},
 				Usage:     "list snapshots (optionally filter by volume)",
 				ArgsUsage: "[volume]",
-				Flags:     []cli.Flag{sortFlag(), ascFlag()},
+				Flags:     []cli.Flag{sortFlag(), ascFlag(), labelFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					c := clientFrom(cmd)
 					sortBy := cmd.String("sort")
@@ -49,13 +50,14 @@ func snapshotCmd() *cli.Command {
 					}
 					rev := !cmd.Bool("asc")
 					vol := cmd.Args().First()
+					labels := cmd.StringSlice("label")
 					if isWide(cmd) {
 						var resp *v1.SnapshotDetailListResponse
 						var err error
 						if vol != "" {
-							resp, err = c.ListVolumeSnapshotsDetail(ctx, vol)
+							resp, err = c.ListVolumeSnapshotsDetail(ctx, vol, labels...)
 						} else {
-							resp, err = c.ListSnapshotsDetail(ctx)
+							resp, err = c.ListSnapshotsDetail(ctx, labels...)
 						}
 						if err != nil {
 							return err
@@ -63,11 +65,11 @@ func snapshotCmd() *cli.Command {
 						sortSnapshotsDetail(resp.Snapshots, sortBy, rev)
 						return output(cmd, resp, func() {
 							w := tab()
-							_, _ = fmt.Fprintln(w, "NAME\tVOLUME\tSIZE\tUSED\tEXCLUSIVE\tREADONLY\tCREATED")
+							_, _ = fmt.Fprintln(w, "NAME\tVOLUME\tSIZE\tUSED\tEXCLUSIVE\tREADONLY\tLABELS\tCREATED")
 							for _, s := range resp.Snapshots {
-								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%v\t%s\n",
+								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%v\t%s\t%s\n",
 									s.Name, s.Volume, utils.FormatBytes(s.SizeBytes), utils.FormatBytes(s.UsedBytes),
-									utils.FormatBytes(s.ExclusiveBytes), s.ReadOnly, s.CreatedAt.Format(timeFmt))
+									utils.FormatBytes(s.ExclusiveBytes), s.ReadOnly, formatLabelsShort(s.Labels), s.CreatedAt.Format(timeFmt))
 							}
 							_ = w.Flush()
 						})
@@ -75,9 +77,9 @@ func snapshotCmd() *cli.Command {
 					var resp *v1.SnapshotListResponse
 					var err error
 					if vol != "" {
-						resp, err = c.ListVolumeSnapshots(ctx, vol)
+						resp, err = c.ListVolumeSnapshots(ctx, vol, labels...)
 					} else {
-						resp, err = c.ListSnapshots(ctx)
+						resp, err = c.ListSnapshots(ctx, labels...)
 					}
 					if err != nil {
 						return err
@@ -114,6 +116,7 @@ func snapshotCmd() *cli.Command {
 						fmt.Printf("Used:       %s\n", utils.FormatBytes(resp.UsedBytes))
 						fmt.Printf("Exclusive:  %s\n", utils.FormatBytes(resp.ExclusiveBytes))
 						fmt.Printf("ReadOnly:   %v\n", resp.ReadOnly)
+						printLabels("Labels:", resp.Labels, 12)
 						fmt.Printf("Created:    %s\n", resp.CreatedAt.Format(timeFmt))
 						fmt.Printf("Updated:    %s\n", resp.UpdatedAt.Format(timeFmt))
 					})
@@ -123,11 +126,12 @@ func snapshotCmd() *cli.Command {
 				Name:      "create",
 				Usage:     "create a snapshot",
 				ArgsUsage: "<volume> <name>",
+				Flags:     []cli.Flag{labelFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					if cmd.NArg() < 2 {
 						return fmt.Errorf("usage: snapshot create <volume> <name>")
 					}
-					resp, err := clientFrom(cmd).CreateSnapshot(ctx, v1.SnapshotCreateRequest{Volume: cmd.Args().Get(0), Name: cmd.Args().Get(1)})
+					resp, err := clientFrom(cmd).CreateSnapshot(ctx, v1.SnapshotCreateRequest{Volume: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: labelsWithDefault(cmd, "created-by", "cli")})
 					if err != nil {
 						return wrapErr(err, "snapshot", cmd.Args().Get(1))
 					}

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -97,12 +97,14 @@ func taskCmd() *cli.Command {
 				Usage:   "list tasks",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "filter by type (e.g. scrub)"},
+					labelFlag(),
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					c := clientFrom(cmd)
 					taskType := cmd.String("type")
+					labels := cmd.StringSlice("label")
 					if isWide(cmd) {
-						resp, err := c.ListTasksDetail(ctx, taskType)
+						resp, err := c.ListTasksDetail(ctx, taskType, labels...)
 						if err != nil {
 							return err
 						}
@@ -111,7 +113,7 @@ func taskCmd() *cli.Command {
 						})
 						return output(cmd, resp, func() {
 							w := tab()
-							_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tTIMEOUT\tTOOK\tCREATED\tRESULT\tERROR")
+							_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tLABELS\tTIMEOUT\tTOOK\tCREATED\tRESULT\tERROR")
 							for _, t := range resp.Tasks {
 								took := "-"
 								if t.CompletedAt != nil {
@@ -131,13 +133,13 @@ func taskCmd() *cli.Command {
 								if t.Error != "" {
 									errMsg = t.Error
 								}
-								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\t%s\t%s\t%s\n",
-									t.ID, t.Type, t.Status, t.Progress, timeout, took, t.CreatedAt.Format(timeFmt), result, errMsg)
+								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\t%s\t%s\t%s\t%s\n",
+									t.ID, t.Type, t.Status, t.Progress, formatLabelsShort(t.Labels), timeout, took, t.CreatedAt.Format(timeFmt), result, errMsg)
 							}
 							_ = w.Flush()
 						})
 					}
-					resp, err := c.ListTasks(ctx, taskType)
+					resp, err := c.ListTasks(ctx, taskType, labels...)
 					if err != nil {
 						return err
 					}
@@ -188,6 +190,7 @@ func taskCmd() *cli.Command {
 							}
 							fmt.Printf("Opts:       %s\n", strings.Join(parts, ", "))
 						}
+						printLabels("Labels:", resp.Labels, 12)
 						if resp.Timeout != "" {
 							fmt.Printf("Timeout:    %s\n", resp.Timeout)
 						}
@@ -235,10 +238,11 @@ func taskCmd() *cli.Command {
 						Flags: []cli.Flag{
 							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
 							&cli.BoolFlag{Name: "wait", Aliases: []string{"w"}, Usage: "wait for completion"},
+							labelFlag(),
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							c := clientFrom(cmd)
-							req := v1.TaskCreateRequest{}
+							req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, "created-by", "cli")}
 							if t := cmd.Duration("timeout"); t > 0 {
 								req.Timeout = t.String()
 							}
@@ -262,10 +266,11 @@ func taskCmd() *cli.Command {
 							&cli.DurationFlag{Name: "sleep", Aliases: []string{"s"}, Usage: "sleep duration (e.g. 10s, 1m)"},
 							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
 							&cli.BoolFlag{Name: "wait", Aliases: []string{"w"}, Usage: "wait for completion"},
+							labelFlag(),
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							c := clientFrom(cmd)
-							req := v1.TaskCreateRequest{}
+							req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, "created-by", "cli")}
 							if s := cmd.Duration("sleep"); s > 0 {
 								req.Opts = map[string]string{"sleep": s.String()}
 							}

--- a/ctl/utils.go
+++ b/ctl/utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/urfave/cli/v3"
 )
 
@@ -27,6 +28,93 @@ const (
 	sortClients = "clients"
 	sortVolume  = "volume"
 )
+
+func labelFlag() cli.Flag {
+	return &cli.StringSliceFlag{Name: "label", Aliases: []string{"l"}, Usage: "label filter key=value (repeatable)"}
+}
+
+func formatLabels(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(labels))
+	for k, v := range labels {
+		parts = append(parts, k+"="+v)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+func printLabels(header string, labels map[string]string, indent int) {
+	if len(labels) == 0 {
+		fmt.Printf("%-*s%s\n", indent, header, "none")
+		return
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		if i == 0 {
+			fmt.Printf("%-*s%s=%s\n", indent, header, k, labels[k])
+		} else {
+			fmt.Printf("%-*s%s=%s\n", indent, "", k, labels[k])
+		}
+	}
+}
+
+func formatLabelsShort(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(labels))
+	if v, ok := labels["created-by"]; ok {
+		parts = append(parts, "created-by="+v)
+	}
+	rest := make([]string, 0, len(labels))
+	for k, v := range labels {
+		if k == "created-by" {
+			continue
+		}
+		rest = append(rest, k+"="+v)
+	}
+	sort.Strings(rest)
+	parts = append(parts, rest...)
+	s := strings.Join(parts, ", ")
+	if len(s) > 48 {
+		return s[:45] + "..."
+	}
+	return s
+}
+
+func parseLabelsFlag(cmd *cli.Command) map[string]string {
+	raw := cmd.StringSlice("label")
+	if len(raw) == 0 {
+		return nil
+	}
+	if len(raw) > config.MaxUserLabels {
+		_, _ = fmt.Fprintf(os.Stderr, "warning: too many labels (%d), max %d user labels allowed\n", len(raw), config.MaxUserLabels)
+		raw = raw[:config.MaxUserLabels]
+	}
+	labels := make(map[string]string, len(raw))
+	for _, pair := range raw {
+		k, v, _ := strings.Cut(pair, "=")
+		labels[k] = v
+	}
+	return labels
+}
+
+func labelsWithDefault(cmd *cli.Command, key, value string) map[string]string {
+	labels := parseLabelsFlag(cmd)
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, ok := labels[key]; !ok {
+		labels[key] = value
+	}
+	return labels
+}
 
 func sortFlag() cli.Flag {
 	return &cli.StringFlag{Name: "sort", Aliases: []string{"s"}, Usage: "sort by: name, size, used, used%, created, clients"}

--- a/ctl/utils_test.go
+++ b/ctl/utils_test.go
@@ -22,3 +22,30 @@ func TestWrapErr(t *testing.T) {
 	// Nil returns nil
 	assert.Nil(t, wrapErr(nil, "volume", "test"))
 }
+
+func TestFormatLabels(t *testing.T) {
+	assert.Equal(t, "none", formatLabels(nil))
+	assert.Equal(t, "none", formatLabels(map[string]string{}))
+	assert.Equal(t, "env=prod", formatLabels(map[string]string{"env": "prod"}))
+	assert.Equal(t, "env=prod, team=be", formatLabels(map[string]string{"team": "be", "env": "prod"}))
+}
+
+func TestFormatLabelsShort(t *testing.T) {
+	assert.Equal(t, "-", formatLabelsShort(nil))
+	assert.Equal(t, "-", formatLabelsShort(map[string]string{}))
+
+	// created-by pinned first
+	assert.Equal(t, "created-by=cli, env=prod", formatLabelsShort(map[string]string{"env": "prod", "created-by": "cli"}))
+
+	// only created-by
+	assert.Equal(t, "created-by=csi", formatLabelsShort(map[string]string{"created-by": "csi"}))
+
+	// no created-by
+	assert.Equal(t, "env=prod", formatLabelsShort(map[string]string{"env": "prod"}))
+
+	// truncation at 48 chars
+	long := map[string]string{"a": "xxxxxxxxxxxxxxxxxx", "b": "yyyyyyyyyyyyyyyyyy", "c": "zzzzzzzzzzzzzzzzzz"}
+	result := formatLabelsShort(long)
+	assert.LessOrEqual(t, len(result), 48)
+	assert.True(t, len(result) >= 3 && result[len(result)-3:] == "...")
+}

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -24,7 +24,7 @@ func volumeCmd() *cli.Command {
 				Name:    "list",
 				Aliases: []string{"ls"},
 				Usage:   "list all volumes",
-				Flags:   []cli.Flag{sortFlag(), ascFlag()},
+				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					c := clientFrom(cmd)
 					sortBy := cmd.String("sort")
@@ -32,27 +32,28 @@ func volumeCmd() *cli.Command {
 						sortBy = sortUsedPct
 					}
 					rev := !cmd.Bool("asc")
+					labels := cmd.StringSlice("label")
 
 					if isWide(cmd) {
-						resp, err := c.ListVolumesDetail(ctx)
+						resp, err := c.ListVolumesDetail(ctx, labels...)
 						if err != nil {
 							return err
 						}
 						sortVolumesDetail(resp.Volumes, sortBy, rev)
 						return output(cmd, resp, func() {
 							w := tab()
-							_, _ = fmt.Fprintln(w, "NAME\tSIZE\tUSED\tQUOTA\tCOMPRESSION\tNOCOW\tUID\tGID\tMODE\tCLIENTS\tCREATED")
+							_, _ = fmt.Fprintln(w, "NAME\tSIZE\tUSED\tQUOTA\tCOMPRESSION\tNOCOW\tUID\tGID\tMODE\tLABELS\tCLIENTS\tCREATED")
 							for _, v := range resp.Volumes {
-								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%v\t%d\t%d\t%s\t%d\t%s\n",
+								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%v\t%d\t%d\t%s\t%s\t%d\t%s\n",
 									v.Name, utils.FormatBytes(v.SizeBytes), utils.FormatBytes(v.UsedBytes), utils.FormatBytes(v.QuotaBytes),
 									v.Compression, v.NoCOW, v.UID, v.GID, v.Mode,
-									len(v.Clients), v.CreatedAt.Format(timeFmt))
+									formatLabelsShort(v.Labels), len(v.Clients), v.CreatedAt.Format(timeFmt))
 							}
 							_ = w.Flush()
 						})
 					}
 
-					resp, err := c.ListVolumes(ctx)
+					resp, err := c.ListVolumes(ctx, labels...)
 					if err != nil {
 						return err
 					}
@@ -97,6 +98,7 @@ func volumeCmd() *cli.Command {
 						fmt.Printf("UID:          %d\n", resp.UID)
 						fmt.Printf("GID:          %d\n", resp.GID)
 						fmt.Printf("Mode:         %s\n", resp.Mode)
+						printLabels("Labels:", resp.Labels, 14)
 						if len(resp.Clients) == 0 {
 							fmt.Printf("Clients:      none\n")
 						} else {
@@ -120,6 +122,7 @@ func volumeCmd() *cli.Command {
 					&cli.IntFlag{Name: "uid", Aliases: []string{"u"}, Usage: "owner UID"},
 					&cli.IntFlag{Name: "gid", Aliases: []string{"g"}, Usage: "owner GID"},
 					&cli.StringFlag{Name: "mode", Aliases: []string{"m"}, Usage: "directory mode (octal)"},
+					labelFlag(),
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					if cmd.NArg() < 2 {
@@ -144,6 +147,7 @@ func volumeCmd() *cli.Command {
 						UID:         int(cmd.Int("uid")),
 						GID:         int(cmd.Int("gid")),
 						Mode:        cmd.String("mode"),
+						Labels:      labelsWithDefault(cmd, "created-by", "cli"),
 					}
 
 					resp, err := clientFrom(cmd).CreateVolume(ctx, req)
@@ -231,12 +235,13 @@ func volumeCmd() *cli.Command {
 				Name:      "clone",
 				Usage:     "clone a volume (PVC-to-PVC)",
 				ArgsUsage: "<source> <name>",
+				Flags:     []cli.Flag{labelFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					if cmd.NArg() < 2 {
 						return fmt.Errorf("usage: volume clone <source> <name>")
 					}
 
-					resp, err := clientFrom(cmd).CloneVolume(ctx, v1.VolumeCloneRequest{Source: cmd.Args().Get(0), Name: cmd.Args().Get(1)})
+					resp, err := clientFrom(cmd).CloneVolume(ctx, v1.VolumeCloneRequest{Source: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
 					if err != nil {
 						return wrapErr(err, "volume", cmd.Args().Get(1))
 					}

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -26,6 +26,19 @@ Token resolves to tenant via `AGENT_TENANTS`. All `/v1/*` endpoints require auth
 | `METADATA_ERROR` | 500 | Volume/snapshot metadata corrupt or unreadable |
 | `INTERNAL_ERROR` | 500 | Server error |
 
+## Labels
+
+Volumes, snapshots, clones, and tasks support user-defined labels (`map[string]string`). Labels are optional on create requests and returned in detail responses.
+
+| Constraint | Rule |
+|---|---|
+| Key format | `^[a-z0-9][a-z0-9._-]{0,62}$` |
+| Value format | `^[a-zA-Z0-9._-]{0,128}$` (empty allowed) |
+| Max labels | 12 per resource |
+| Max user labels | 4 via PVC annotation or CLI `--label` |
+
+Filter with `?label=key=value` (exact match, repeatable, AND logic) or `?label=key` (key exists, any value).
+
 ## Volumes
 
 ### POST /v1/volumes
@@ -42,7 +55,8 @@ Token resolves to tenant via `AGENT_TENANTS`. All `/v1/*` endpoints require auth
   "quota_bytes": 1073741824,
   "uid": 1000,
   "gid": 1000,
-  "mode": "0750"
+  "mode": "0750",
+  "labels": {"env": "prod", "team": "backend"}
 }
 
 // Response 201
@@ -57,6 +71,7 @@ Token resolves to tenant via `AGENT_TENANTS`. All `/v1/*` endpoints require auth
   "uid": 1000,
   "gid": 1000,
   "mode": "0750",
+  "labels": {"env": "prod", "team": "backend"},
   "clients": [],
   "created_at": "2025-01-15T10:30:00Z",
   "updated_at": "2025-01-15T10:30:00Z",
@@ -73,7 +88,7 @@ curl -X POST http://10.0.0.5:8080/v1/volumes \
 
 ### GET /v1/volumes
 
-Returns a summary list. Use `GET /v1/volumes/:name` for full details, or append `?detail=true` to get full details for all volumes in a single call.
+Returns a summary list. Use `GET /v1/volumes/:name` for full details, or append `?detail=true` to get full details for all volumes in a single call. Filter by label with `?label=key=value` (exact match) or `?label=key` (key exists). Repeatable, AND logic.
 
 ```json
 {
@@ -90,7 +105,7 @@ Returns a summary list. Use `GET /v1/volumes/:name` for full details, or append 
 }
 ```
 
-With `?detail=true`, each volume includes the full detail fields (same as `GET /v1/volumes/:name`): `path`, `quota_bytes`, `compression`, `nocow`, `uid`, `gid`, `mode`, `clients` (as array), `updated_at`, `last_attach_at`.
+With `?detail=true`, each volume includes the full detail fields (same as `GET /v1/volumes/:name`): `path`, `quota_bytes`, `compression`, `nocow`, `uid`, `gid`, `mode`, `labels`, `clients` (as array), `updated_at`, `last_attach_at`.
 
 ### GET /v1/volumes/:name
 
@@ -106,6 +121,7 @@ With `?detail=true`, each volume includes the full detail fields (same as `GET /
   "uid": 1000,
   "gid": 1000,
   "mode": "0750",
+  "labels": {"env": "prod", "team": "backend"},
   "clients": ["10.1.0.50"],
   "created_at": "2025-01-15T10:30:00Z",
   "updated_at": "2025-01-15T10:30:00Z",
@@ -115,7 +131,7 @@ With `?detail=true`, each volume includes the full detail fields (same as `GET /
 
 ### PATCH /v1/volumes/:name
 
-All fields optional. `size_bytes` must be larger than current.
+All fields optional. `size_bytes` must be larger than current. `labels` replaces all labels when present.
 
 ```json
 {
@@ -124,7 +140,8 @@ All fields optional. `size_bytes` must be larger than current.
   "compression": "lzo",
   "uid": 2000,
   "gid": 2000,
-  "mode": "0755"
+  "mode": "0755",
+  "labels": {"env": "staging"}
 }
 ```
 
@@ -175,7 +192,8 @@ All fields optional. `size_bytes` must be larger than current.
 // Request
 {
   "volume": "vol-1",
-  "name": "snap-1"
+  "name": "snap-1",
+  "labels": {"env": "prod"}
 }
 
 // Response 201
@@ -187,6 +205,7 @@ All fields optional. `size_bytes` must be larger than current.
   "used_bytes": 16384,
   "exclusive_bytes": 0,
   "readonly": true,
+  "labels": {"env": "prod"},
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z"
 }
@@ -194,7 +213,7 @@ All fields optional. `size_bytes` must be larger than current.
 
 ### GET /v1/snapshots
 
-Returns a summary list of all snapshots. Use `GET /v1/snapshots/:name` for full details, or append `?detail=true` to get full details for all snapshots in a single call.
+Returns a summary list of all snapshots. Use `GET /v1/snapshots/:name` for full details, or append `?detail=true` to get full details for all snapshots in a single call. Filter by label with `?label=key=value` or `?label=key`. Repeatable, AND logic.
 
 ```json
 {
@@ -211,11 +230,11 @@ Returns a summary list of all snapshots. Use `GET /v1/snapshots/:name` for full 
 }
 ```
 
-With `?detail=true`, each snapshot includes the full detail fields (same as `GET /v1/snapshots/:name`): `path`, `exclusive_bytes`, `readonly`, `updated_at`.
+With `?detail=true`, each snapshot includes the full detail fields (same as `GET /v1/snapshots/:name`): `path`, `exclusive_bytes`, `readonly`, `labels`, `updated_at`.
 
 ### GET /v1/volumes/:name/snapshots
 
-Returns a summary list of snapshots for a specific volume. Same response format as `GET /v1/snapshots`. Also supports `?detail=true`.
+Returns a summary list of snapshots for a specific volume. Same response format as `GET /v1/snapshots`. Also supports `?detail=true` and `?label=` filtering.
 
 ### GET /v1/snapshots/:name
 
@@ -228,6 +247,7 @@ Returns a summary list of snapshots for a specific volume. Same response format 
   "used_bytes": 16384,
   "exclusive_bytes": 0,
   "readonly": true,
+  "labels": {"env": "prod"},
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z"
 }
@@ -241,13 +261,14 @@ Returns a summary list of snapshots for a specific volume. Same response format 
 
 ### POST /v1/volumes/clone
 
-Direct volume-to-volume clone via a single atomic btrfs snapshot. No intermediate snapshot needed. 409 returns existing volume.
+Direct volume-to-volume clone via a single atomic btrfs snapshot. No intermediate snapshot needed. 409 returns existing volume. If `labels` is omitted, source volume labels are inherited.
 
 ```json
 // Request
 {
   "source": "my-volume",
-  "name": "my-clone"
+  "name": "my-clone",
+  "labels": {"env": "staging"}
 }
 
 // Response 201
@@ -262,6 +283,7 @@ Direct volume-to-volume clone via a single atomic btrfs snapshot. No intermediat
   "uid": 0,
   "gid": 0,
   "mode": "2770",
+  "labels": {"env": "staging"},
   "clients": [],
   "created_at": "2025-01-15T12:30:00Z",
   "updated_at": "2025-01-15T12:30:00Z"
@@ -272,13 +294,14 @@ Direct volume-to-volume clone via a single atomic btrfs snapshot. No intermediat
 
 ### POST /v1/clones
 
-Clone from a read-only snapshot. 409 returns existing clone.
+Clone from a read-only snapshot. 409 returns existing clone. If `labels` is omitted, source snapshot labels are inherited.
 
 ```json
 // Request
 {
   "snapshot": "snap-1",
-  "name": "clone-1"
+  "name": "clone-1",
+  "labels": {"env": "dev"}
 }
 
 // Response 201
@@ -286,6 +309,7 @@ Clone from a read-only snapshot. 409 returns existing clone.
   "name": "clone-1",
   "source_snapshot": "snap-1",
   "path": "/srv/csi/default/clone-1",
+  "labels": {"env": "dev"},
   "created_at": "2025-01-15T12:30:00Z"
 }
 ```
@@ -354,11 +378,12 @@ Starts a background task. `type` is `scrub` or `test`. Returns 423 if a scrub is
 // Request (all fields optional)
 {
   "timeout": "1h",
-  "opts": {"sleep": "10s"}
+  "opts": {"sleep": "10s"},
+  "labels": {"created-by": "cron"}
 }
 ```
 
-`timeout` overrides the server default (scrub: 24h, test: 6h). `opts` is task-type-specific: scrub has no opts, test accepts `{"sleep": "10s"}`.
+`timeout` overrides the server default (scrub: 24h, test: 6h). `opts` is task-type-specific: scrub has no opts, test accepts `{"sleep": "10s"}`. `labels` are optional metadata (same rules as volume labels).
 
 ```json
 // Response 202
@@ -388,7 +413,7 @@ curl -X POST http://10.0.0.5:8080/v1/tasks/test \
 
 ### GET /v1/tasks
 
-List all tasks. Optional `?type=` filter (e.g. `scrub`, `test`). Returns a summary without the `result` field. Append `?detail=true` to include `result`.
+List all tasks. Optional `?type=` filter (e.g. `scrub`, `test`). Filter by label with `?label=key=value` or `?label=key`. Repeatable, AND logic. Returns a summary without the `result` field. Append `?detail=true` to include `result` and `labels`.
 
 ```json
 {
@@ -408,11 +433,11 @@ List all tasks. Optional `?type=` filter (e.g. `scrub`, `test`). Returns a summa
 }
 ```
 
-With `?detail=true`, each task includes `result` and `opts` fields.
+With `?detail=true`, each task includes `result`, `opts`, and `labels` fields.
 
 ### GET /v1/tasks/:id
 
-Returns a single task with full details including `result` and `opts`. 404 if not found.
+Returns a single task with full details including `result`, `opts`, and `labels`. 404 if not found.
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ Also configurable via `--agent-url` and `--agent-token` flags.
 |---|---|---|
 | `DRIVER_ENDPOINT` | `unix:///csi/csi.sock` | gRPC socket |
 | `DRIVER_METRICS_ADDR` | `:9090` | Metrics address |
+| `DRIVER_DEFAULT_LABELS` | - | Default labels for all volumes (`key=value,key=value`) |
 
 ## Node Environment Variables
 
@@ -84,8 +85,34 @@ Each StorageClass binds one agent + one tenant. The SC name is used in volume ID
 | `btrfs-nfs-csi/uid` | integer |
 | `btrfs-nfs-csi/gid` | integer |
 | `btrfs-nfs-csi/mode` | octal string |
+| `btrfs-nfs-csi/labels` | `key=value,key=value` (max 4 user labels, see below) |
 
 Annotations override StorageClass defaults. Applied at create and on every attach.
+
+### Default Labels
+
+The CSI controller automatically sets these labels on every PVC volume:
+
+| Label | Value | Reserved |
+|---|---|---|
+| `kubernetes.pvc.name` | PVC name | yes |
+| `kubernetes.pvc.namespace` | PVC namespace | yes |
+| `kubernetes.pvc.storageclass` | StorageClass name | yes |
+| `created-by` | `csi` | no (overridable) |
+
+Reserved keys cannot be overridden via PVC annotation (set by user will be skipped with a warning). This restriction only applies to the CSI controller, the agent API and CLI have no reserved keys. The `created-by` label can be overridden. Max 4 user labels via annotation (max 12 total).
+
+### Custom Default Labels
+
+Set `DRIVER_DEFAULT_LABELS` on the controller to add custom defaults to every volume:
+
+```yaml
+env:
+  - name: DRIVER_DEFAULT_LABELS
+    value: "kubernetes.cluster=my-cluster,env=prod"
+```
+
+These are merged after the built-in defaults but before user annotation labels. Reserved keys (`kubernetes.pvc.*`) are ignored. User annotation labels override env defaults on key conflict.
 
 ## Secret
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -200,6 +200,44 @@ Only one scrub can run at a time per filesystem. The agent detects externally st
 
 Completed tasks include a result with bytes scrubbed and error counts. Tasks are persisted to disk and cleaned up after `AGENT_TASK_CLEANUP_INTERVAL` (default 24h).
 
+**Scheduled scrub (systemd timer):**
+
+```ini
+# /etc/systemd/system/btrfs-scrub.service
+[Unit]
+Description=btrfs scrub via CSI agent
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/default/btrfs-nfs-csi
+ExecStart=btrfs-nfs-csi task create scrub --label created-by=systemd-timer --wait
+```
+
+```ini
+# /etc/systemd/system/btrfs-scrub.timer
+[Unit]
+Description=Weekly btrfs scrub
+
+[Timer]
+OnCalendar=Sun *-*-* 02:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+cat > /etc/default/btrfs-nfs-csi <<EOF
+AGENT_URL=http://10.0.0.5:8080
+AGENT_TOKEN=changeme
+EOF
+chmod 600 /etc/default/btrfs-nfs-csi
+
+systemctl enable --now btrfs-scrub.timer
+```
+
+The scrub result (bytes scrubbed, error counts) is exposed via Prometheus metrics. Your monitoring stack (e.g. Alertmanager) can alert on scrub failures or uncorrectable errors. Neat, right?
+
 ## CLI
 
 The `btrfs-nfs-csi` binary doubles as a CLI tool. Any command that isn't `agent`, `controller`, or `driver` is treated as a CLI command.
@@ -213,14 +251,17 @@ btrfs-nfs-csi volume list -o wide
 btrfs-nfs-csi volume list -o json
 btrfs-nfs-csi volume get my-vol
 btrfs-nfs-csi volume create my-vol 10Gi --compression zstd
+btrfs-nfs-csi volume create my-vol 10Gi --label env=prod --label team=backend
 btrfs-nfs-csi volume expand my-vol 20Gi
-btrfs-nfs-csi volume clone source-vol new-vol
+btrfs-nfs-csi volume clone source-vol new-vol --label env=staging
+btrfs-nfs-csi volume list --label env=prod  # filter by label
 btrfs-nfs-csi volume delete my-vol --confirm --yes
 
 btrfs-nfs-csi snapshot list
 btrfs-nfs-csi snapshot list my-vol          # filter by volume
-btrfs-nfs-csi snapshot create my-vol snap-1
-btrfs-nfs-csi snapshot clone snap-1 new-vol # clone from snapshot
+btrfs-nfs-csi snapshot list --label env=prod
+btrfs-nfs-csi snapshot create my-vol snap-1 --label env=prod
+btrfs-nfs-csi snapshot clone snap-1 new-vol --label env=dev
 btrfs-nfs-csi snapshot delete snap-1 --confirm --yes
 
 btrfs-nfs-csi export list
@@ -229,10 +270,12 @@ btrfs-nfs-csi export remove my-vol 10.1.0.50
 
 btrfs-nfs-csi task list
 btrfs-nfs-csi task list --type scrub
+btrfs-nfs-csi task list --label created-by=cron
 btrfs-nfs-csi task get <id>
 btrfs-nfs-csi task cancel <id>
 btrfs-nfs-csi task create scrub
 btrfs-nfs-csi task create scrub --wait
+btrfs-nfs-csi task create scrub --label created-by=cron
 btrfs-nfs-csi task create test
 btrfs-nfs-csi task create test --sleep 10s --wait
 btrfs-nfs-csi stats
@@ -248,3 +291,5 @@ btrfs-nfs-csi version
 **Sorting:** `--sort` / `-s` with `--asc` (default descending). Volume default: `used%`. Snapshot default: `created`.
 
 **Size values:** Supports `Ki`, `Mi`, `Gi` (binary) and `K`, `M`, `G` (decimal).
+
+**Default labels:** CLI create commands automatically add `created-by=cli`. Override with `--label created-by=myvalue`.

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func runController() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := controller.Start(ctx, cfg.Endpoint, cfg.MetricsAddr, version, commit); err != nil {
+	if err := controller.Start(ctx, cfg.Endpoint, cfg.MetricsAddr, version, commit, cfg.DefaultLabels); err != nil {
 		log.Fatal().Err(err).Msg("controller failed")
 	}
 }


### PR DESCRIPTION
#100 lol

## Summary

- Add `labels` (`map[string]string`) to volumes, snapshots, clones, and tasks for categorization and filtering
- Labels follow simplified K8s rules: key `[a-z0-9._-]` max 63 chars, value `[a-zA-Z0-9._-]` max 128 chars, max 12 per resource (keeping metadata JSON below 4KB)
- Label filtering on all list endpoints via `?label=key=value` (exact match) or `?label=key` (key exists). Repeatable, AND logic
- CLI `--label key=value` flag on all create and list commands (max 4 user labels)
- Labels shown in detail responses and `-o wide` (truncated to 48 chars, `created-by` pinned first)
- `get` shows labels one per line, aligned
- Clones inherit source labels when no labels are explicitly set
- Labels updated on every attach (reconcile from PVC annotations)
- Label update via PATCH replaces all labels (not merge)

**Default labels:**
- CSI controller auto-sets `kubernetes.pvc.name`, `kubernetes.pvc.namespace`, `kubernetes.pvc.storageclass` (reserved, cannot be overridden via annotation) and `created-by=csi`
- Custom controller defaults via `DRIVER_DEFAULT_LABELS` env var (e.g. `kubernetes.cluster=my-cluster`)
- CLI auto-sets `created-by=cli` on all create commands (overridable via `--label`)
- Max 4 user labels via PVC annotation or CLI `--label`

**Code structure:**
- Validation regexes (`ValidName`, `ValidLabelKey`, `ValidLabelVal`) and `MaxLabels` in shared `config` package
- `labeled` interface + generic `filterByLabels[T]` in `agent/api/v1/labels.go`
- `GetLabels()` on all metadata types (`VolumeMetadata`, `SnapshotMetadata`, `CloneMetadata`, `Task`)
- Scheduled scrub example with systemd timer in operations docs