### PR TITLE
Improve logging: split volume IDs, gRPC trace level

### DIFF
--- a/agent/storage/usage.go
+++ b/agent/storage/usage.go
@@ -153,7 +153,7 @@ func updateAll(ctx context.Context, mgr *btrfs.Manager, basePath string, tenant 
 
 		info, err := mgr.QgroupUsageEx(ctx, dataDir)
 		if err != nil {
-			log.Debug().Err(err).Str("snapshot", e.Name()).Msg("usage updater: snapshot qgroup query failed")
+			log.Warn().Err(err).Str("snapshot", e.Name()).Msg("usage updater: snapshot qgroup query failed")
 			snapFailed++
 			continue
 		}

--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -64,7 +64,7 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	}
 
 	start := time.Now()
-	log.Debug().Str("method", info.FullMethod).Str("req", fmt.Sprintf("%+v", req)).Msg("gRPC call")
+	log.Trace().Str("method", info.FullMethod).Str("req", fmt.Sprintf("%+v", req)).Msg("gRPC call")
 
 	resp, err := handler(ctx, req)
 

--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -76,7 +76,7 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	if err != nil {
 		log.Error().Err(err).Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC error")
 	} else {
-		log.Debug().Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC ok")
+		log.Trace().Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC ok")
 	}
 
 	return resp, err

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/csiserver"
+	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/rs/zerolog/log"
@@ -15,6 +16,17 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/mount-utils"
 )
