### PR TITLE
Cursor-based pagination for all list endpoints

### DIFF
--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -17,6 +18,23 @@ func generateLabelQuery(labels []string) url.Values {
 		v.Add("label", l)
 	}
 	return v
+}
+
+type ListOpts struct {
+	After  string
+	Limit  int
+	Labels []string
+}
+
+func (o ListOpts) query() url.Values {
+	q := generateLabelQuery(o.Labels)
+	if o.After != "" {
+		q.Set("after", o.After)
+	}
+	if o.Limit > 0 {
+		q.Set("limit", strconv.Itoa(o.Limit))
+	}
+	return q
 }
 
 type Client struct {
@@ -100,18 +118,17 @@ func (c *Client) UnexportVolume(ctx context.Context, name string, cl string) err
 	return c.do(ctx, http.MethodDelete, "/v1/volumes/"+name+"/export", ExportRequest{Client: cl}, nil)
 }
 
-func (c *Client) ListVolumes(ctx context.Context, labels ...string) (*VolumeListResponse, error) {
+func (c *Client) ListVolumes(ctx context.Context, opts ListOpts) (*VolumeListResponse, error) {
 	var resp VolumeListResponse
-	q := generateLabelQuery(labels)
-	if err := c.do(ctx, http.MethodGet, "/v1/volumes?"+q.Encode(), nil, &resp); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/v1/volumes?"+opts.query().Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListVolumesDetail(ctx context.Context, labels ...string) (*VolumeDetailListResponse, error) {
+func (c *Client) ListVolumesDetail(ctx context.Context, opts ListOpts) (*VolumeDetailListResponse, error) {
 	var resp VolumeDetailListResponse
-	q := generateLabelQuery(labels)
+	q := opts.query()
 	q.Set("detail", "true")
 	if err := c.do(ctx, http.MethodGet, "/v1/volumes?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
@@ -127,27 +144,25 @@ func (c *Client) GetVolume(ctx context.Context, name string) (*VolumeDetailRespo
 	return &resp, nil
 }
 
-func (c *Client) ListSnapshots(ctx context.Context, labels ...string) (*SnapshotListResponse, error) {
+func (c *Client) ListSnapshots(ctx context.Context, opts ListOpts) (*SnapshotListResponse, error) {
 	var resp SnapshotListResponse
-	q := generateLabelQuery(labels)
-	if err := c.do(ctx, http.MethodGet, "/v1/snapshots?"+q.Encode(), nil, &resp); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/v1/snapshots?"+opts.query().Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListVolumeSnapshots(ctx context.Context, volume string, labels ...string) (*SnapshotListResponse, error) {
+func (c *Client) ListVolumeSnapshots(ctx context.Context, volume string, opts ListOpts) (*SnapshotListResponse, error) {
 	var resp SnapshotListResponse
-	q := generateLabelQuery(labels)
-	if err := c.do(ctx, http.MethodGet, "/v1/volumes/"+volume+"/snapshots?"+q.Encode(), nil, &resp); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/v1/volumes/"+volume+"/snapshots?"+opts.query().Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (c *Client) ListVolumeSnapshotsDetail(ctx context.Context, volume string, labels ...string) (*SnapshotDetailListResponse, error) {
+func (c *Client) ListVolumeSnapshotsDetail(ctx context.Context, volume string, opts ListOpts) (*SnapshotDetailListResponse, error) {
 	var resp SnapshotDetailListResponse
-	q := generateLabelQuery(labels)
+	q := opts.query()
 	q.Set("detail", "true")
 	if err := c.do(ctx, http.MethodGet, "/v1/volumes/"+volume+"/snapshots?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
@@ -155,9 +170,9 @@ func (c *Client) ListVolumeSnapshotsDetail(ctx context.Context, volume string, l
 	return &resp, nil
 }
 
-func (c *Client) ListSnapshotsDetail(ctx context.Context, labels ...string) (*SnapshotDetailListResponse, error) {
+func (c *Client) ListSnapshotsDetail(ctx context.Context, opts ListOpts) (*SnapshotDetailListResponse, error) {
 	var resp SnapshotDetailListResponse
-	q := generateLabelQuery(labels)
+	q := opts.query()
 	q.Set("detail", "true")
 	if err := c.do(ctx, http.MethodGet, "/v1/snapshots?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
@@ -189,9 +204,9 @@ func (c *Client) CreateTask(ctx context.Context, taskType string, req TaskCreate
 	return &resp, nil
 }
 
-func (c *Client) ListTasks(ctx context.Context, taskType string, labels ...string) (*TaskListResponse, error) {
+func (c *Client) ListTasks(ctx context.Context, taskType string, opts ListOpts) (*TaskListResponse, error) {
 	var resp TaskListResponse
-	q := generateLabelQuery(labels)
+	q := opts.query()
 	if taskType != "" {
 		q.Set("type", taskType)
 	}
@@ -201,9 +216,9 @@ func (c *Client) ListTasks(ctx context.Context, taskType string, labels ...strin
 	return &resp, nil
 }
 
-func (c *Client) ListTasksDetail(ctx context.Context, taskType string, labels ...string) (*TaskDetailListResponse, error) {
+func (c *Client) ListTasksDetail(ctx context.Context, taskType string, opts ListOpts) (*TaskDetailListResponse, error) {
 	var resp TaskDetailListResponse
-	q := generateLabelQuery(labels)
+	q := opts.query()
 	q.Set("detail", "true")
 	if taskType != "" {
 		q.Set("type", taskType)

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -2,12 +2,24 @@ package v1
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
 
 	"github.com/labstack/echo/v5"
 )
+
+func parsePageParams(c *echo.Context) (after string, limit int) {
+	after = c.QueryParam("after")
+	if v := c.QueryParam("limit"); v != "" {
+		limit, _ = strconv.Atoi(v)
+		if limit < 0 {
+			limit = 0
+		}
+	}
+	return
+}
 
 type Handler struct {
 	Store *storage.Storage
@@ -46,12 +58,14 @@ func (h *Handler) CreateVolume(c *echo.Context) error {
 
 func (h *Handler) ListVolumes(c *echo.Context) error {
 	tenant := c.Get("tenant").(string)
+	after, limit := parsePageParams(c)
 
-	vols, err := h.Store.ListVolumes(tenant)
+	page, err := h.Store.ListVolumesPaginated(tenant, after, limit)
 	if err != nil {
 		return StorageError(c, err)
 	}
 
+	vols := page.Items
 	if filters := c.QueryParams()["label"]; len(filters) > 0 {
 		vols = filterByLabels(vols, filters)
 	}
@@ -61,7 +75,7 @@ func (h *Handler) ListVolumes(c *echo.Context) error {
 		for i := range vols {
 			resp[i] = volumeDetailResponseFrom(&vols[i])
 		}
-		return c.JSON(http.StatusOK, VolumeDetailListResponse{Volumes: resp, Total: len(resp)})
+		return c.JSON(http.StatusOK, VolumeDetailListResponse{Volumes: resp, Total: page.Total, Next: page.Next})
 	}
 
 	resp := make([]VolumeResponse, len(vols))
@@ -69,7 +83,7 @@ func (h *Handler) ListVolumes(c *echo.Context) error {
 		resp[i] = volumeResponseFrom(&vols[i])
 	}
 
-	return c.JSON(http.StatusOK, VolumeListResponse{Volumes: resp, Total: len(resp)})
+	return c.JSON(http.StatusOK, VolumeListResponse{Volumes: resp, Total: page.Total, Next: page.Next})
 }
 
 func volumeDetailResponseFrom(meta *storage.VolumeMetadata) VolumeDetailResponse {
@@ -168,17 +182,19 @@ func (h *Handler) UnexportVolume(c *echo.Context) error {
 
 func (h *Handler) ListExports(c *echo.Context) error {
 	tenant := c.Get("tenant").(string)
+	after, limit := parsePageParams(c)
 
-	entries, err := h.Store.ListExports(c.Request().Context(), tenant)
+	page, err := h.Store.ListExportsPaginated(c.Request().Context(), tenant, after, limit)
 	if err != nil {
 		return StorageError(c, err)
 	}
 
-	if entries == nil {
-		entries = []storage.ExportEntry{}
+	exports := page.Items
+	if exports == nil {
+		exports = []storage.ExportEntry{}
 	}
 
-	return c.JSON(http.StatusOK, ExportListResponse{Exports: entries})
+	return c.JSON(http.StatusOK, ExportListResponse{Exports: exports, Total: page.Total, Next: page.Next})
 }
 
 func (h *Handler) Stats(c *echo.Context) error {
@@ -270,14 +286,16 @@ func (h *Handler) CreateSnapshot(c *echo.Context) error {
 	return c.JSON(http.StatusCreated, snapshotDetailResponseFrom(meta))
 }
 
-func (h *Handler) ListSnapshots(c *echo.Context) error {
+func (h *Handler) listSnapshotsPage(c *echo.Context, volume string) error {
 	tenant := c.Get("tenant").(string)
+	after, limit := parsePageParams(c)
 
-	snaps, err := h.Store.ListSnapshots(tenant, "")
+	page, err := h.Store.ListSnapshotsPaginated(tenant, volume, after, limit)
 	if err != nil {
 		return StorageError(c, err)
 	}
 
+	snaps := page.Items
 	if filters := c.QueryParams()["label"]; len(filters) > 0 {
 		snaps = filterByLabels(snaps, filters)
 	}
@@ -287,7 +305,7 @@ func (h *Handler) ListSnapshots(c *echo.Context) error {
 		for i := range snaps {
 			resp[i] = snapshotDetailResponseFrom(&snaps[i])
 		}
-		return c.JSON(http.StatusOK, SnapshotDetailListResponse{Snapshots: resp, Total: len(resp)})
+		return c.JSON(http.StatusOK, SnapshotDetailListResponse{Snapshots: resp, Total: page.Total, Next: page.Next})
 	}
 
 	resp := make([]SnapshotResponse, len(snaps))
@@ -295,35 +313,15 @@ func (h *Handler) ListSnapshots(c *echo.Context) error {
 		resp[i] = snapshotResponseFrom(&snaps[i])
 	}
 
-	return c.JSON(http.StatusOK, SnapshotListResponse{Snapshots: resp, Total: len(resp)})
+	return c.JSON(http.StatusOK, SnapshotListResponse{Snapshots: resp, Total: page.Total, Next: page.Next})
+}
+
+func (h *Handler) ListSnapshots(c *echo.Context) error {
+	return h.listSnapshotsPage(c, "")
 }
 
 func (h *Handler) ListVolumeSnapshots(c *echo.Context) error {
-	tenant := c.Get("tenant").(string)
-
-	snaps, err := h.Store.ListSnapshots(tenant, c.Param("name"))
-	if err != nil {
-		return StorageError(c, err)
-	}
-
-	if filters := c.QueryParams()["label"]; len(filters) > 0 {
-		snaps = filterByLabels(snaps, filters)
-	}
-
-	if c.QueryParam("detail") == "true" {
-		resp := make([]SnapshotDetailResponse, len(snaps))
-		for i := range snaps {
-			resp[i] = snapshotDetailResponseFrom(&snaps[i])
-		}
-		return c.JSON(http.StatusOK, SnapshotDetailListResponse{Snapshots: resp, Total: len(resp)})
-	}
-
-	resp := make([]SnapshotResponse, len(snaps))
-	for i := range snaps {
-		resp[i] = snapshotResponseFrom(&snaps[i])
-	}
-
-	return c.JSON(http.StatusOK, SnapshotListResponse{Snapshots: resp, Total: len(resp)})
+	return h.listSnapshotsPage(c, c.Param("name"))
 }
 
 func snapshotDetailResponseFrom(meta *storage.SnapshotMetadata) SnapshotDetailResponse {
@@ -452,7 +450,8 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 }
 
 func (h *Handler) ListTasks(c *echo.Context) error {
-	tasks := h.Store.Tasks().List(c.QueryParam("type"))
+	after, limit := parsePageParams(c)
+	tasks, total, next := h.Store.Tasks().ListPaginated(c.QueryParam("type"), after, limit)
 
 	if filters := c.QueryParams()["label"]; len(filters) > 0 {
 		tasks = filterByLabels(tasks, filters)
@@ -463,14 +462,14 @@ func (h *Handler) ListTasks(c *echo.Context) error {
 		for i, t := range tasks {
 			detail[i] = taskDetailResponseFrom(&t)
 		}
-		return c.JSON(http.StatusOK, TaskDetailListResponse{Tasks: detail, Total: len(detail)})
+		return c.JSON(http.StatusOK, TaskDetailListResponse{Tasks: detail, Total: total, Next: next})
 	}
 
 	resp := make([]TaskResponse, len(tasks))
 	for i, t := range tasks {
 		resp[i] = taskResponseFrom(&t)
 	}
-	return c.JSON(http.StatusOK, TaskListResponse{Tasks: resp, Total: len(resp)})
+	return c.JSON(http.StatusOK, TaskListResponse{Tasks: resp, Total: total, Next: next})
 }
 
 func (h *Handler) GetTask(c *echo.Context) error {

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -73,11 +73,13 @@ type VolumeDetailResponse struct {
 type VolumeListResponse struct {
 	Volumes []VolumeResponse `json:"volumes"`
 	Total   int              `json:"total"`
+	Next    string           `json:"next,omitempty"`
 }
 
 type VolumeDetailListResponse struct {
 	Volumes []VolumeDetailResponse `json:"volumes"`
 	Total   int                    `json:"total"`
+	Next    string                 `json:"next,omitempty"`
 }
 
 type SnapshotResponse struct {
@@ -104,11 +106,13 @@ type SnapshotDetailResponse struct {
 type SnapshotListResponse struct {
 	Snapshots []SnapshotResponse `json:"snapshots"`
 	Total     int                `json:"total"`
+	Next      string             `json:"next,omitempty"`
 }
 
 type SnapshotDetailListResponse struct {
 	Snapshots []SnapshotDetailResponse `json:"snapshots"`
 	Total     int                      `json:"total"`
+	Next      string                   `json:"next,omitempty"`
 }
 
 type CloneResponse struct {
@@ -121,6 +125,8 @@ type CloneResponse struct {
 
 type ExportListResponse struct {
 	Exports []ExportEntry `json:"exports"`
+	Total   int           `json:"total"`
+	Next    string        `json:"next,omitempty"`
 }
 
 type StatsResponse struct {
@@ -225,11 +231,13 @@ type TaskDetailResponse struct {
 type TaskListResponse struct {
 	Tasks []TaskResponse `json:"tasks"`
 	Total int            `json:"total"`
+	Next  string         `json:"next,omitempty"`
 }
 
 type TaskDetailListResponse struct {
 	Tasks []TaskDetailResponse `json:"tasks"`
 	Total int                  `json:"total"`
+	Next  string               `json:"next,omitempty"`
 }
 
 type ErrorResponse struct {

--- a/agent/storage/export.go
+++ b/agent/storage/export.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -115,4 +116,41 @@ func (s *Storage) ListExports(ctx context.Context, tenant string) ([]ExportEntry
 	}
 	log.Debug().Str("tenant", tenant).Int("count", len(entries)).Msg("exports listed")
 	return entries, nil
+}
+
+func (s *Storage) ListExportsPaginated(ctx context.Context, tenant, after string, limit int) (*PaginatedResult[ExportEntry], error) {
+	entries, err := s.ListExports(ctx, tenant)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Path != entries[j].Path {
+			return entries[i].Path < entries[j].Path
+		}
+		return entries[i].Client < entries[j].Client
+	})
+
+	total := len(entries)
+	if after != "" {
+		for i, e := range entries {
+			key := e.Path + "|" + e.Client
+			if key > after {
+				entries = entries[i:]
+				break
+			}
+			if i == len(entries)-1 {
+				return &PaginatedResult[ExportEntry]{Total: total}, nil
+			}
+		}
+	}
+
+	result := &PaginatedResult[ExportEntry]{Total: total}
+	if limit > 0 && len(entries) > limit {
+		last := entries[limit-1]
+		result.Next = last.Path + "|" + last.Client
+		result.Items = entries[:limit]
+	} else {
+		result.Items = entries
+	}
+	return result, nil
 }

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -89,6 +89,12 @@ func (m VolumeMetadata) GetLabels() map[string]string   { return m.Labels }
 func (m SnapshotMetadata) GetLabels() map[string]string { return m.Labels }
 func (m CloneMetadata) GetLabels() map[string]string    { return m.Labels }
 
+type PaginatedResult[T any] struct {
+	Items []T
+	Total int
+	Next  string // cursor for next page, empty = end of list
+}
+
 type ExportEntry struct {
 	Path   string `json:"path"`
 	Client string `json:"client"`

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -116,6 +116,63 @@ func (s *Storage) ListSnapshots(tenant, volume string) ([]SnapshotMetadata, erro
 	return snaps, nil
 }
 
+func (s *Storage) ListSnapshotsPaginated(tenant, volume, after string, limit int) (*PaginatedResult[SnapshotMetadata], error) {
+	bp, err := s.tenantPath(tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	snapBaseDir := filepath.Join(bp, config.SnapshotsDir)
+	entries, err := os.ReadDir(snapBaseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &PaginatedResult[SnapshotMetadata]{}, nil
+		}
+		log.Error().Err(err).Msg("failed to read snapshots directory")
+		return nil, fmt.Errorf("failed to read snapshots directory: %w", err)
+	}
+
+	// when volume filter is set, total requires reading all metadata, so we
+	// count directories as an approximation (exact when unfiltered)
+	total := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			total++
+		}
+	}
+
+	var snaps []SnapshotMetadata
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if after != "" && e.Name() <= after {
+			continue
+		}
+		metaPath := filepath.Join(snapBaseDir, e.Name(), config.MetadataFile)
+		var meta SnapshotMetadata
+		if err := ReadMetadata(metaPath, &meta); err != nil {
+			continue
+		}
+		if volume != "" && meta.Volume != volume {
+			continue
+		}
+		snaps = append(snaps, meta)
+		if limit > 0 && len(snaps) > limit {
+			break
+		}
+	}
+
+	result := &PaginatedResult[SnapshotMetadata]{Total: total}
+	if limit > 0 && len(snaps) > limit {
+		result.Next = snaps[limit-1].Name
+		result.Items = snaps[:limit]
+	} else {
+		result.Items = snaps
+	}
+	return result, nil
+}
+
 func (s *Storage) GetSnapshot(tenant, name string) (*SnapshotMetadata, error) {
 	bp, err := s.tenantPath(tenant)
 	if err != nil {

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -183,6 +184,31 @@ func (tm *Manager) List(taskType string) []Task {
 		result = append(result, *t)
 	}
 	return result
+}
+
+// ListPaginated returns a paginated, sorted list of tasks.
+func (tm *Manager) ListPaginated(taskType, after string, limit int) (items []Task, total int, next string) {
+	all := tm.List(taskType)
+	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
+	total = len(all)
+
+	if after != "" {
+		for i, t := range all {
+			if t.ID > after {
+				all = all[i:]
+				break
+			}
+			if i == len(all)-1 {
+				return nil, total, ""
+			}
+		}
+	}
+
+	if limit > 0 && len(all) > limit {
+		next = all[limit-1].ID
+		return all[:limit], total, next
+	}
+	return all, total, ""
 }
 
 // Cancel aborts a running task via context cancellation.

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -164,6 +164,55 @@ func (s *Storage) ListVolumes(tenant string) ([]VolumeMetadata, error) {
 	return vols, nil
 }
 
+func (s *Storage) ListVolumesPaginated(tenant, after string, limit int) (*PaginatedResult[VolumeMetadata], error) {
+	bp, err := s.tenantPath(tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(bp)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read base path")
+		return nil, fmt.Errorf("failed to read base path: %w", err)
+	}
+
+	// count valid directories (excluding snapshots dir)
+	total := 0
+	for _, e := range entries {
+		if e.IsDir() && e.Name() != config.SnapshotsDir {
+			total++
+		}
+	}
+
+	var vols []VolumeMetadata
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == config.SnapshotsDir {
+			continue
+		}
+		if after != "" && e.Name() <= after {
+			continue
+		}
+		metaPath := filepath.Join(bp, e.Name(), config.MetadataFile)
+		var meta VolumeMetadata
+		if err := ReadMetadata(metaPath, &meta); err != nil {
+			continue
+		}
+		vols = append(vols, meta)
+		if limit > 0 && len(vols) > limit {
+			break
+		}
+	}
+
+	result := &PaginatedResult[VolumeMetadata]{Total: total}
+	if limit > 0 && len(vols) > limit {
+		result.Next = vols[limit-1].Name
+		result.Items = vols[:limit]
+	} else {
+		result.Items = vols
+	}
+	return result, nil
+}
+
 func (s *Storage) GetVolume(tenant, name string) (*VolumeMetadata, error) {
 	bp, err := s.tenantPath(tenant)
 	if err != nil {

--- a/agent/storage/volume_test.go
+++ b/agent/storage/volume_test.go
@@ -279,6 +279,60 @@ func TestListVolumes(t *testing.T) {
 	})
 }
 
+// --- TestListVolumesPaginated ---
+
+func TestListVolumesPaginated(t *testing.T) {
+	s, bp, _, _ := newTestStorage(t)
+
+	for _, name := range []string{"aaa", "bbb", "ccc", "ddd", "eee"} {
+		dir := filepath.Join(bp, name)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		writeTestMetadata(t, dir, VolumeMetadata{Name: name, SizeBytes: 1024})
+	}
+
+	t.Run("all", func(t *testing.T) {
+		page, err := s.ListVolumesPaginated("test", "", 0)
+		require.NoError(t, err)
+		assert.Len(t, page.Items, 5)
+		assert.Equal(t, 5, page.Total)
+		assert.Empty(t, page.Next)
+	})
+
+	t.Run("first_page", func(t *testing.T) {
+		page, err := s.ListVolumesPaginated("test", "", 2)
+		require.NoError(t, err)
+		assert.Len(t, page.Items, 2)
+		assert.Equal(t, "aaa", page.Items[0].Name)
+		assert.Equal(t, "bbb", page.Items[1].Name)
+		assert.Equal(t, "bbb", page.Next)
+		assert.Equal(t, 5, page.Total)
+	})
+
+	t.Run("second_page", func(t *testing.T) {
+		page, err := s.ListVolumesPaginated("test", "bbb", 2)
+		require.NoError(t, err)
+		assert.Len(t, page.Items, 2)
+		assert.Equal(t, "ccc", page.Items[0].Name)
+		assert.Equal(t, "ddd", page.Items[1].Name)
+		assert.Equal(t, "ddd", page.Next)
+	})
+
+	t.Run("last_page", func(t *testing.T) {
+		page, err := s.ListVolumesPaginated("test", "ddd", 2)
+		require.NoError(t, err)
+		assert.Len(t, page.Items, 1)
+		assert.Equal(t, "eee", page.Items[0].Name)
+		assert.Empty(t, page.Next)
+	})
+
+	t.Run("after_last", func(t *testing.T) {
+		page, err := s.ListVolumesPaginated("test", "eee", 2)
+		require.NoError(t, err)
+		assert.Empty(t, page.Items)
+		assert.Empty(t, page.Next)
+	})
+}
+
 // --- TestGetVolume ---
 
 func TestGetVolume(t *testing.T) {

--- a/controller/snapshots.go
+++ b/controller/snapshots.go
@@ -17,79 +17,125 @@ import (
 func (s *Server) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 	agents := s.agents.Agents()
 
-	type agentQuery struct {
-		sc     string
-		client *agentAPI.Client
-		volume string
-	}
-	var queries []agentQuery
-
+	// single-agent queries (by snapshot or source volume ID)
 	if req.SnapshotId != "" {
 		sc, _, err := utils.ParseVolumeID(req.SnapshotId)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid snapshot ID: %v", err)
 		}
-		if c, ok := agents[sc]; ok {
-			queries = append(queries, agentQuery{sc: sc, client: c})
+		c, ok := agents[sc]
+		if !ok {
+			return &csi.ListSnapshotsResponse{}, nil
 		}
-	} else if req.SourceVolumeId != "" {
-		sc, volName, err := utils.ParseVolumeID(req.SourceVolumeId)
+		snapList, err := c.ListSnapshots(ctx, agentAPI.ListOpts{})
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid source volume ID: %v", err)
+			return nil, status.Errorf(codes.Internal, "list snapshots from %s: %v", sc, err)
 		}
-		if c, ok := agents[sc]; ok {
-			queries = append(queries, agentQuery{sc: sc, client: c, volume: volName})
-		}
-	} else {
-		for sc, client := range agents {
-			queries = append(queries, agentQuery{sc: sc, client: client})
-		}
-	}
-
-	var entries []*csi.ListSnapshotsResponse_Entry
-	for _, q := range queries {
-		start := time.Now()
-		var snapList *agentAPI.SnapshotListResponse
-		var err error
-		if q.volume != "" {
-			snapList, err = q.client.ListVolumeSnapshots(ctx, q.volume)
-		} else {
-			snapList, err = q.client.ListSnapshots(ctx)
-		}
-		agentDuration.WithLabelValues("list_snapshots", q.sc).Observe(time.Since(start).Seconds())
-		if err != nil {
-			agentOpsTotal.WithLabelValues("list_snapshots", "error", q.sc).Inc()
-			log.Warn().Err(err).Str("sc", q.sc).Msg("failed to list snapshots from agent")
-			continue
-		}
-		agentOpsTotal.WithLabelValues("list_snapshots", "success", q.sc).Inc()
-
+		var entries []*csi.ListSnapshotsResponse_Entry
 		for _, snap := range snapList.Snapshots {
-			snapID := utils.MakeVolumeID(q.sc, snap.Name)
-
-			if req.SnapshotId != "" && snapID != req.SnapshotId {
+			snapID := utils.MakeVolumeID(sc, snap.Name)
+			if snapID != req.SnapshotId {
 				continue
 			}
-
 			entries = append(entries, &csi.ListSnapshotsResponse_Entry{
 				Snapshot: &csi.Snapshot{
 					SnapshotId:     snapID,
-					SourceVolumeId: utils.MakeVolumeID(q.sc, snap.Volume),
+					SourceVolumeId: utils.MakeVolumeID(sc, snap.Volume),
 					SizeBytes:      int64(snap.SizeBytes),
 					ReadyToUse:     true,
 					CreationTime:   timestamppb.New(snap.CreatedAt),
 				},
 			})
 		}
+		return &csi.ListSnapshotsResponse{Entries: entries}, nil
 	}
 
-	paged, nextToken, err := paginate(entries, req.StartingToken, req.MaxEntries)
+	if req.SourceVolumeId != "" {
+		sc, volName, err := utils.ParseVolumeID(req.SourceVolumeId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid source volume ID: %v", err)
+		}
+		c, ok := agents[sc]
+		if !ok {
+			return &csi.ListSnapshotsResponse{}, nil
+		}
+		snapList, err := c.ListVolumeSnapshots(ctx, volName, agentAPI.ListOpts{})
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "list snapshots from %s: %v", sc, err)
+		}
+		var entries []*csi.ListSnapshotsResponse_Entry
+		for _, snap := range snapList.Snapshots {
+			entries = append(entries, &csi.ListSnapshotsResponse_Entry{
+				Snapshot: &csi.Snapshot{
+					SnapshotId:     utils.MakeVolumeID(sc, snap.Name),
+					SourceVolumeId: utils.MakeVolumeID(sc, snap.Volume),
+					SizeBytes:      int64(snap.SizeBytes),
+					ReadyToUse:     true,
+					CreationTime:   timestamppb.New(snap.CreatedAt),
+				},
+			})
+		}
+		return &csi.ListSnapshotsResponse{Entries: entries}, nil
+	}
+
+	// multi-agent paginated query
+	pt, err := decodePageToken(req.StartingToken)
 	if err != nil {
 		return nil, err
 	}
 
+	sorted := sortedAgents(agents)
+	limit := int(req.MaxEntries)
+
+	var entries []*csi.ListSnapshotsResponse_Entry
+	var nextToken string
+
+	for _, a := range sorted {
+		if pt.SC != "" && a.sc < pt.SC {
+			continue
+		}
+		after := ""
+		if a.sc == pt.SC {
+			after = pt.After
+		}
+
+		start := time.Now()
+		snapList, err := a.client.ListSnapshots(ctx, agentAPI.ListOpts{After: after, Limit: limit})
+		agentDuration.WithLabelValues("list_snapshots", a.sc).Observe(time.Since(start).Seconds())
+		if err != nil {
+			agentOpsTotal.WithLabelValues("list_snapshots", "error", a.sc).Inc()
+			log.Warn().Err(err).Str("sc", a.sc).Msg("failed to list snapshots from agent")
+			continue
+		}
+		agentOpsTotal.WithLabelValues("list_snapshots", "success", a.sc).Inc()
+
+		for _, snap := range snapList.Snapshots {
+			entries = append(entries, &csi.ListSnapshotsResponse_Entry{
+				Snapshot: &csi.Snapshot{
+					SnapshotId:     utils.MakeVolumeID(a.sc, snap.Name),
+					SourceVolumeId: utils.MakeVolumeID(a.sc, snap.Volume),
+					SizeBytes:      int64(snap.SizeBytes),
+					ReadyToUse:     true,
+					CreationTime:   timestamppb.New(snap.CreatedAt),
+				},
+			})
+		}
+
+		if snapList.Next != "" {
+			nextToken = encodePageToken(a.sc, snapList.Next)
+			break
+		}
+
+		if limit > 0 {
+			limit -= len(snapList.Snapshots)
+			if limit <= 0 {
+				break
+			}
+		}
+	}
+
 	return &csi.ListSnapshotsResponse{
-		Entries:   paged,
+		Entries:   entries,
 		NextToken: nextToken,
 	}, nil
 }

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -1,8 +1,9 @@
 package controller
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	agentAPI "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
@@ -12,29 +13,31 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// paginate applies index-based pagination to a slice. Order is non-deterministic
-// (map iteration) which may cause duplicates or skips across paginated requests.
-// Acceptable for now since a single agent is not expected to host more than ~5k
-// volumes and the project is targeting homelab or small prod environments.
-func paginate[T any](entries []T, startingToken string, maxEntries int32) ([]T, string, error) {
-	startIndex := 0
-	if startingToken != "" {
-		idx, err := strconv.Atoi(startingToken)
-		if err != nil {
-			return nil, "", status.Errorf(codes.Aborted, "invalid starting_token: %v", err)
-		}
-		startIndex = idx
+// pageToken encodes/decodes a cursor for multi-agent pagination.
+// Format: base64(json({"sc":"storageclass","after":"last_name"}))
+type pageToken struct {
+	SC    string `json:"sc"`
+	After string `json:"after"`
+}
+
+func encodePageToken(sc, after string) string {
+	data, _ := json.Marshal(pageToken{SC: sc, After: after})
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodePageToken(token string) (pageToken, error) {
+	var pt pageToken
+	if token == "" {
+		return pt, nil
 	}
-	if startIndex > len(entries) {
-		startIndex = len(entries)
+	data, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return pt, status.Errorf(codes.Aborted, "invalid starting_token: %v", err)
 	}
-	entries = entries[startIndex:]
-	var nextToken string
-	if maxEntries > 0 && int(maxEntries) < len(entries) {
-		nextToken = strconv.Itoa(startIndex + int(maxEntries))
-		entries = entries[:maxEntries]
+	if err := json.Unmarshal(data, &pt); err != nil {
+		return pt, status.Errorf(codes.Aborted, "invalid starting_token: %v", err)
 	}
-	return entries, nextToken, nil
+	return pt, nil
 }
 
 const (

--- a/controller/utils_test.go
+++ b/controller/utils_test.go
@@ -6,63 +6,29 @@ import (
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
-// --- TestPaginate ---
+// --- TestPageToken ---
 
-func TestPaginate(t *testing.T) {
-	items := []string{"a", "b", "c", "d", "e"}
-
-	t.Run("empty_slice", func(t *testing.T) {
-		out, next, err := paginate([]string{}, "", 0)
+func TestPageToken(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		token := encodePageToken("my-sc", "vol-42")
+		pt, err := decodePageToken(token)
 		require.NoError(t, err)
-		assert.Empty(t, out)
-		assert.Empty(t, next)
+		assert.Equal(t, "my-sc", pt.SC)
+		assert.Equal(t, "vol-42", pt.After)
 	})
 
-	t.Run("no_limit_no_token", func(t *testing.T) {
-		out, next, err := paginate(items, "", 0)
+	t.Run("empty_token", func(t *testing.T) {
+		pt, err := decodePageToken("")
 		require.NoError(t, err)
-		assert.Equal(t, items, out)
-		assert.Empty(t, next)
-	})
-
-	t.Run("with_max_entries", func(t *testing.T) {
-		out, next, err := paginate(items, "", 2)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"a", "b"}, out)
-		assert.Equal(t, "2", next)
-	})
-
-	t.Run("with_starting_token", func(t *testing.T) {
-		out, next, err := paginate(items, "2", 2)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"c", "d"}, out)
-		assert.Equal(t, "4", next)
-	})
-
-	t.Run("token_at_end", func(t *testing.T) {
-		out, next, err := paginate(items, "4", 10)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"e"}, out)
-		assert.Empty(t, next)
-	})
-
-	t.Run("token_beyond_length", func(t *testing.T) {
-		out, next, err := paginate(items, "99", 0)
-		require.NoError(t, err)
-		assert.Empty(t, out)
-		assert.Empty(t, next)
+		assert.Empty(t, pt.SC)
+		assert.Empty(t, pt.After)
 	})
 
 	t.Run("invalid_token", func(t *testing.T) {
-		_, _, err := paginate(items, "notanumber", 0)
+		_, err := decodePageToken("not-valid-base64!!!")
 		require.Error(t, err)
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		assert.Equal(t, codes.Aborted, st.Code())
 	})
 }
 

--- a/controller/volumes.go
+++ b/controller/volumes.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"time"
 
@@ -15,38 +16,77 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func (s *Server) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	agents := s.agents.Agents()
+type agentEntry struct {
+	sc     string
+	client *agentAPI.Client
+}
 
-	var entries []*csi.ListVolumesResponse_Entry
-	for sc, client := range agents {
-		start := time.Now()
-		volList, err := client.ListVolumes(ctx)
-		agentDuration.WithLabelValues("list_volumes", sc).Observe(time.Since(start).Seconds())
-		if err != nil {
-			agentOpsTotal.WithLabelValues("list_volumes", "error", sc).Inc()
-			log.Warn().Err(err).Str("sc", sc).Msg("failed to list volumes from agent")
-			continue
-		}
-		agentOpsTotal.WithLabelValues("list_volumes", "success", sc).Inc()
-
-		for _, vol := range volList.Volumes {
-			entries = append(entries, &csi.ListVolumesResponse_Entry{
-				Volume: &csi.Volume{
-					VolumeId:      utils.MakeVolumeID(sc, vol.Name),
-					CapacityBytes: int64(vol.SizeBytes),
-				},
-			})
-		}
+func sortedAgents(agents map[string]*agentAPI.Client) []agentEntry {
+	entries := make([]agentEntry, 0, len(agents))
+	for sc, c := range agents {
+		entries = append(entries, agentEntry{sc: sc, client: c})
 	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].sc < entries[j].sc })
+	return entries
+}
 
-	paged, nextToken, err := paginate(entries, req.StartingToken, req.MaxEntries)
+func (s *Server) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	pt, err := decodePageToken(req.StartingToken)
 	if err != nil {
 		return nil, err
 	}
 
+	agents := sortedAgents(s.agents.Agents())
+	limit := int(req.MaxEntries)
+
+	var entries []*csi.ListVolumesResponse_Entry
+	var nextToken string
+
+	for _, a := range agents {
+		if pt.SC != "" && a.sc < pt.SC {
+			continue
+		}
+
+		after := ""
+		if a.sc == pt.SC {
+			after = pt.After
+		}
+
+		opts := agentAPI.ListOpts{After: after, Limit: limit}
+		start := time.Now()
+		volList, err := a.client.ListVolumes(ctx, opts)
+		agentDuration.WithLabelValues("list_volumes", a.sc).Observe(time.Since(start).Seconds())
+		if err != nil {
+			agentOpsTotal.WithLabelValues("list_volumes", "error", a.sc).Inc()
+			log.Warn().Err(err).Str("sc", a.sc).Msg("failed to list volumes from agent")
+			continue
+		}
+		agentOpsTotal.WithLabelValues("list_volumes", "success", a.sc).Inc()
+
+		for _, vol := range volList.Volumes {
+			entries = append(entries, &csi.ListVolumesResponse_Entry{
+				Volume: &csi.Volume{
+					VolumeId:      utils.MakeVolumeID(a.sc, vol.Name),
+					CapacityBytes: int64(vol.SizeBytes),
+				},
+			})
+		}
+
+		if volList.Next != "" {
+			nextToken = encodePageToken(a.sc, volList.Next)
+			break
+		}
+
+		if limit > 0 {
+			limit -= len(volList.Volumes)
+			if limit <= 0 {
+				break
+			}
+		}
+	}
+
 	return &csi.ListVolumesResponse{
-		Entries:   paged,
+		Entries:   entries,
 		NextToken: nextToken,
 	}, nil
 }

--- a/ctl/snapshot.go
+++ b/ctl/snapshot.go
@@ -50,14 +50,14 @@ func snapshotCmd() *cli.Command {
 					}
 					rev := !cmd.Bool("asc")
 					vol := cmd.Args().First()
-					labels := cmd.StringSlice("label")
+					opts := v1.ListOpts{Labels: cmd.StringSlice("label")}
 					if isWide(cmd) {
 						var resp *v1.SnapshotDetailListResponse
 						var err error
 						if vol != "" {
-							resp, err = c.ListVolumeSnapshotsDetail(ctx, vol, labels...)
+							resp, err = c.ListVolumeSnapshotsDetail(ctx, vol, opts)
 						} else {
-							resp, err = c.ListSnapshotsDetail(ctx, labels...)
+							resp, err = c.ListSnapshotsDetail(ctx, opts)
 						}
 						if err != nil {
 							return err
@@ -77,9 +77,9 @@ func snapshotCmd() *cli.Command {
 					var resp *v1.SnapshotListResponse
 					var err error
 					if vol != "" {
-						resp, err = c.ListVolumeSnapshots(ctx, vol, labels...)
+						resp, err = c.ListVolumeSnapshots(ctx, vol, opts)
 					} else {
-						resp, err = c.ListSnapshots(ctx, labels...)
+						resp, err = c.ListSnapshots(ctx, opts)
 					}
 					if err != nil {
 						return err

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -102,9 +102,9 @@ func taskCmd() *cli.Command {
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					c := clientFrom(cmd)
 					taskType := cmd.String("type")
-					labels := cmd.StringSlice("label")
+					opts := v1.ListOpts{Labels: cmd.StringSlice("label")}
 					if isWide(cmd) {
-						resp, err := c.ListTasksDetail(ctx, taskType, labels...)
+						resp, err := c.ListTasksDetail(ctx, taskType, opts)
 						if err != nil {
 							return err
 						}
@@ -139,7 +139,7 @@ func taskCmd() *cli.Command {
 							_ = w.Flush()
 						})
 					}
-					resp, err := c.ListTasks(ctx, taskType, labels...)
+					resp, err := c.ListTasks(ctx, taskType, opts)
 					if err != nil {
 						return err
 					}

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -32,10 +32,10 @@ func volumeCmd() *cli.Command {
 						sortBy = sortUsedPct
 					}
 					rev := !cmd.Bool("asc")
-					labels := cmd.StringSlice("label")
+					opts := v1.ListOpts{Labels: cmd.StringSlice("label")}
 
 					if isWide(cmd) {
-						resp, err := c.ListVolumesDetail(ctx, labels...)
+						resp, err := c.ListVolumesDetail(ctx, opts)
 						if err != nil {
 							return err
 						}
@@ -53,7 +53,7 @@ func volumeCmd() *cli.Command {
 						})
 					}
 
-					resp, err := c.ListVolumes(ctx, labels...)
+					resp, err := c.ListVolumes(ctx, opts)
 					if err != nil {
 						return err
 					}

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -39,6 +39,24 @@ Volumes, snapshots, clones, and tasks support user-defined labels (`map[string]s
 
 Filter with `?label=key=value` (exact match, repeatable, AND logic) or `?label=key` (key exists, any value).
 
+## Pagination
+
+All list endpoints support cursor-based pagination via query parameters:
+
+| Parameter | Description |
+|---|---|
+| `after` | Cursor: return items after this name (exclusive) |
+| `limit` | Max items per page (0 or omitted = all) |
+
+Responses include:
+
+| Field | Description |
+|---|---|
+| `total` | Total number of resources (approximate when volume-filtered) |
+| `next` | Cursor for the next page (empty = last page) |
+
+Example: `GET /v1/volumes?limit=10` returns the first 10 volumes. Use the `next` value as `after` for the next page: `GET /v1/volumes?limit=10&after=<next>`.
+
 ## Volumes
 
 ### POST /v1/volumes
@@ -88,7 +106,7 @@ curl -X POST http://10.0.0.5:8080/v1/volumes \
 
 ### GET /v1/volumes
 
-Returns a summary list. Use `GET /v1/volumes/:name` for full details, or append `?detail=true` to get full details for all volumes in a single call. Filter by label with `?label=key=value` (exact match) or `?label=key` (key exists). Repeatable, AND logic.
+Returns a summary list. Supports pagination (`?after=&limit=`), label filtering (`?label=key=value` or `?label=key`), and `?detail=true` for full details.
 
 ```json
 {
@@ -213,7 +231,7 @@ All fields optional. `size_bytes` must be larger than current. `labels` replaces
 
 ### GET /v1/snapshots
 
-Returns a summary list of all snapshots. Use `GET /v1/snapshots/:name` for full details, or append `?detail=true` to get full details for all snapshots in a single call. Filter by label with `?label=key=value` or `?label=key`. Repeatable, AND logic.
+Returns a summary list of all snapshots. Supports pagination (`?after=&limit=`), label filtering (`?label=key=value` or `?label=key`), and `?detail=true` for full details.
 
 ```json
 {
@@ -234,7 +252,7 @@ With `?detail=true`, each snapshot includes the full detail fields (same as `GET
 
 ### GET /v1/volumes/:name/snapshots
 
-Returns a summary list of snapshots for a specific volume. Same response format as `GET /v1/snapshots`. Also supports `?detail=true` and `?label=` filtering.
+Returns a summary list of snapshots for a specific volume. Same response format as `GET /v1/snapshots`. Supports pagination, label filtering, and `?detail=true`.
 
 ### GET /v1/snapshots/:name
 
@@ -413,7 +431,7 @@ curl -X POST http://10.0.0.5:8080/v1/tasks/test \
 
 ### GET /v1/tasks
 
-List all tasks. Optional `?type=` filter (e.g. `scrub`, `test`). Filter by label with `?label=key=value` or `?label=key`. Repeatable, AND logic. Returns a summary without the `result` field. Append `?detail=true` to include `result` and `labels`.
+List all tasks. Supports pagination (`?after=&limit=`), `?type=` filter, label filtering (`?label=key=value` or `?label=key`), and `?detail=true` for full details including `result` and `labels`.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Replace index-based pagination with name-based cursor pagination across all list endpoints
- Agent storage: `ListVolumesPaginated`, `ListSnapshotsPaginated` with `after`/`limit` params, skip metadata reads for entries before cursor
- Agent API: `?after=NAME&limit=N` query params, `next` field in all list responses
- Task manager: `ListPaginated` with sorted-by-ID cursor
- Exports: `ListExportsPaginated` with path|client composite cursor
- Client: `ListOpts{After, Limit, Labels}` struct replaces variadic labels
- CSI controller: multi-agent pagination with base64-encoded composite token (`sc` + `after`), sorted agent iteration, per-agent limit budget
- Old `paginate()` index-based function removed
- Backward compatible: `after=""`/`limit=0` returns all (existing behavior)