+
+// parseVolumeLog parses a composite volume ID (sc|name) into separate fields.
+// If parsing fails, emits a warning and returns the raw ID as volume name.
+func parseVolumeLog(volumeID string) (sc, name string) {
+	sc, name, err := utils.ParseVolumeID(volumeID)
+	if err != nil {
+		log.Warn().Str("volumeId", volumeID).Msg("unparseable volume ID")
+		return "", volumeID
+	}
+	return sc, name
+}
 
 func Start(ctx context.Context, endpoint, nodeID, nodeIP, metricsAddr, version string, healthCheckInterval time.Duration) error {
 	startMetricsServer(metricsAddr)
@@ -56,6 +68,7 @@ func (s *NodeServer) volumeLock(id string) func() {
 }
 
 func (s *NodeServer) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	log.Trace().Msg("NodeGetCapabilities")
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{
 			{
@@ -84,6 +97,7 @@ func (s *NodeServer) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabi
 }
 
 func (s *NodeServer) NodeGetInfo(_ context.Context, _ *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	log.Trace().Str("node", s.nodeID).Msg("NodeGetInfo")
 	return &csi.NodeGetInfoResponse{
 		NodeId: s.nodeID + config.NodeIDSep + s.nodeIP,
 	}, nil

--- a/driver/health.go
+++ b/driver/health.go
@@ -167,7 +167,7 @@ func (s *NodeServer) buildVolumeMap(ctx context.Context) map[string]volumeInfo {
 
 	vaList, err := s.kubeClient.StorageV1().VolumeAttachments().List(apiCtx, metav1.ListOptions{})
 	if err != nil {
-		log.Debug().Err(err).Msg("health check: failed to list volume attachments")
+		log.Warn().Err(err).Msg("health check: failed to list volume attachments")
 		return result
 	}
 
@@ -181,7 +181,7 @@ func (s *NodeServer) buildVolumeMap(ctx context.Context) map[string]volumeInfo {
 		}
 		pv, err := s.kubeClient.CoreV1().PersistentVolumes().Get(apiCtx, *pvName, metav1.GetOptions{})
 		if err != nil {
-			log.Debug().Err(err).Str("pv", *pvName).Msg("health check: failed to get PV")
+			log.Warn().Err(err).Str("pv", *pvName).Msg("health check: failed to get PV")
 			continue
 		}
 		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != config.DriverName {

--- a/driver/metrics.go
+++ b/driver/metrics.go
@@ -93,7 +93,7 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	if err != nil {
 		log.Error().Err(err).Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC error")
 	} else {
-		log.Debug().Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC ok")
+		log.Trace().Str("method", info.FullMethod).Str("code", code).Dur("took", time.Since(start)).Msg("gRPC ok")
 	}
 
 	return resp, err

--- a/driver/metrics.go
+++ b/driver/metrics.go
@@ -81,7 +81,7 @@ func metricsInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo
 	}
 
 	start := time.Now()
-	log.Debug().Str("method", info.FullMethod).Str("req", fmt.Sprintf("%+v", req)).Msg("gRPC call")
+	log.Trace().Str("method", info.FullMethod).Str("req", fmt.Sprintf("%+v", req)).Msg("gRPC call")
 
 	resp, err := handler(ctx, req)
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -26,6 +26,8 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		return nil, status.Error(codes.InvalidArgument, "volume ID and staging target path required")
 	}
 
+	sc, vol := parseVolumeLog(req.VolumeId)
+
 	unlock := s.volumeLock(req.VolumeId)
 	defer unlock()
 
@@ -41,12 +43,12 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	// Healthy mount check: stat the data dir to see if staging is already done.
 	// Stale staging mounts are handled by the background health checker, not here.
 	if err := statWithTimeout(stagingPath+"/"+config.DataDir, staleCheckTimeout); err == nil {
-		log.Info().Str("volume", req.VolumeId).Str("path", stagingPath).Msg("already mounted at staging path")
+		log.Info().Str("volume", vol).Str("sc", sc).Str("path", stagingPath).Msg("already mounted at staging path")
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
 	if err := os.MkdirAll(stagingPath, 0755); err != nil {
-		return nil, status.Errorf(codes.Internal, "mkdir staging for volume %s: %v", req.VolumeId, err)
+		return nil, status.Errorf(codes.Internal, "mkdir staging for volume %s: %v", vol, err)
 	}
 
 	source := fmt.Sprintf("%s:%s", nfsServer, nfsSharePath)
@@ -64,7 +66,7 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		opts = append(opts, strings.Split(extra, ",")...)
 	}
 
-	log.Debug().Str("volume", req.VolumeId).Str("source", source).Str("target", stagingPath).Strs("opts", opts).Msg("mounting NFS")
+	log.Debug().Str("volume", vol).Str("sc", sc).Str("source", source).Str("target", stagingPath).Strs("opts", opts).Msg("mounting NFS")
 
 	start := time.Now()
 	err := s.mounter.Mount(source, stagingPath, "nfs", opts)
@@ -72,11 +74,11 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	mountDuration.WithLabelValues("nfs_mount").Observe(elapsed.Seconds())
 	if err != nil {
 		mountOpsTotal.WithLabelValues("nfs_mount", "error").Inc()
-		return nil, status.Errorf(codes.Internal, "mount NFS for volume %s: %v", req.VolumeId, err)
+		return nil, status.Errorf(codes.Internal, "mount NFS for volume %s: %v", vol, err)
 	}
 	mountOpsTotal.WithLabelValues("nfs_mount", "success").Inc()
 
-	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("source", source).Str("target", stagingPath).Dur("took", elapsed).Msg("stage complete")
+	log.Info().Str("volume", vol).Str("sc", sc).Str("node", s.nodeID).Str("source", source).Str("target", stagingPath).Dur("took", elapsed).Msg("stage complete")
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
@@ -85,18 +87,20 @@ func (s *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 		return nil, status.Error(codes.InvalidArgument, "volume ID and staging target path required")
 	}
 
+	sc, vol := parseVolumeLog(req.VolumeId)
+
 	unlock := s.volumeLock(req.VolumeId)
 	defer unlock()
 
-	log.Debug().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.StagingTargetPath).Msg("unstaging volume")
+	log.Debug().Str("volume", vol).Str("sc", sc).Str("node", s.nodeID).Str("path", req.StagingTargetPath).Msg("unstaging volume")
 
 	if err := cleanupMountPoint(ctx, s.mounter, req.StagingTargetPath); err != nil {
-		return nil, status.Errorf(codes.Internal, "cleanup staging for volume %s at %s: %v", req.VolumeId, req.StagingTargetPath, err)
+		return nil, status.Errorf(codes.Internal, "cleanup staging for volume %s at %s: %v", vol, req.StagingTargetPath, err)
 	}
 
 	s.healthState.Delete(req.VolumeId)
 
-	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.StagingTargetPath).Msg("unstage complete")
+	log.Info().Str("volume", vol).Str("sc", sc).Str("node", s.nodeID).Str("path", req.StagingTargetPath).Msg("unstage complete")
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
@@ -105,22 +109,24 @@ func (s *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return nil, status.Error(codes.InvalidArgument, "volume ID, staging target path, and target path required")
 	}
 
+	sc, vol := parseVolumeLog(req.VolumeId)
+
 	unlock := s.volumeLock(req.VolumeId)
 	defer unlock()
 
 	if err := statWithTimeout(req.TargetPath, staleCheckTimeout); err == nil {
-		log.Info().Str("volume", req.VolumeId).Str("path", req.TargetPath).Msg("already mounted, skipping publish")
+		log.Info().Str("volume", vol).Str("sc", sc).Str("path", req.TargetPath).Msg("already mounted, skipping publish")
 		return &csi.NodePublishVolumeResponse{}, nil
 	} else if mount.IsCorruptedMnt(err) || errors.Is(err, errStatTimeout) {
-		log.Warn().Err(err).Str("volume", req.VolumeId).Str("path", req.TargetPath).Msg("stale bind mount detected, remounting over it")
+		log.Warn().Err(err).Str("volume", vol).Str("sc", sc).Str("path", req.TargetPath).Msg("stale bind mount detected, remounting over it")
 	}
 
 	if err := os.MkdirAll(req.TargetPath, 0755); err != nil {
-		return nil, status.Errorf(codes.Internal, "mkdir target for volume %s: %v", req.VolumeId, err)
+		return nil, status.Errorf(codes.Internal, "mkdir target for volume %s: %v", vol, err)
 	}
 
 	dataDir := req.StagingTargetPath + "/" + config.DataDir
-	log.Debug().Str("volume", req.VolumeId).Str("source", dataDir).Str("target", req.TargetPath).Bool("readonly", req.Readonly).Msg("bind mounting")
+	log.Debug().Str("volume", vol).Str("sc", sc).Str("source", dataDir).Str("target", req.TargetPath).Bool("readonly", req.Readonly).Msg("bind mounting")
 
 	start := time.Now()
 	err := s.mounter.Mount(dataDir, req.TargetPath, "", []string{"bind"})
@@ -128,7 +134,7 @@ func (s *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	mountDuration.WithLabelValues("bind_mount").Observe(elapsed.Seconds())
 	if err != nil {
 		mountOpsTotal.WithLabelValues("bind_mount", "error").Inc()
-		return nil, status.Errorf(codes.Internal, "bind mount for volume %s: %v", req.VolumeId, err)
+		return nil, status.Errorf(codes.Internal, "bind mount for volume %s: %v", vol, err)
 	}
 	mountOpsTotal.WithLabelValues("bind_mount", "success").Inc()
 
@@ -139,14 +145,14 @@ func (s *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		if err != nil {
 			mountOpsTotal.WithLabelValues("remount_ro", "error").Inc()
 			if cleanErr := cleanupMountPoint(ctx, s.mounter, req.TargetPath); cleanErr != nil {
-				log.Error().Err(cleanErr).Str("volume", req.VolumeId).Str("path", req.TargetPath).Msg("cleanup after remount-ro failure also failed")
+				log.Error().Err(cleanErr).Str("volume", vol).Str("sc", sc).Str("path", req.TargetPath).Msg("cleanup after remount-ro failure also failed")
 			}
-			return nil, status.Errorf(codes.Internal, "remount ro for volume %s: %v", req.VolumeId, err)
+			return nil, status.Errorf(codes.Internal, "remount ro for volume %s: %v", vol, err)
 		}
 		mountOpsTotal.WithLabelValues("remount_ro", "success").Inc()
 	}
 
-	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("target", req.TargetPath).Bool("readonly", req.Readonly).Dur("took", elapsed).Msg("publish complete")
+	log.Info().Str("volume", vol).Str("sc", sc).Str("node", s.nodeID).Str("target", req.TargetPath).Bool("readonly", req.Readonly).Dur("took", elapsed).Msg("publish complete")
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
@@ -155,16 +161,18 @@ func (s *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 		return nil, status.Error(codes.InvalidArgument, "volume ID and target path required")
 	}
 
+	sc, vol := parseVolumeLog(req.VolumeId)
+
 	unlock := s.volumeLock(req.VolumeId)
 	defer unlock()
 
-	log.Debug().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.TargetPath).Msg("unpublishing volume")
+	log.Debug().Str("volume", vol).Str("sc", sc).Str("node", s.nodeID).Str("path", req.TargetPath).Msg("unpublishing volume")
 
 	if err := cleanupMountPoint(ctx, s.mounter, req.TargetPath); err != nil {
-		return nil, status.Errorf(codes.Internal, "cleanup target for volume %s at %s: %v", req.VolumeId, req.TargetPath, err)
+		return nil, status.Errorf(codes.Internal, "cleanup target for volume %s at %s: %v", vol, req.TargetPath, err)
 	}
 
-	log.Info().Str("volume", req.VolumeId).Str("node", s.nodeID).Str("path", req.TargetPath).Msg("unpublish complete")
+	log.Info().Str("volume", vol).Str("sc", sc).Str("node", s.nodeID).Str("path", req.TargetPath).Msg("unpublish complete")
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 

--- a/driver/stats.go
+++ b/driver/stats.go
@@ -35,17 +35,19 @@ func (s *NodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolum
 		stagingPath = s.findStagingPath(req.VolumeId)
 	}
 
-	log.Debug().Str("volume", req.VolumeId).Str("volumePath", req.VolumePath).Str("stagingPath", stagingPath).Msg("looking up volume stats")
+	sc, vol := parseVolumeLog(req.VolumeId)
+
+	log.Debug().Str("volume", vol).Str("sc", sc).Str("volumePath", req.VolumePath).Str("stagingPath", stagingPath).Msg("looking up volume stats")
 
 	if stagingPath != "" {
 		metaPath := stagingPath + "/" + config.MetadataFile
 		data, err := os.ReadFile(metaPath)
 		if err != nil {
-			log.Warn().Err(err).Str("volume", req.VolumeId).Str("path", metaPath).Msg("failed to read metadata")
+			log.Warn().Err(err).Str("volume", vol).Str("sc", sc).Str("path", metaPath).Msg("failed to read metadata")
 		} else {
 			var vs volumeStats
 			if err := json.Unmarshal(data, &vs); err != nil {
-				log.Warn().Err(err).Str("volume", req.VolumeId).Str("path", metaPath).Msg("metadata JSON corrupt")
+				log.Warn().Err(err).Str("volume", vol).Str("sc", sc).Str("path", metaPath).Msg("metadata JSON corrupt")
 			} else {
 				if vs.QuotaBytes > 0 {
 					used := int64(vs.UsedBytes)
@@ -67,7 +69,7 @@ func (s *NodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolum
 					return resp, nil
 				}
 				// Quota disabled: fallback to statfs
-				log.Debug().Str("volume", req.VolumeId).Msg("quota not configured, falling back to statfs")
+				log.Debug().Str("volume", vol).Str("sc", sc).Msg("quota not configured, falling back to statfs")
 				resp, err := statfsResponse(req.VolumePath)
 				if err == nil {
 					s.attachVolumeCondition(req.VolumeId, resp)


### PR DESCRIPTION
## Summary
- Split composite volume IDs (`sc|name`) into separate `volume=` and `sc=` log fields across all driver methods
- Parse once per method entry via `parseVolumeLog()`, warn once if ID is unparseable
- Move gRPC request struct dumps from DEBUG to TRACE (both driver and controller interceptors)
- Add TRACE logging to `NodeGetCapabilities` and `NodeGetInfo`
- Fix incomplete migration in `stats.go` (3 log sites still used raw volume ID)