### PR TITLE
CLI UX: column filter, watch mode, delete protection, PVC events

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ If you run a homelab, a small on-prem cluster, or an edge deployment and want re
 - Web dashboard (`/v1/dashboard`)
 - Background task system with progress tracking, persistence, and configurable timeouts
 - Filesystem scrub via API
-- NFS mount health checker with auto-heal (detects stale mounts, remounts automatically, heals all pods without restart)
+- NFS mount health checker with auto-heal (detects stale mounts, remounts automatically, heals all pods without restart, k8s events on PVC)
+- CLI with column filter (`-c`), watch mode (`-w`), label-based delete protection, relative volume resize (`+5Gi`), and xargs-friendly output
 - TLS support
 - HA via DRBD + Pacemaker (active/passive failover)
 

--- a/charts/btrfs-nfs-csi/values.yaml
+++ b/charts/btrfs-nfs-csi/values.yaml
@@ -76,6 +76,12 @@ controller:
   readinessProbe: {}
   extraArgs: []
   extraEnv: []
+  # To add default labels to all volumes created by this controller (e.g. multi-tenant
+  # or multi-cluster setups), set DRIVER_DEFAULT_LABELS.
+  # Note: labels can be added at any time, but cannot be removed from existing volumes.
+  # extraEnv:
+  #   - name: DRIVER_DEFAULT_LABELS
+  #     value: "kubernetes.cluster=my-cluster,env=prod"
   extraVolumes: []
   extraVolumeMounts: []
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/csiserver"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 )
 
 func Start(ctx context.Context, endpoint, metricsAddr, version, commit, defaultLabels string) error {
@@ -29,11 +34,16 @@ func Start(ctx context.Context, endpoint, metricsAddr, version, commit, defaultL
 	agents := NewAgentTracker(kubeClient, version, commit)
 	go agents.Run(ctx)
 
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: config.DriverName + "-controller"})
+	defer broadcaster.Shutdown()
+
 	srv, err := csiserver.New(endpoint, version, metricsInterceptor)
 	if err != nil {
 		return err
 	}
-	csi.RegisterControllerServer(srv.GRPC(), &Server{agents: agents, kubeClient: kubeClient})
+	csi.RegisterControllerServer(srv.GRPC(), &Server{agents: agents, kubeClient: kubeClient, recorder: recorder})
 	return srv.Run(ctx, "controller")
 }
 
@@ -41,6 +51,7 @@ type Server struct {
 	csi.UnimplementedControllerServer
 	agents     *AgentTracker
 	kubeClient kubernetes.Interface
+	recorder   record.EventRecorder
 }
 
 func (s *Server) ValidateVolumeCapabilities(_ context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {

--- a/controller/pvc.go
+++ b/controller/pvc.go
@@ -11,7 +11,9 @@ import (
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	"github.com/rs/zerolog/log"
@@ -105,7 +107,7 @@ func (s *Server) resolveVolumeParams(ctx context.Context, params map[string]stri
 		vp.Mode = v
 	}
 	if v, ok := annos[config.AnnoPrefix+config.ParamLabels]; ok && v != "" {
-		mergeUserLabels(vp.Labels, parseLabels(v), config.MaxUserLabels)
+		s.mergeUserLabels(pvc, vp.Labels, parseLabels(v), config.MaxUserLabels)
 	}
 
 	return vp
@@ -115,9 +117,10 @@ var reservedLabelKeys = map[string]bool{
 	"kubernetes.pvc.name":         true,
 	"kubernetes.pvc.namespace":    true,
 	"kubernetes.pvc.storageclass": true,
+	"created-by":                  true,
 }
 
-func mergeUserLabels(dst, user map[string]string, maxUser int) {
+func (s *Server) mergeUserLabels(pvc runtime.Object, dst, user map[string]string, maxUser int) {
 	keys := make([]string, 0, len(user))
 	for k := range user {
 		keys = append(keys, k)
@@ -128,10 +131,17 @@ func mergeUserLabels(dst, user map[string]string, maxUser int) {
 	for _, k := range keys {
 		if reservedLabelKeys[k] {
 			log.Warn().Str("key", k).Msg("skipping reserved label key from PVC annotation")
+			s.recorder.Eventf(pvc, corev1.EventTypeWarning, "LabelSkipped", "skipping reserved label key %q from PVC annotation", k)
+			continue
+		}
+		if !config.ValidLabelKey.MatchString(k) || !config.ValidLabelVal.MatchString(user[k]) {
+			log.Warn().Str("key", k).Str("value", user[k]).Msg("skipping invalid label from PVC annotation")
+			s.recorder.Eventf(pvc, corev1.EventTypeWarning, "LabelInvalid", "skipping invalid label %q=%q from PVC annotation", k, user[k])
 			continue
 		}
 		if merged >= maxUser {
 			log.Warn().Int("max", maxUser).Msg("too many user labels in PVC annotation, truncating")
+			s.recorder.Eventf(pvc, corev1.EventTypeWarning, "LabelsTruncated", "too many user labels (max %d), remaining labels ignored", maxUser)
 			break
 		}
 		dst[k] = user[k]

--- a/controller/pvc_test.go
+++ b/controller/pvc_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekube "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 )
 
@@ -103,11 +104,18 @@ func TestToUpdateRequest(t *testing.T) {
 
 // --- TestMergeUserLabels ---
 
+func testServer() *Server {
+	return &Server{recorder: record.NewFakeRecorder(10)}
+}
+
 func TestMergeUserLabels(t *testing.T) {
+	srv := testServer()
+	pvc := &corev1.PersistentVolumeClaim{}
+
 	t.Run("basic_merge", func(t *testing.T) {
 		dst := map[string]string{"created-by": "csi"}
 		user := map[string]string{"env": "prod", "team": "be"}
-		mergeUserLabels(dst, user, 4)
+		srv.mergeUserLabels(pvc, dst, user, 4)
 		assert.Equal(t, "csi", dst["created-by"])
 		assert.Equal(t, "prod", dst["env"])
 		assert.Equal(t, "be", dst["team"])
@@ -116,7 +124,7 @@ func TestMergeUserLabels(t *testing.T) {
 	t.Run("reserved_keys_skipped", func(t *testing.T) {
 		dst := map[string]string{"kubernetes.pvc.name": "my-pvc"}
 		user := map[string]string{"kubernetes.pvc.name": "hacked", "env": "prod"}
-		mergeUserLabels(dst, user, 4)
+		srv.mergeUserLabels(pvc, dst, user, 4)
 		assert.Equal(t, "my-pvc", dst["kubernetes.pvc.name"])
 		assert.Equal(t, "prod", dst["env"])
 	})
@@ -124,7 +132,7 @@ func TestMergeUserLabels(t *testing.T) {
 	t.Run("max_user_labels", func(t *testing.T) {
 		dst := map[string]string{}
 		user := map[string]string{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5"}
-		mergeUserLabels(dst, user, 4)
+		srv.mergeUserLabels(pvc, dst, user, 4)
 		assert.Len(t, dst, 4)
 	})
 
@@ -132,8 +140,8 @@ func TestMergeUserLabels(t *testing.T) {
 		dst1 := map[string]string{}
 		dst2 := map[string]string{}
 		user := map[string]string{"z": "1", "a": "2", "m": "3", "b": "4", "x": "5"}
-		mergeUserLabels(dst1, user, 3)
-		mergeUserLabels(dst2, user, 3)
+		srv.mergeUserLabels(pvc, dst1, user, 3)
+		srv.mergeUserLabels(pvc, dst2, user, 3)
 		assert.Equal(t, dst1, dst2)
 		// alphabetically first 3: a, b, m
 		assert.Contains(t, dst1, "a")
@@ -141,11 +149,11 @@ func TestMergeUserLabels(t *testing.T) {
 		assert.Contains(t, dst1, "m")
 	})
 
-	t.Run("user_overrides_non_reserved", func(t *testing.T) {
+	t.Run("created_by_reserved", func(t *testing.T) {
 		dst := map[string]string{"created-by": "csi"}
 		user := map[string]string{"created-by": "terraform"}
-		mergeUserLabels(dst, user, 4)
-		assert.Equal(t, "terraform", dst["created-by"])
+		srv.mergeUserLabels(pvc, dst, user, 4)
+		assert.Equal(t, "csi", dst["created-by"])
 	})
 }
 
@@ -197,7 +205,7 @@ func TestResolveVolumeParams(t *testing.T) {
 				StorageClassName: ptr.To("my-sc"),
 			},
 		}
-		srv := &Server{kubeClient: fakekube.NewSimpleClientset(pvc)}
+		srv := &Server{kubeClient: fakekube.NewSimpleClientset(pvc), recorder: record.NewFakeRecorder(10)}
 
 		params := map[string]string{
 			config.PvcNameKey:      "my-pvc",
@@ -215,7 +223,7 @@ func TestResolveVolumeParams(t *testing.T) {
 	})
 
 	t.Run("no_pvc_info", func(t *testing.T) {
-		srv := &Server{kubeClient: fakekube.NewSimpleClientset()}
+		srv := &Server{kubeClient: fakekube.NewSimpleClientset(), recorder: record.NewFakeRecorder(10)}
 
 		vp := srv.resolveVolumeParams(context.Background(), map[string]string{
 			config.ParamNoCOW: "true",
@@ -227,7 +235,7 @@ func TestResolveVolumeParams(t *testing.T) {
 	})
 
 	t.Run("pvc_not_found", func(t *testing.T) {
-		srv := &Server{kubeClient: fakekube.NewSimpleClientset()}
+		srv := &Server{kubeClient: fakekube.NewSimpleClientset(), recorder: record.NewFakeRecorder(10)}
 
 		vp := srv.resolveVolumeParams(context.Background(), map[string]string{
 			config.PvcNameKey:      "missing",

--- a/ctl/ctl.go
+++ b/ctl/ctl.go
@@ -14,10 +14,87 @@ var (
 	Commit  = "unknown"
 )
 
+func showStats(ctx context.Context, cmd *cli.Command) error {
+	c := clientFrom(cmd)
+	return runWatch(ctx, cmd, func() error {
+		resp, err := c.Stats(ctx)
+		if err != nil {
+			return err
+		}
+		return output(cmd, resp, func() {
+			fmt.Println("statfs:")
+			fmt.Printf("  Total:       %s\n", utils.FormatBytes(resp.Statfs.TotalBytes))
+			fmt.Printf("  Used:        %s (%.0f%%)\n", utils.FormatBytes(resp.Statfs.UsedBytes), usedPct(resp.Statfs.UsedBytes, resp.Statfs.TotalBytes))
+			fmt.Printf("  Free:        %s\n", utils.FormatBytes(resp.Statfs.FreeBytes))
+			fmt.Println()
+			fmt.Println("btrfs:")
+			fmt.Printf("  Total:       %s\n", utils.FormatBytes(resp.Btrfs.TotalBytes))
+			fmt.Printf("  Used:        %s (%.0f%%)\n", utils.FormatBytes(resp.Btrfs.UsedBytes), usedPct(resp.Btrfs.UsedBytes, resp.Btrfs.TotalBytes))
+			fmt.Printf("  Free:        %s\n", utils.FormatBytes(resp.Btrfs.FreeBytes))
+			fmt.Printf("  Unallocated: %s\n", utils.FormatBytes(resp.Btrfs.UnallocatedBytes))
+			fmt.Printf("  Metadata:    %s / %s\n", utils.FormatBytes(resp.Btrfs.MetadataUsedBytes), utils.FormatBytes(resp.Btrfs.MetadataTotalBytes))
+			fmt.Printf("  Data ratio:  %.1f\n", resp.Btrfs.DataRatio)
+			fmt.Println()
+			fmt.Println("devices:")
+			w := tab()
+			if isWide(cmd) {
+				_, _ = fmt.Fprintln(w, "  DEVICE\tSIZE\tALLOCATED\tREAD\tWRITTEN\tREAD_IOS\tWRITE_IOS\tREAD_ERR\tWRITE_ERR\tFLUSH_ERR\tCSUM_ERR\tGEN_ERR\tSTATUS")
+				for _, d := range resp.Btrfs.Devices {
+					status := "ok"
+					if d.Missing {
+						status = "MISSING"
+					} else if d.Errors.ReadErrs+d.Errors.WriteErrs+d.Errors.FlushErrs+d.Errors.CorruptionErrs+d.Errors.GenerationErrs > 0 {
+						status = "ERRORS"
+					}
+					_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
+						d.Device, utils.FormatBytes(d.SizeBytes), utils.FormatBytes(d.AllocatedBytes),
+						utils.FormatBytes(d.IO.ReadBytesTotal), utils.FormatBytes(d.IO.WriteBytesTotal),
+						d.IO.ReadIOsTotal, d.IO.WriteIOsTotal,
+						d.Errors.ReadErrs, d.Errors.WriteErrs, d.Errors.FlushErrs,
+						d.Errors.CorruptionErrs, d.Errors.GenerationErrs, status)
+				}
+			} else {
+				_, _ = fmt.Fprintln(w, "  DEVICE\tSIZE\tALLOCATED\tREAD\tWRITTEN\tERRORS\tSTATUS")
+				for _, d := range resp.Btrfs.Devices {
+					errs := d.Errors.ReadErrs + d.Errors.WriteErrs + d.Errors.FlushErrs + d.Errors.CorruptionErrs + d.Errors.GenerationErrs
+					status := "ok"
+					if d.Missing {
+						status = "MISSING"
+					} else if errs > 0 {
+						status = "ERRORS"
+					}
+					_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+						d.Device, utils.FormatBytes(d.SizeBytes), utils.FormatBytes(d.AllocatedBytes),
+						utils.FormatBytes(d.IO.ReadBytesTotal), utils.FormatBytes(d.IO.WriteBytesTotal),
+						errs, status)
+				}
+			}
+			_ = w.Flush()
+		})
+	})
+}
+
+func showHealth(ctx context.Context, cmd *cli.Command) error {
+	resp, err := clientFrom(cmd).Healthz(ctx)
+	if err != nil {
+		return err
+	}
+	return output(cmd, resp, func() {
+		fmt.Printf("status:  %s\nversion: %s\ncommit:  %s\nuptime:  %ds\n",
+			resp.Status, resp.Version, resp.Commit, resp.UptimeSeconds)
+	})
+}
+
 func Run(args []string) {
 	app := &cli.Command{
 		Name:  "btrfs-nfs-csi",
 		Usage: "btrfs-nfs-csi agent CLI",
+		After: func(ctx context.Context, cmd *cli.Command) error {
+			if !isJSON(cmd) && !cmd.IsSet("watch") {
+				fmt.Println()
+			}
+			return nil
+		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "agent-url", Sources: cli.EnvVars("AGENT_URL"), Usage: "agent API URL"},
 			&cli.StringFlag{Name: "agent-token", Sources: cli.EnvVars("AGENT_TOKEN"), Usage: "tenant token"},
@@ -37,83 +114,20 @@ func Run(args []string) {
 				},
 			},
 			{
-				Name:  "stats",
-				Usage: "show filesystem stats",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					resp, err := clientFrom(cmd).Stats(ctx)
-					if err != nil {
-						return err
-					}
-					return output(cmd, resp, func() {
-						fmt.Println("statfs:")
-						fmt.Printf("  Total:       %s\n", utils.FormatBytes(resp.Statfs.TotalBytes))
-						fmt.Printf("  Used:        %s (%.0f%%)\n", utils.FormatBytes(resp.Statfs.UsedBytes), usedPct(resp.Statfs.UsedBytes, resp.Statfs.TotalBytes))
-						fmt.Printf("  Free:        %s\n", utils.FormatBytes(resp.Statfs.FreeBytes))
-						fmt.Println()
-						fmt.Println("btrfs:")
-						fmt.Printf("  Total:       %s\n", utils.FormatBytes(resp.Btrfs.TotalBytes))
-						fmt.Printf("  Used:        %s (%.0f%%)\n", utils.FormatBytes(resp.Btrfs.UsedBytes), usedPct(resp.Btrfs.UsedBytes, resp.Btrfs.TotalBytes))
-						fmt.Printf("  Free:        %s\n", utils.FormatBytes(resp.Btrfs.FreeBytes))
-						fmt.Printf("  Unallocated: %s\n", utils.FormatBytes(resp.Btrfs.UnallocatedBytes))
-						fmt.Printf("  Metadata:    %s / %s\n", utils.FormatBytes(resp.Btrfs.MetadataUsedBytes), utils.FormatBytes(resp.Btrfs.MetadataTotalBytes))
-						fmt.Printf("  Data ratio:  %.1f\n", resp.Btrfs.DataRatio)
-						fmt.Println()
-						fmt.Println("devices:")
-						w := tab()
-						if isWide(cmd) {
-							_, _ = fmt.Fprintln(w, "  DEVICE\tSIZE\tALLOCATED\tREAD\tWRITTEN\tREAD_IOS\tWRITE_IOS\tREAD_ERR\tWRITE_ERR\tFLUSH_ERR\tCSUM_ERR\tGEN_ERR\tSTATUS")
-							for _, d := range resp.Btrfs.Devices {
-								status := "ok"
-								if d.Missing {
-									status = "MISSING"
-								} else if d.Errors.ReadErrs+d.Errors.WriteErrs+d.Errors.FlushErrs+d.Errors.CorruptionErrs+d.Errors.GenerationErrs > 0 {
-									status = "ERRORS"
-								}
-								_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
-									d.Device, utils.FormatBytes(d.SizeBytes), utils.FormatBytes(d.AllocatedBytes),
-									utils.FormatBytes(d.IO.ReadBytesTotal), utils.FormatBytes(d.IO.WriteBytesTotal),
-									d.IO.ReadIOsTotal, d.IO.WriteIOsTotal,
-									d.Errors.ReadErrs, d.Errors.WriteErrs, d.Errors.FlushErrs,
-									d.Errors.CorruptionErrs, d.Errors.GenerationErrs, status)
-							}
-						} else {
-							_, _ = fmt.Fprintln(w, "  DEVICE\tSIZE\tALLOCATED\tREAD\tWRITTEN\tERRORS\tSTATUS")
-							for _, d := range resp.Btrfs.Devices {
-								errs := d.Errors.ReadErrs + d.Errors.WriteErrs + d.Errors.FlushErrs + d.Errors.CorruptionErrs + d.Errors.GenerationErrs
-								status := "ok"
-								if d.Missing {
-									status = "MISSING"
-								} else if errs > 0 {
-									status = "ERRORS"
-								}
-								_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%d\t%s\n",
-									d.Device, utils.FormatBytes(d.SizeBytes), utils.FormatBytes(d.AllocatedBytes),
-									utils.FormatBytes(d.IO.ReadBytesTotal), utils.FormatBytes(d.IO.WriteBytesTotal),
-									errs, status)
-							}
-						}
-						_ = w.Flush()
-					})
-				},
+				Name:   "stats",
+				Usage:  "show filesystem stats",
+				Flags:  []cli.Flag{watchFlag()},
+				Action: showStats,
 			},
 			{
-				Name:  "health",
-				Usage: "show agent health",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					resp, err := clientFrom(cmd).Healthz(ctx)
-					if err != nil {
-						return err
-					}
-					return output(cmd, resp, func() {
-						fmt.Printf("status:  %s\nversion: %s\ncommit:  %s\nuptime:  %ds\n",
-							resp.Status, resp.Version, resp.Commit, resp.UptimeSeconds)
-					})
-				},
+				Name:   "health",
+				Usage:  "show agent health",
+				Action: showHealth,
 			},
 		},
 	}
 
-	if err := app.Run(context.Background(), append([]string{"btrfs-nfs-csi"}, args...)); err != nil {
+	if err := app.Run(context.Background(), append([]string{"btrfs-nfs-csi"}, injectWatchDefault(args)...)); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/ctl/export.go
+++ b/ctl/export.go
@@ -52,4 +52,3 @@ func exportList(ctx context.Context, cmd *cli.Command) error {
 		})
 	})
 }
-

--- a/ctl/export.go
+++ b/ctl/export.go
@@ -7,66 +7,49 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func exportCmd() *cli.Command {
-	return &cli.Command{
-		Name:    "export",
-		Aliases: []string{"exports"},
-		Usage:   "manage NFS exports",
-		Commands: []*cli.Command{
-			{
-				Name:      "add",
-				Usage:     "add NFS export",
-				ArgsUsage: "<volume> <client-ip>",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					if cmd.NArg() < 2 {
-						return fmt.Errorf("usage: export add <volume> <client-ip>")
-					}
-					vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
-					if err := clientFrom(cmd).ExportVolume(ctx, vol, client); err != nil {
-						return wrapErr(err, "volume", vol)
-					}
-					return output(cmd, map[string]string{"volume": vol, "client": client}, func() {
-						fmt.Printf("exported %q to %s\n", vol, client)
-					})
-				},
-			},
-			{
-				Name:      "remove",
-				Aliases:   []string{"rm"},
-				Usage:     "remove NFS export",
-				ArgsUsage: "<volume> <client-ip>",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					if cmd.NArg() < 2 {
-						return fmt.Errorf("usage: export remove <volume> <client-ip>")
-					}
-					vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
-					if err := clientFrom(cmd).UnexportVolume(ctx, vol, client); err != nil {
-						return wrapErr(err, "volume", vol)
-					}
-					return output(cmd, map[string]string{"volume": vol, "client": client}, func() {
-						fmt.Printf("unexported %q from %s\n", vol, client)
-					})
-				},
-			},
-			{
-				Name:    "list",
-				Aliases: []string{"ls"},
-				Usage:   "list active NFS exports",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					resp, err := clientFrom(cmd).ListExports(ctx)
-					if err != nil {
-						return err
-					}
-					return output(cmd, resp, func() {
-						w := tab()
-						_, _ = fmt.Fprintln(w, "PATH\tCLIENT")
-						for _, e := range resp.Exports {
-							_, _ = fmt.Fprintf(w, "%s\t%s\n", e.Path, e.Client)
-						}
-						_ = w.Flush()
-					})
-				},
-			},
-		},
+func exportAdd(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() < 2 {
+		return fmt.Errorf("usage: export add <volume> <client-ip>")
 	}
+	vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
+	if err := clientFrom(cmd).ExportVolume(ctx, vol, client); err != nil {
+		return wrapErr(err, "volume", vol)
+	}
+	if !isJSON(cmd) {
+		fmt.Printf("exported %q to %s\n", vol, client)
+	}
+	return nil
 }
+
+func exportRemove(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() < 2 {
+		return fmt.Errorf("usage: export remove <volume> <client-ip>")
+	}
+	vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
+	if err := clientFrom(cmd).UnexportVolume(ctx, vol, client); err != nil {
+		return wrapErr(err, "volume", vol)
+	}
+	if !isJSON(cmd) {
+		fmt.Printf("unexported %q from %s\n", vol, client)
+	}
+	return nil
+}
+
+func exportList(ctx context.Context, cmd *cli.Command) error {
+	c := clientFrom(cmd)
+	return runWatch(ctx, cmd, func() error {
+		resp, err := c.ListExports(ctx)
+		if err != nil {
+			return err
+		}
+		return output(cmd, resp, func() {
+			tw := newTableWriter(cmd, []string{"PATH", "CLIENT"})
+			tw.writeHeader()
+			for _, e := range resp.Exports {
+				tw.writeRow(map[string]string{"PATH": e.Path, "CLIENT": e.Client})
+			}
+			tw.flush()
+		})
+	})
+}
+

--- a/ctl/model.go
+++ b/ctl/model.go
@@ -1,0 +1,239 @@
+package ctl
+
+import (
+	"context"
+
+	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/urfave/cli/v3"
+)
+
+func volumeCmd() *cli.Command {
+	return &cli.Command{
+		Name:    "volume",
+		Aliases: []string{"volumes", "vol"},
+		Usage:   "manage volumes",
+		Commands: []*cli.Command{
+			{
+				Name:    "list",
+				Aliases: []string{"ls"},
+				Usage:   "list all volumes",
+				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					c := clientFrom(cmd)
+					sortBy := cmd.String("sort")
+					if sortBy == "" {
+						sortBy = sortUsedPct
+					}
+					rev := !cmd.Bool("asc")
+					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					return runWatch(ctx, cmd, func() error {
+						return listVolumes(ctx, cmd, c, sortBy, rev, opts)
+					})
+				},
+			},
+			{
+				Name:      "get",
+				Usage:     "get volume details",
+				ArgsUsage: "<name>",
+				Action:    volumeGet,
+			},
+			{
+				Name:      "create",
+				Usage:     "create a volume",
+				ArgsUsage: "<name> <size>",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "compression", Aliases: []string{"c"}, Usage: "compression: zstd, lzo, zlib"},
+					&cli.BoolFlag{Name: "nocow", Aliases: []string{"C"}, Usage: "disable copy-on-write (for databases)"},
+					&cli.IntFlag{Name: "uid", Aliases: []string{"u"}, Usage: "owner UID"},
+					&cli.IntFlag{Name: "gid", Aliases: []string{"g"}, Usage: "owner GID"},
+					&cli.StringFlag{Name: "mode", Aliases: []string{"m"}, Usage: "directory mode (octal)"},
+					labelFlag(),
+				},
+				Action: volumeCreate,
+			},
+			{
+				Name:      "delete",
+				Aliases:   []string{"rm"},
+				Usage:     "delete volumes",
+				ArgsUsage: "<name> [name...]",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "confirm", Hidden: true},
+					&cli.BoolFlag{Name: "yes", Hidden: true},
+				},
+				Action: volumeDelete,
+			},
+			{
+				Name:      "expand",
+				Usage:     "resize a volume",
+				ArgsUsage: "<name> <size|+size|-size>",
+				Action:    volumeExpand,
+			},
+			{
+				Name:      "clone",
+				Usage:     "clone a volume (PVC-to-PVC)",
+				ArgsUsage: "<source> <name>",
+				Flags:     []cli.Flag{labelFlag()},
+				Action:    volumeClone,
+			},
+		},
+	}
+}
+
+func snapshotCmd() *cli.Command {
+	return &cli.Command{
+		Name:    "snapshot",
+		Aliases: []string{"snapshots", "snap"},
+		Usage:   "manage snapshots",
+		Commands: []*cli.Command{
+			{
+				Name:      "list",
+				Aliases:   []string{"ls"},
+				Usage:     "list snapshots (optionally filter by volume)",
+				ArgsUsage: "[volume]",
+				Flags:     []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					c := clientFrom(cmd)
+					sortBy := cmd.String("sort")
+					if sortBy == "" {
+						sortBy = sortCreated
+					}
+					rev := !cmd.Bool("asc")
+					vol := cmd.Args().First()
+					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					return runWatch(ctx, cmd, func() error {
+						return listSnapshots(ctx, cmd, c, vol, sortBy, rev, opts)
+					})
+				},
+			},
+			{
+				Name:      "get",
+				Usage:     "get snapshot details",
+				ArgsUsage: "<name>",
+				Action:    snapshotGet,
+			},
+			{
+				Name:      "create",
+				Usage:     "create a snapshot",
+				ArgsUsage: "<volume> <name>",
+				Flags:     []cli.Flag{labelFlag()},
+				Action:    snapshotCreate,
+			},
+			{
+				Name:      "delete",
+				Aliases:   []string{"rm"},
+				Usage:     "delete snapshots",
+				ArgsUsage: "<name> [name...]",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "confirm", Hidden: true},
+					&cli.BoolFlag{Name: "yes", Hidden: true},
+				},
+				Action: snapshotDelete,
+			},
+			{
+				Name:      "clone",
+				Usage:     "create writable clone from snapshot",
+				ArgsUsage: "<snapshot> <name>",
+				Flags:     []cli.Flag{labelFlag()},
+				Action:    snapshotClone,
+			},
+		},
+	}
+}
+
+func exportCmd() *cli.Command {
+	return &cli.Command{
+		Name:    "export",
+		Aliases: []string{"exports"},
+		Usage:   "manage NFS exports",
+		Commands: []*cli.Command{
+			{
+				Name:      "add",
+				Usage:     "add NFS export",
+				ArgsUsage: "<volume> <client-ip>",
+				Action:    exportAdd,
+			},
+			{
+				Name:      "remove",
+				Aliases:   []string{"rm"},
+				Usage:     "remove NFS export",
+				ArgsUsage: "<volume> <client-ip>",
+				Action:    exportRemove,
+			},
+			{
+				Name:    "list",
+				Aliases: []string{"ls"},
+				Usage:   "list active NFS exports",
+				Flags:   []cli.Flag{columnsFlag(), watchFlag()},
+				Action:  exportList,
+			},
+		},
+	}
+}
+
+func taskCmd() *cli.Command {
+	return &cli.Command{
+		Name:    "task",
+		Aliases: []string{"tasks"},
+		Usage:   "manage background tasks",
+		Commands: []*cli.Command{
+			{
+				Name:    "list",
+				Aliases: []string{"ls"},
+				Usage:   "list tasks",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "filter by type (e.g. scrub)"},
+					labelFlag(),
+					columnsFlag(),
+					watchFlag(),
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					c := clientFrom(cmd)
+					taskType := cmd.String("type")
+					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					return runWatch(ctx, cmd, func() error {
+						return listTasks(ctx, cmd, c, taskType, opts)
+					})
+				},
+			},
+			{
+				Name:      "get",
+				Usage:     "get task details",
+				ArgsUsage: "<id>",
+				Action:    taskGet,
+			},
+			{
+				Name:      "cancel",
+				Usage:     "cancel a running task",
+				ArgsUsage: "<id>",
+				Action:    taskCancel,
+			},
+			{
+				Name:  "create",
+				Usage: "create a background task",
+				Commands: []*cli.Command{
+					{
+						Name:  v1.TaskTypeScrub,
+						Usage: "start a btrfs scrub",
+						Flags: []cli.Flag{
+							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
+							&cli.BoolFlag{Name: "wait", Aliases: []string{"W"}, Usage: "wait for completion"},
+							labelFlag(),
+						},
+						Action: taskCreateScrub,
+					},
+					{
+						Name:  v1.TaskTypeTest,
+						Usage: "start a test task",
+						Flags: []cli.Flag{
+							&cli.DurationFlag{Name: "sleep", Aliases: []string{"s"}, Usage: "sleep duration (e.g. 10s, 1m)"},
+							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
+							&cli.BoolFlag{Name: "wait", Aliases: []string{"W"}, Usage: "wait for completion"},
+							labelFlag(),
+						},
+						Action: taskCreateTest,
+					},
+				},
+			},
+		},
+	}
+}

--- a/ctl/snapshot.go
+++ b/ctl/snapshot.go
@@ -137,4 +137,3 @@ func snapshotClone(ctx context.Context, cmd *cli.Command) error {
 	}
 	return output(cmd, resp, func() { fmt.Printf("clone %q created from snapshot %q\n", resp.Name, resp.SourceSnapshot) })
 }
-

--- a/ctl/snapshot.go
+++ b/ctl/snapshot.go
@@ -11,172 +11,130 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func snapshotCloneCmd() *cli.Command {
-	return &cli.Command{
-		Name:      "clone",
-		Usage:     "create writable clone from snapshot",
-		ArgsUsage: "<snapshot> <name>",
-		Flags:     []cli.Flag{labelFlag()},
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.NArg() < 2 {
-				return fmt.Errorf("usage: snapshot clone <snapshot> <name>")
+func listSnapshots(ctx context.Context, cmd *cli.Command, c *v1.Client, vol, sortBy string, rev bool, opts v1.ListOpts) error {
+	if isWide(cmd) {
+		var resp *v1.SnapshotDetailListResponse
+		var err error
+		if vol != "" {
+			resp, err = c.ListVolumeSnapshotsDetail(ctx, vol, opts)
+		} else {
+			resp, err = c.ListSnapshotsDetail(ctx, opts)
+		}
+		if err != nil {
+			return err
+		}
+		sortSnapshotsDetail(resp.Snapshots, sortBy, rev)
+		return output(cmd, resp, func() {
+			tw := newTableWriter(cmd, []string{"NAME", "VOLUME", "SIZE", "USED", "EXCLUSIVE", "READONLY", "LABELS", "CREATED"})
+			tw.writeHeader()
+			for _, s := range resp.Snapshots {
+				tw.writeRow(map[string]string{
+					"NAME": s.Name, "VOLUME": s.Volume, "SIZE": utils.FormatBytes(s.SizeBytes), "USED": utils.FormatBytes(s.UsedBytes),
+					"EXCLUSIVE": utils.FormatBytes(s.ExclusiveBytes), "READONLY": fmt.Sprintf("%v", s.ReadOnly),
+					"LABELS": formatLabelsShort(s.Labels), "CREATED": s.CreatedAt.Format(timeFmt),
+				})
 			}
-			resp, err := clientFrom(cmd).CreateClone(ctx, v1.CloneCreateRequest{Snapshot: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
-			if err != nil {
-				return wrapErr(err, "clone", cmd.Args().Get(1))
-			}
-			return output(cmd, resp, func() { fmt.Printf("clone %q created from snapshot %q\n", resp.Name, resp.SourceSnapshot) })
-		},
+			tw.flush()
+		})
 	}
+	var resp *v1.SnapshotListResponse
+	var err error
+	if vol != "" {
+		resp, err = c.ListVolumeSnapshots(ctx, vol, opts)
+	} else {
+		resp, err = c.ListSnapshots(ctx, opts)
+	}
+	if err != nil {
+		return err
+	}
+	sortSnapshots(resp.Snapshots, sortBy, rev)
+	return output(cmd, resp, func() {
+		tw := newTableWriter(cmd, []string{"NAME", "VOLUME", "SIZE", "USED", "CREATED"})
+		tw.writeHeader()
+		for _, s := range resp.Snapshots {
+			tw.writeRow(map[string]string{
+				"NAME": s.Name, "VOLUME": s.Volume, "SIZE": utils.FormatBytes(s.SizeBytes),
+				"USED": utils.FormatBytes(s.UsedBytes), "CREATED": s.CreatedAt.Format(timeFmt),
+			})
+		}
+		tw.flush()
+	})
 }
 
-func snapshotCmd() *cli.Command {
-	return &cli.Command{
-		Name:    "snapshot",
-		Aliases: []string{"snapshots", "snap"},
-		Usage:   "manage snapshots",
-		Commands: []*cli.Command{
-			{
-				Name:      "list",
-				Aliases:   []string{"ls"},
-				Usage:     "list snapshots (optionally filter by volume)",
-				ArgsUsage: "[volume]",
-				Flags:     []cli.Flag{sortFlag(), ascFlag(), labelFlag()},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					c := clientFrom(cmd)
-					sortBy := cmd.String("sort")
-					if sortBy == "" {
-						sortBy = sortCreated
-					}
-					rev := !cmd.Bool("asc")
-					vol := cmd.Args().First()
-					opts := v1.ListOpts{Labels: cmd.StringSlice("label")}
-					if isWide(cmd) {
-						var resp *v1.SnapshotDetailListResponse
-						var err error
-						if vol != "" {
-							resp, err = c.ListVolumeSnapshotsDetail(ctx, vol, opts)
-						} else {
-							resp, err = c.ListSnapshotsDetail(ctx, opts)
-						}
-						if err != nil {
-							return err
-						}
-						sortSnapshotsDetail(resp.Snapshots, sortBy, rev)
-						return output(cmd, resp, func() {
-							w := tab()
-							_, _ = fmt.Fprintln(w, "NAME\tVOLUME\tSIZE\tUSED\tEXCLUSIVE\tREADONLY\tLABELS\tCREATED")
-							for _, s := range resp.Snapshots {
-								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%v\t%s\t%s\n",
-									s.Name, s.Volume, utils.FormatBytes(s.SizeBytes), utils.FormatBytes(s.UsedBytes),
-									utils.FormatBytes(s.ExclusiveBytes), s.ReadOnly, formatLabelsShort(s.Labels), s.CreatedAt.Format(timeFmt))
-							}
-							_ = w.Flush()
-						})
-					}
-					var resp *v1.SnapshotListResponse
-					var err error
-					if vol != "" {
-						resp, err = c.ListVolumeSnapshots(ctx, vol, opts)
-					} else {
-						resp, err = c.ListSnapshots(ctx, opts)
-					}
-					if err != nil {
-						return err
-					}
-					sortSnapshots(resp.Snapshots, sortBy, rev)
-					return output(cmd, resp, func() {
-						w := tab()
-						_, _ = fmt.Fprintln(w, "NAME\tVOLUME\tSIZE\tUSED\tCREATED")
-						for _, s := range resp.Snapshots {
-							_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-								s.Name, s.Volume, utils.FormatBytes(s.SizeBytes), utils.FormatBytes(s.UsedBytes), s.CreatedAt.Format(timeFmt))
-						}
-						_ = w.Flush()
-					})
-				},
-			},
-			{
-				Name:      "get",
-				Usage:     "get snapshot details",
-				ArgsUsage: "<name>",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					name := cmd.Args().First()
-					if name == "" {
-						return fmt.Errorf("snapshot name required")
-					}
-					resp, err := clientFrom(cmd).GetSnapshot(ctx, name)
-					if err != nil {
-						return wrapErr(err, "snapshot", name)
-					}
-					return output(cmd, resp, func() {
-						fmt.Printf("Name:       %s\n", resp.Name)
-						fmt.Printf("Volume:     %s\n", resp.Volume)
-						fmt.Printf("Size:       %s\n", utils.FormatBytes(resp.SizeBytes))
-						fmt.Printf("Used:       %s\n", utils.FormatBytes(resp.UsedBytes))
-						fmt.Printf("Exclusive:  %s\n", utils.FormatBytes(resp.ExclusiveBytes))
-						fmt.Printf("ReadOnly:   %v\n", resp.ReadOnly)
-						printLabels("Labels:", resp.Labels, 12)
-						fmt.Printf("Created:    %s\n", resp.CreatedAt.Format(timeFmt))
-						fmt.Printf("Updated:    %s\n", resp.UpdatedAt.Format(timeFmt))
-					})
-				},
-			},
-			{
-				Name:      "create",
-				Usage:     "create a snapshot",
-				ArgsUsage: "<volume> <name>",
-				Flags:     []cli.Flag{labelFlag()},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					if cmd.NArg() < 2 {
-						return fmt.Errorf("usage: snapshot create <volume> <name>")
-					}
-					resp, err := clientFrom(cmd).CreateSnapshot(ctx, v1.SnapshotCreateRequest{Volume: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: labelsWithDefault(cmd, "created-by", "cli")})
-					if err != nil {
-						return wrapErr(err, "snapshot", cmd.Args().Get(1))
-					}
-					return output(cmd, resp, func() { fmt.Printf("snapshot %q created from volume %q\n", resp.Name, resp.Volume) })
-				},
-			},
-			{
-				Name:      "delete",
-				Aliases:   []string{"rm"},
-				Usage:     "delete snapshots",
-				ArgsUsage: "<name> [name...]",
-				Flags: []cli.Flag{
-					&cli.BoolFlag{Name: "confirm", Hidden: true},
-					&cli.BoolFlag{Name: "yes", Hidden: true},
-				},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					names := cmd.Args().Slice()
-					if len(names) == 0 {
-						return fmt.Errorf("snapshot name required")
-					}
-					force := os.Getenv("BTRFS_NFS_CSI_FORCE") == "true"
-					if !force && !cmd.Bool("confirm") {
-						_, _ = fmt.Fprintf(os.Stderr, "to delete, run:\n  btrfs-nfs-csi snapshot delete %s --confirm\n", strings.Join(names, " "))
-						return nil
-					}
-					if !force && !cmd.Bool("yes") {
-						_, _ = fmt.Fprintf(os.Stderr, "this will permanently destroy all snapshots.\nto proceed, run:\n  btrfs-nfs-csi snapshot delete %s --confirm --yes\n", strings.Join(names, " "))
-						return nil
-					}
-					c := clientFrom(cmd)
-					deleted := make([]string, 0, len(names))
-					for _, name := range names {
-						if err := c.DeleteSnapshot(ctx, name); err != nil {
-							return wrapErr(err, "snapshot", name)
-						}
-						deleted = append(deleted, name)
-					}
-					return output(cmd, map[string]any{"deleted": deleted}, func() {
-						for _, name := range deleted {
-							fmt.Printf("snapshot %q deleted\n", name)
-						}
-					})
-				},
-			},
-			snapshotCloneCmd(),
-		},
+func snapshotGet(ctx context.Context, cmd *cli.Command) error {
+	name := cmd.Args().First()
+	if name == "" {
+		return fmt.Errorf("snapshot name required")
 	}
+	resp, err := clientFrom(cmd).GetSnapshot(ctx, name)
+	if err != nil {
+		return wrapErr(err, "snapshot", name)
+	}
+	return output(cmd, resp, func() {
+		fmt.Printf("Name:       %s\n", resp.Name)
+		fmt.Printf("Volume:     %s\n", resp.Volume)
+		fmt.Printf("Size:       %s\n", utils.FormatBytes(resp.SizeBytes))
+		fmt.Printf("Used:       %s\n", utils.FormatBytes(resp.UsedBytes))
+		fmt.Printf("Exclusive:  %s\n", utils.FormatBytes(resp.ExclusiveBytes))
+		fmt.Printf("ReadOnly:   %v\n", resp.ReadOnly)
+		printLabels("Labels:", resp.Labels, 12)
+		fmt.Printf("Created:    %s\n", resp.CreatedAt.Format(timeFmt))
+		fmt.Printf("Updated:    %s\n", resp.UpdatedAt.Format(timeFmt))
+	})
 }
+
+func snapshotCreate(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() < 2 {
+		return fmt.Errorf("usage: snapshot create <volume> <name>")
+	}
+	resp, err := clientFrom(cmd).CreateSnapshot(ctx, v1.SnapshotCreateRequest{Volume: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: labelsWithDefault(cmd, "created-by", cliIdentity())})
+	if err != nil {
+		return wrapErr(err, "snapshot", cmd.Args().Get(1))
+	}
+	return output(cmd, resp, func() { fmt.Printf("snapshot %q created from volume %q\n", resp.Name, resp.Volume) })
+}
+
+func snapshotDelete(ctx context.Context, cmd *cli.Command) error {
+	names := cmd.Args().Slice()
+	if len(names) == 0 {
+		return fmt.Errorf("snapshot name required")
+	}
+	force := os.Getenv("BTRFS_NFS_CSI_FORCE") == "true"
+	confirmed := force || (cmd.Bool("confirm") && cmd.Bool("yes"))
+	c := clientFrom(cmd)
+	var protected []string
+	for _, name := range names {
+		if !confirmed {
+			snap, err := c.GetSnapshot(ctx, name)
+			if err != nil {
+				return wrapErr(err, "snapshot", name)
+			}
+			if snap.Labels["created-by"] != cliIdentity() {
+				protected = append(protected, name)
+				continue
+			}
+		}
+		if err := c.DeleteSnapshot(ctx, name); err != nil {
+			return wrapErr(err, "snapshot", name)
+		}
+		if !isJSON(cmd) {
+			fmt.Printf("snapshot %q deleted\n", name)
+		}
+	}
+	if len(protected) > 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "skipped %d protected snapshot(s) (created-by != cli):\n  btrfs-nfs-csi snapshot delete %s --confirm --yes\n", len(protected), strings.Join(protected, " "))
+	}
+	return nil
+}
+
+func snapshotClone(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() < 2 {
+		return fmt.Errorf("usage: snapshot clone <snapshot> <name>")
+	}
+	resp, err := clientFrom(cmd).CreateClone(ctx, v1.CloneCreateRequest{Snapshot: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
+	if err != nil {
+		return wrapErr(err, "clone", cmd.Args().Get(1))
+	}
+	return output(cmd, resp, func() { fmt.Printf("clone %q created from snapshot %q\n", resp.Name, resp.SourceSnapshot) })
+}
+

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -286,4 +286,3 @@ func waitForTask(ctx context.Context, c *v1.Client, id string) error {
 		}
 	}
 }
-

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -85,215 +85,169 @@ func genericResultSummary(result json.RawMessage) string {
 	return strings.Join(parts, ", ")
 }
 
-func taskCmd() *cli.Command {
-	return &cli.Command{
-		Name:    "task",
-		Aliases: []string{"tasks"},
-		Usage:   "manage background tasks",
-		Commands: []*cli.Command{
-			{
-				Name:    "list",
-				Aliases: []string{"ls"},
-				Usage:   "list tasks",
-				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "filter by type (e.g. scrub)"},
-					labelFlag(),
-				},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					c := clientFrom(cmd)
-					taskType := cmd.String("type")
-					opts := v1.ListOpts{Labels: cmd.StringSlice("label")}
-					if isWide(cmd) {
-						resp, err := c.ListTasksDetail(ctx, taskType, opts)
-						if err != nil {
-							return err
-						}
-						sort.Slice(resp.Tasks, func(i, j int) bool {
-							return resp.Tasks[i].CreatedAt.After(resp.Tasks[j].CreatedAt)
-						})
-						return output(cmd, resp, func() {
-							w := tab()
-							_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tLABELS\tTIMEOUT\tTOOK\tCREATED\tRESULT\tERROR")
-							for _, t := range resp.Tasks {
-								took := "-"
-								if t.CompletedAt != nil {
-									took = fmtDuration(t.CompletedAt.Sub(t.CreatedAt))
-								} else if t.StartedAt != nil {
-									took = fmtDuration(time.Since(*t.StartedAt))
-								}
-								result := taskResultSummary(&t)
-								if result == "" {
-									result = "-"
-								}
-								timeout := "-"
-								if t.Timeout != "" {
-									timeout = t.Timeout
-								}
-								errMsg := "-"
-								if t.Error != "" {
-									errMsg = t.Error
-								}
-								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\t%s\t%s\t%s\t%s\n",
-									t.ID, t.Type, t.Status, t.Progress, formatLabelsShort(t.Labels), timeout, took, t.CreatedAt.Format(timeFmt), result, errMsg)
-							}
-							_ = w.Flush()
-						})
-					}
-					resp, err := c.ListTasks(ctx, taskType, opts)
-					if err != nil {
-						return err
-					}
-					sort.Slice(resp.Tasks, func(i, j int) bool {
-						return resp.Tasks[i].CreatedAt.After(resp.Tasks[j].CreatedAt)
-					})
-					return output(cmd, resp, func() {
-						w := tab()
-						_, _ = fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tPROGRESS\tTIMEOUT\tTOOK\tCREATED")
-						for _, t := range resp.Tasks {
-							took := "-"
-							if t.CompletedAt != nil {
-								took = fmtDuration(t.CompletedAt.Sub(t.CreatedAt))
-							} else if t.StartedAt != nil {
-								took = fmtDuration(time.Since(*t.StartedAt))
-							}
-							timeout := "-"
-							if t.Timeout != "" {
-								timeout = t.Timeout
-							}
-							_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d%%\t%s\t%s\t%s\n",
-								t.ID, t.Type, t.Status, t.Progress, timeout, took, t.CreatedAt.Format(timeFmt))
-						}
-						_ = w.Flush()
-					})
-				},
-			},
-			{
-				Name:      "get",
-				Usage:     "get task details",
-				ArgsUsage: "<id>",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					id := cmd.Args().First()
-					if id == "" {
-						return fmt.Errorf("task ID required")
-					}
-					resp, err := clientFrom(cmd).GetTask(ctx, id)
-					if err != nil {
-						return wrapErr(err, "task", id)
-					}
-					return output(cmd, resp, func() {
-						fmt.Printf("ID:         %s\n", resp.ID)
-						fmt.Printf("Type:       %s\n", resp.Type)
-						if len(resp.Opts) > 0 {
-							parts := make([]string, 0, len(resp.Opts))
-							for k, v := range resp.Opts {
-								parts = append(parts, k+"="+v)
-							}
-							fmt.Printf("Opts:       %s\n", strings.Join(parts, ", "))
-						}
-						printLabels("Labels:", resp.Labels, 12)
-						if resp.Timeout != "" {
-							fmt.Printf("Timeout:    %s\n", resp.Timeout)
-						}
-						fmt.Printf("Status:     %s\n", resp.Status)
-						fmt.Printf("Progress:   %d%%\n", resp.Progress)
-						if resp.Error != "" {
-							fmt.Printf("Error:      %s\n", resp.Error)
-						}
-						fmt.Printf("Created:    %s\n", resp.CreatedAt.Format(timeFmt))
-						if resp.StartedAt != nil {
-							fmt.Printf("Started:    %s\n", resp.StartedAt.Format(timeFmt))
-						}
-						if resp.CompletedAt != nil {
-							fmt.Printf("Completed:  %s\n", resp.CompletedAt.Format(timeFmt))
-							fmt.Printf("Took:       %s\n", fmtDuration(resp.CompletedAt.Sub(resp.CreatedAt)))
-						}
-						if s := taskResultSummary(resp); s != "" {
-							fmt.Printf("Result:     %s\n", s)
-						}
-					})
-				},
-			},
-			{
-				Name:      "cancel",
-				Usage:     "cancel a running task",
-				ArgsUsage: "<id>",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					id := cmd.Args().First()
-					if id == "" {
-						return fmt.Errorf("task ID required")
-					}
-					if err := clientFrom(cmd).CancelTask(ctx, id); err != nil {
-						return wrapErr(err, "task", id)
-					}
-					return output(cmd, map[string]string{"cancel_requested": id}, func() { fmt.Printf("task %q cancel requested\n", id) })
-				},
-			},
-			{
-				Name:  "create",
-				Usage: "create a background task",
-				Commands: []*cli.Command{
-					{
-						Name:  v1.TaskTypeScrub,
-						Usage: "start a btrfs scrub",
-						Flags: []cli.Flag{
-							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
-							&cli.BoolFlag{Name: "wait", Aliases: []string{"w"}, Usage: "wait for completion"},
-							labelFlag(),
-						},
-						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c := clientFrom(cmd)
-							req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, "created-by", "cli")}
-							if t := cmd.Duration("timeout"); t > 0 {
-								req.Timeout = t.String()
-							}
-							resp, err := c.CreateTask(ctx, v1.TaskTypeScrub, req)
-							if err != nil {
-								return err
-							}
-							if !cmd.Bool("wait") {
-								return output(cmd, resp, func() {
-									fmt.Printf("scrub started (task %s)\n", resp.TaskID)
-								})
-							}
-							fmt.Printf("scrub started (task %s)\n", resp.TaskID)
-							return waitForTask(ctx, c, resp.TaskID)
-						},
-					},
-					{
-						Name:  v1.TaskTypeTest,
-						Usage: "start a test task",
-						Flags: []cli.Flag{
-							&cli.DurationFlag{Name: "sleep", Aliases: []string{"s"}, Usage: "sleep duration (e.g. 10s, 1m)"},
-							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
-							&cli.BoolFlag{Name: "wait", Aliases: []string{"w"}, Usage: "wait for completion"},
-							labelFlag(),
-						},
-						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c := clientFrom(cmd)
-							req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, "created-by", "cli")}
-							if s := cmd.Duration("sleep"); s > 0 {
-								req.Opts = map[string]string{"sleep": s.String()}
-							}
-							if t := cmd.Duration("timeout"); t > 0 {
-								req.Timeout = t.String()
-							}
-							resp, err := c.CreateTask(ctx, v1.TaskTypeTest, req)
-							if err != nil {
-								return err
-							}
-							if !cmd.Bool("wait") {
-								return output(cmd, resp, func() {
-									fmt.Printf("test task started (task %s)\n", resp.TaskID)
-								})
-							}
-							fmt.Printf("test task started (task %s)\n", resp.TaskID)
-							return waitForTask(ctx, c, resp.TaskID)
-						},
-					},
-				},
-			},
-		},
+func taskTook(createdAt time.Time, startedAt, completedAt *time.Time) string {
+	if completedAt != nil {
+		return fmtDuration(completedAt.Sub(createdAt))
 	}
+	if startedAt != nil {
+		return fmtDuration(time.Since(*startedAt))
+	}
+	return "-"
+}
+
+func taskTimeout(t string) string {
+	if t != "" {
+		return t
+	}
+	return "-"
+}
+
+func listTasks(ctx context.Context, cmd *cli.Command, c *v1.Client, taskType string, opts v1.ListOpts) error {
+	if isWide(cmd) {
+		resp, err := c.ListTasksDetail(ctx, taskType, opts)
+		if err != nil {
+			return err
+		}
+		sort.Slice(resp.Tasks, func(i, j int) bool {
+			return resp.Tasks[i].CreatedAt.After(resp.Tasks[j].CreatedAt)
+		})
+		return output(cmd, resp, func() {
+			tw := newTableWriter(cmd, []string{"ID", "TYPE", "STATUS", "PROGRESS", "LABELS", "TIMEOUT", "TOOK", "CREATED", "RESULT", "ERROR"})
+			tw.writeHeader()
+			for _, t := range resp.Tasks {
+				result := taskResultSummary(&t)
+				if result == "" {
+					result = "-"
+				}
+				errMsg := "-"
+				if t.Error != "" {
+					errMsg = t.Error
+				}
+				tw.writeRow(map[string]string{
+					"ID": t.ID, "TYPE": string(t.Type), "STATUS": string(t.Status), "PROGRESS": fmt.Sprintf("%d%%", t.Progress),
+					"LABELS": formatLabelsShort(t.Labels), "TIMEOUT": taskTimeout(t.Timeout), "TOOK": taskTook(t.CreatedAt, t.StartedAt, t.CompletedAt),
+					"CREATED": t.CreatedAt.Format(timeFmt), "RESULT": result, "ERROR": errMsg,
+				})
+			}
+			tw.flush()
+		})
+	}
+	resp, err := c.ListTasks(ctx, taskType, opts)
+	if err != nil {
+		return err
+	}
+	sort.Slice(resp.Tasks, func(i, j int) bool {
+		return resp.Tasks[i].CreatedAt.After(resp.Tasks[j].CreatedAt)
+	})
+	return output(cmd, resp, func() {
+		tw := newTableWriter(cmd, []string{"ID", "TYPE", "STATUS", "PROGRESS", "TIMEOUT", "TOOK", "CREATED"})
+		tw.writeHeader()
+		for _, t := range resp.Tasks {
+			tw.writeRow(map[string]string{
+				"ID": t.ID, "TYPE": string(t.Type), "STATUS": string(t.Status), "PROGRESS": fmt.Sprintf("%d%%", t.Progress),
+				"TIMEOUT": taskTimeout(t.Timeout), "TOOK": taskTook(t.CreatedAt, t.StartedAt, t.CompletedAt),
+				"CREATED": t.CreatedAt.Format(timeFmt),
+			})
+		}
+		tw.flush()
+	})
+}
+
+func taskGet(ctx context.Context, cmd *cli.Command) error {
+	id := cmd.Args().First()
+	if id == "" {
+		return fmt.Errorf("task ID required")
+	}
+	resp, err := clientFrom(cmd).GetTask(ctx, id)
+	if err != nil {
+		return wrapErr(err, "task", id)
+	}
+	return output(cmd, resp, func() {
+		fmt.Printf("ID:         %s\n", resp.ID)
+		fmt.Printf("Type:       %s\n", resp.Type)
+		if len(resp.Opts) > 0 {
+			parts := make([]string, 0, len(resp.Opts))
+			for k, v := range resp.Opts {
+				parts = append(parts, k+"="+v)
+			}
+			fmt.Printf("Opts:       %s\n", strings.Join(parts, ", "))
+		}
+		printLabels("Labels:", resp.Labels, 12)
+		if resp.Timeout != "" {
+			fmt.Printf("Timeout:    %s\n", resp.Timeout)
+		}
+		fmt.Printf("Status:     %s\n", resp.Status)
+		fmt.Printf("Progress:   %d%%\n", resp.Progress)
+		if resp.Error != "" {
+			fmt.Printf("Error:      %s\n", resp.Error)
+		}
+		fmt.Printf("Created:    %s\n", resp.CreatedAt.Format(timeFmt))
+		if resp.StartedAt != nil {
+			fmt.Printf("Started:    %s\n", resp.StartedAt.Format(timeFmt))
+		}
+		if resp.CompletedAt != nil {
+			fmt.Printf("Completed:  %s\n", resp.CompletedAt.Format(timeFmt))
+			fmt.Printf("Took:       %s\n", fmtDuration(resp.CompletedAt.Sub(resp.CreatedAt)))
+		}
+		if s := taskResultSummary(resp); s != "" {
+			fmt.Printf("Result:     %s\n", s)
+		}
+	})
+}
+
+func taskCancel(ctx context.Context, cmd *cli.Command) error {
+	id := cmd.Args().First()
+	if id == "" {
+		return fmt.Errorf("task ID required")
+	}
+	if err := clientFrom(cmd).CancelTask(ctx, id); err != nil {
+		return wrapErr(err, "task", id)
+	}
+	if !isJSON(cmd) {
+		fmt.Printf("task %q cancel requested\n", id)
+	}
+	return nil
+}
+
+func taskCreateScrub(ctx context.Context, cmd *cli.Command) error {
+	c := clientFrom(cmd)
+	req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, "created-by", cliIdentity())}
+	if t := cmd.Duration("timeout"); t > 0 {
+		req.Timeout = t.String()
+	}
+	resp, err := c.CreateTask(ctx, v1.TaskTypeScrub, req)
+	if err != nil {
+		return err
+	}
+	if !cmd.Bool("wait") {
+		return output(cmd, resp, func() {
+			fmt.Printf("scrub started (task %s)\n", resp.TaskID)
+		})
+	}
+	fmt.Printf("scrub started (task %s)\n", resp.TaskID)
+	return waitForTask(ctx, c, resp.TaskID)
+}
+
+func taskCreateTest(ctx context.Context, cmd *cli.Command) error {
+	c := clientFrom(cmd)
+	req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, "created-by", cliIdentity())}
+	if s := cmd.Duration("sleep"); s > 0 {
+		req.Opts = map[string]string{"sleep": s.String()}
+	}
+	if t := cmd.Duration("timeout"); t > 0 {
+		req.Timeout = t.String()
+	}
+	resp, err := c.CreateTask(ctx, v1.TaskTypeTest, req)
+	if err != nil {
+		return err
+	}
+	if !cmd.Bool("wait") {
+		return output(cmd, resp, func() {
+			fmt.Printf("test task started (task %s)\n", resp.TaskID)
+		})
+	}
+	fmt.Printf("test task started (task %s)\n", resp.TaskID)
+	return waitForTask(ctx, c, resp.TaskID)
 }
 
 func waitForTask(ctx context.Context, c *v1.Client, id string) error {
@@ -310,10 +264,7 @@ func waitForTask(ctx context.Context, c *v1.Client, id string) error {
 			}
 			switch t.Status {
 			case v1.TaskStatusCompleted:
-				took := "-"
-				if t.CompletedAt != nil {
-					took = fmtDuration(t.CompletedAt.Sub(t.CreatedAt))
-				}
+				took := taskTook(t.CreatedAt, t.StartedAt, t.CompletedAt)
 				if s := taskResultSummary(t); s != "" {
 					fmt.Printf("completed (took %s, %s)\n", took, s)
 				} else {
@@ -335,3 +286,4 @@ func waitForTask(ctx context.Context, c *v1.Client, id string) error {
 		}
 	}
 }
+

--- a/ctl/utils.go
+++ b/ctl/utils.go
@@ -1,9 +1,11 @@
 package ctl
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -12,6 +14,8 @@ import (
 	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/urfave/cli/v3"
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 )
 
 const (
@@ -30,7 +34,7 @@ const (
 )
 
 func labelFlag() cli.Flag {
-	return &cli.StringSliceFlag{Name: "label", Aliases: []string{"l"}, Usage: "label filter key=value (repeatable)"}
+	return &cli.StringSliceFlag{Name: "label", Aliases: []string{"l"}, Usage: "label filter key=value (repeatable, AND)"}
 }
 
 func formatLabels(labels map[string]string) string {
@@ -88,8 +92,21 @@ func formatLabelsShort(labels map[string]string) string {
 	return s
 }
 
-func parseLabelsFlag(cmd *cli.Command) map[string]string {
+func splitLabelsFlag(cmd *cli.Command) []string {
 	raw := cmd.StringSlice("label")
+	var out []string
+	for _, entry := range raw {
+		for _, part := range strings.Split(entry, ",") {
+			if p := strings.TrimSpace(part); p != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func parseLabelsFlag(cmd *cli.Command) map[string]string {
+	raw := splitLabelsFlag(cmd)
 	if len(raw) == 0 {
 		return nil
 	}
@@ -103,6 +120,13 @@ func parseLabelsFlag(cmd *cli.Command) map[string]string {
 		labels[k] = v
 	}
 	return labels
+}
+
+func cliIdentity() string {
+	if id := os.Getenv("BTRFS_NFS_CSI_IDENTITY"); id != "" {
+		return id
+	}
+	return "cli"
 }
 
 func labelsWithDefault(cmd *cli.Command, key, value string) map[string]string {
@@ -122,6 +146,115 @@ func sortFlag() cli.Flag {
 
 func ascFlag() cli.Flag {
 	return &cli.BoolFlag{Name: "asc", Usage: "ascending sort (default is descending)"}
+}
+
+func watchFlag() cli.Flag {
+	return &cli.DurationFlag{Name: "watch", Aliases: []string{"w"}, Value: 2 * time.Second, Usage: "watch mode with interval (default 2s)"}
+}
+
+func injectWatchDefault(args []string) []string {
+	for i, a := range args {
+		if a == "-w" || a == "--watch" {
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				out := make([]string, 0, len(args)+1)
+				out = append(out, args[:i+1]...)
+				out = append(out, "2s")
+				out = append(out, args[i+1:]...)
+				return out
+			}
+		}
+	}
+	return args
+}
+
+func runWatch(ctx context.Context, cmd *cli.Command, fn func() error) error {
+	if !cmd.IsSet("watch") || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return fn()
+	}
+	interval := cmd.Duration("watch")
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+	if termios, err := unix.IoctlGetTermios(int(os.Stdin.Fd()), unix.TCGETS); err == nil {
+		noEcho := *termios
+		noEcho.Lflag &^= unix.ECHO
+		unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, &noEcho)
+		defer unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, termios)
+	}
+	fmt.Print("\033[?1049h\033[?25l")
+	defer fmt.Print("\033[?25h\033[?1049l")
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		fmt.Print("\033[H")
+		if err := fn(); err != nil {
+			return err
+		}
+		fmt.Printf("\nupdated %s, refresh %s\n", time.Now().Format("15:04:05"), interval)
+		fmt.Print("\033[J")
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func columnsFlag() cli.Flag {
+	return &cli.StringFlag{Name: "columns", Aliases: []string{"c"}, Usage: "comma-separated columns to display (omits header if single column)"}
+}
+
+type tableWriter struct {
+	selected []string
+	w        *tabwriter.Writer
+}
+
+func newTableWriter(cmd *cli.Command, all []string) *tableWriter {
+	selected := all
+	if raw := cmd.String("columns"); raw != "" {
+		avail := make(map[string]string, len(all))
+		for _, col := range all {
+			avail[strings.ToLower(col)] = col
+		}
+		var filtered []string
+		for _, r := range strings.Split(raw, ",") {
+			if col, ok := avail[strings.ToLower(strings.TrimSpace(r))]; ok {
+				filtered = append(filtered, col)
+			}
+		}
+		if len(filtered) > 0 {
+			selected = filtered
+		}
+	}
+	tw := &tableWriter{selected: selected}
+	if len(selected) > 1 {
+		tw.w = tab()
+	}
+	return tw
+}
+
+func (tw *tableWriter) writeHeader() {
+	if tw.w == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(tw.w, strings.Join(tw.selected, "\t"))
+}
+
+func (tw *tableWriter) writeRow(values map[string]string) {
+	if tw.w == nil {
+		fmt.Println(values[tw.selected[0]])
+		return
+	}
+	parts := make([]string, 0, len(tw.selected))
+	for _, col := range tw.selected {
+		parts = append(parts, values[col])
+	}
+	_, _ = fmt.Fprintln(tw.w, strings.Join(parts, "\t"))
+}
+
+func (tw *tableWriter) flush() {
+	if tw.w != nil {
+		_ = tw.w.Flush()
+	}
 }
 
 func sortVolumes(vols []v1.VolumeResponse, field string, reverse bool) {

--- a/ctl/utils.go
+++ b/ctl/utils.go
@@ -177,8 +177,8 @@ func runWatch(ctx context.Context, cmd *cli.Command, fn func() error) error {
 	if termios, err := unix.IoctlGetTermios(int(os.Stdin.Fd()), unix.TCGETS); err == nil {
 		noEcho := *termios
 		noEcho.Lflag &^= unix.ECHO
-		unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, &noEcho)
-		defer unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, termios)
+		_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, &noEcho)
+		defer func() { _ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, termios) }()
 	}
 	fmt.Print("\033[?1049h\033[?25l")
 	defer fmt.Print("\033[?25h\033[?1049l")

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -43,7 +43,7 @@ func listVolumes(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy str
 		for _, v := range resp.Volumes {
 			tw.writeRow(map[string]string{
 				"NAME": v.Name, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
-				"USED%": fmt.Sprintf("%.0f%%", usedPct(v.UsedBytes, v.SizeBytes)),
+				"USED%":   fmt.Sprintf("%.0f%%", usedPct(v.UsedBytes, v.SizeBytes)),
 				"CLIENTS": fmt.Sprintf("%d", v.Clients), "CREATED": v.CreatedAt.Format(timeFmt),
 			})
 		}
@@ -198,4 +198,3 @@ func volumeClone(ctx context.Context, cmd *cli.Command) error {
 		fmt.Printf("volume %q cloned from %q\n", resp.Name, cmd.Args().Get(0))
 	})
 }
-

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -11,245 +11,191 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func volumeCmd() *cli.Command {
-	return &cli.Command{
-		Name:    "volume",
-		Aliases: []string{"volumes", "vol"},
-		Usage:   "manage volumes",
-		Commands: []*cli.Command{
-
-			// --- list ---
-
-			{
-				Name:    "list",
-				Aliases: []string{"ls"},
-				Usage:   "list all volumes",
-				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag()},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					c := clientFrom(cmd)
-					sortBy := cmd.String("sort")
-					if sortBy == "" {
-						sortBy = sortUsedPct
-					}
-					rev := !cmd.Bool("asc")
-					opts := v1.ListOpts{Labels: cmd.StringSlice("label")}
-
-					if isWide(cmd) {
-						resp, err := c.ListVolumesDetail(ctx, opts)
-						if err != nil {
-							return err
-						}
-						sortVolumesDetail(resp.Volumes, sortBy, rev)
-						return output(cmd, resp, func() {
-							w := tab()
-							_, _ = fmt.Fprintln(w, "NAME\tSIZE\tUSED\tQUOTA\tCOMPRESSION\tNOCOW\tUID\tGID\tMODE\tLABELS\tCLIENTS\tCREATED")
-							for _, v := range resp.Volumes {
-								_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%v\t%d\t%d\t%s\t%s\t%d\t%s\n",
-									v.Name, utils.FormatBytes(v.SizeBytes), utils.FormatBytes(v.UsedBytes), utils.FormatBytes(v.QuotaBytes),
-									v.Compression, v.NoCOW, v.UID, v.GID, v.Mode,
-									formatLabelsShort(v.Labels), len(v.Clients), v.CreatedAt.Format(timeFmt))
-							}
-							_ = w.Flush()
-						})
-					}
-
-					resp, err := c.ListVolumes(ctx, opts)
-					if err != nil {
-						return err
-					}
-					sortVolumes(resp.Volumes, sortBy, rev)
-					return output(cmd, resp, func() {
-						w := tab()
-						_, _ = fmt.Fprintln(w, "NAME\tSIZE\tUSED\tUSED%\tCLIENTS\tCREATED")
-						for _, v := range resp.Volumes {
-							_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%.0f%%\t%d\t%s\n",
-								v.Name, utils.FormatBytes(v.SizeBytes), utils.FormatBytes(v.UsedBytes),
-								usedPct(v.UsedBytes, v.SizeBytes), v.Clients, v.CreatedAt.Format(timeFmt))
-						}
-						_ = w.Flush()
-					})
-				},
-			},
-
-			// --- get ---
-
-			{
-				Name:      "get",
-				Usage:     "get volume details",
-				ArgsUsage: "<name>",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					name := cmd.Args().First()
-					if name == "" {
-						return fmt.Errorf("volume name required")
-					}
-
-					resp, err := clientFrom(cmd).GetVolume(ctx, name)
-					if err != nil {
-						return wrapErr(err, "volume", name)
-					}
-
-					return output(cmd, resp, func() {
-						fmt.Printf("Name:         %s\n", resp.Name)
-						fmt.Printf("Size:         %s\n", utils.FormatBytes(resp.SizeBytes))
-						fmt.Printf("Used:         %s (%.0f%%)\n", utils.FormatBytes(resp.UsedBytes), usedPct(resp.UsedBytes, resp.SizeBytes))
-						fmt.Printf("Quota:        %s\n", utils.FormatBytes(resp.QuotaBytes))
-						fmt.Printf("Compression:  %s\n", resp.Compression)
-						fmt.Printf("NoCOW:        %v\n", resp.NoCOW)
-						fmt.Printf("UID:          %d\n", resp.UID)
-						fmt.Printf("GID:          %d\n", resp.GID)
-						fmt.Printf("Mode:         %s\n", resp.Mode)
-						printLabels("Labels:", resp.Labels, 14)
-						if len(resp.Clients) == 0 {
-							fmt.Printf("Clients:      none\n")
-						} else {
-							fmt.Printf("Clients:      %s\n", strings.Join(resp.Clients, ", "))
-						}
-						fmt.Printf("Created:      %s\n", resp.CreatedAt.Format(timeFmt))
-						fmt.Printf("Updated:      %s\n", resp.UpdatedAt.Format(timeFmt))
-					})
-				},
-			},
-
-			// --- create ---
-
-			{
-				Name:      "create",
-				Usage:     "create a volume",
-				ArgsUsage: "<name> <size>",
-				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "compression", Aliases: []string{"c"}, Usage: "compression: zstd, lzo, zlib"},
-					&cli.BoolFlag{Name: "nocow", Aliases: []string{"C"}, Usage: "disable copy-on-write (for databases)"},
-					&cli.IntFlag{Name: "uid", Aliases: []string{"u"}, Usage: "owner UID"},
-					&cli.IntFlag{Name: "gid", Aliases: []string{"g"}, Usage: "owner GID"},
-					&cli.StringFlag{Name: "mode", Aliases: []string{"m"}, Usage: "directory mode (octal)"},
-					labelFlag(),
-				},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					if cmd.NArg() < 2 {
-						return fmt.Errorf("usage: volume create <name> <size>")
-					}
-
-					size, err := utils.ParseSize(cmd.Args().Get(1))
-					if err != nil {
-						return err
-					}
-
-					compression := cmd.String("compression")
-					if compression != "" && !utils.IsValidCompression(compression) {
-						return fmt.Errorf("invalid compression %q, expected: zstd, lzo, zlib (with optional level, e.g. zstd:3)", compression)
-					}
-
-					req := v1.VolumeCreateRequest{
-						Name:        cmd.Args().Get(0),
-						SizeBytes:   size,
-						Compression: compression,
-						NoCOW:       cmd.Bool("nocow"),
-						UID:         int(cmd.Int("uid")),
-						GID:         int(cmd.Int("gid")),
-						Mode:        cmd.String("mode"),
-						Labels:      labelsWithDefault(cmd, "created-by", "cli"),
-					}
-
-					resp, err := clientFrom(cmd).CreateVolume(ctx, req)
-					if err != nil {
-						return wrapErr(err, "volume", req.Name)
-					}
-					return output(cmd, resp, func() {
-						fmt.Printf("volume %q created (%s)\n", resp.Name, utils.FormatBytes(resp.SizeBytes))
-					})
-				},
-			},
-
-			// --- delete ---
-
-			{
-				Name:      "delete",
-				Aliases:   []string{"rm"},
-				Usage:     "delete volumes",
-				ArgsUsage: "<name> [name...]",
-				Flags: []cli.Flag{
-					&cli.BoolFlag{Name: "confirm", Hidden: true},
-					&cli.BoolFlag{Name: "yes", Hidden: true},
-				},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					names := cmd.Args().Slice()
-					if len(names) == 0 {
-						return fmt.Errorf("volume name required")
-					}
-
-					force := os.Getenv("BTRFS_NFS_CSI_FORCE") == "true"
-					if !force && !cmd.Bool("confirm") {
-						_, _ = fmt.Fprintf(os.Stderr, "to delete, run:\n  btrfs-nfs-csi volume delete %s --confirm\n", strings.Join(names, " "))
-						return nil
-					}
-					if !force && !cmd.Bool("yes") {
-						_, _ = fmt.Fprintf(os.Stderr, "this will permanently destroy all data.\nto proceed, run:\n  btrfs-nfs-csi volume delete %s --confirm --yes\n", strings.Join(names, " "))
-						return nil
-					}
-
-					c := clientFrom(cmd)
-					deleted := make([]string, 0, len(names))
-					for _, name := range names {
-						if err := c.DeleteVolume(ctx, name); err != nil {
-							return wrapErr(err, "volume", name)
-						}
-						deleted = append(deleted, name)
-					}
-					return output(cmd, map[string]any{"deleted": deleted}, func() {
-						for _, name := range deleted {
-							fmt.Printf("volume %q deleted\n", name)
-						}
-					})
-				},
-			},
-
-			// --- expand ---
-
-			{
-				Name:      "expand",
-				Usage:     "expand a volume",
-				ArgsUsage: "<name> <new-size>",
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					if cmd.NArg() < 2 {
-						return fmt.Errorf("usage: volume expand <name> <new-size>")
-					}
-
-					size, err := utils.ParseSize(cmd.Args().Get(1))
-					if err != nil {
-						return err
-					}
-
-					resp, err := clientFrom(cmd).UpdateVolume(ctx, cmd.Args().Get(0), v1.VolumeUpdateRequest{SizeBytes: &size})
-					if err != nil {
-						return wrapErr(err, "volume", cmd.Args().Get(0))
-					}
-					return output(cmd, resp, func() {
-						fmt.Printf("volume %q expanded to %s\n", resp.Name, utils.FormatBytes(resp.SizeBytes))
-					})
-				},
-			},
-
-			// --- clone ---
-
-			{
-				Name:      "clone",
-				Usage:     "clone a volume (PVC-to-PVC)",
-				ArgsUsage: "<source> <name>",
-				Flags:     []cli.Flag{labelFlag()},
-				Action: func(ctx context.Context, cmd *cli.Command) error {
-					if cmd.NArg() < 2 {
-						return fmt.Errorf("usage: volume clone <source> <name>")
-					}
-
-					resp, err := clientFrom(cmd).CloneVolume(ctx, v1.VolumeCloneRequest{Source: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
-					if err != nil {
-						return wrapErr(err, "volume", cmd.Args().Get(1))
-					}
-					return output(cmd, resp, func() {
-						fmt.Printf("volume %q cloned from %q\n", resp.Name, cmd.Args().Get(0))
-					})
-				},
-			},
-		},
+func listVolumes(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy string, rev bool, opts v1.ListOpts) error {
+	if isWide(cmd) {
+		resp, err := c.ListVolumesDetail(ctx, opts)
+		if err != nil {
+			return err
+		}
+		sortVolumesDetail(resp.Volumes, sortBy, rev)
+		return output(cmd, resp, func() {
+			tw := newTableWriter(cmd, []string{"NAME", "SIZE", "USED", "QUOTA", "COMPRESSION", "NOCOW", "UID", "GID", "MODE", "LABELS", "CLIENTS", "CREATED"})
+			tw.writeHeader()
+			for _, v := range resp.Volumes {
+				tw.writeRow(map[string]string{
+					"NAME": v.Name, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
+					"QUOTA": utils.FormatBytes(v.QuotaBytes), "COMPRESSION": v.Compression, "NOCOW": fmt.Sprintf("%v", v.NoCOW),
+					"UID": fmt.Sprintf("%d", v.UID), "GID": fmt.Sprintf("%d", v.GID), "MODE": v.Mode,
+					"LABELS": formatLabelsShort(v.Labels), "CLIENTS": fmt.Sprintf("%d", len(v.Clients)), "CREATED": v.CreatedAt.Format(timeFmt),
+				})
+			}
+			tw.flush()
+		})
 	}
+	resp, err := c.ListVolumes(ctx, opts)
+	if err != nil {
+		return err
+	}
+	sortVolumes(resp.Volumes, sortBy, rev)
+	return output(cmd, resp, func() {
+		tw := newTableWriter(cmd, []string{"NAME", "SIZE", "USED", "USED%", "CLIENTS", "CREATED"})
+		tw.writeHeader()
+		for _, v := range resp.Volumes {
+			tw.writeRow(map[string]string{
+				"NAME": v.Name, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
+				"USED%": fmt.Sprintf("%.0f%%", usedPct(v.UsedBytes, v.SizeBytes)),
+				"CLIENTS": fmt.Sprintf("%d", v.Clients), "CREATED": v.CreatedAt.Format(timeFmt),
+			})
+		}
+		tw.flush()
+	})
 }
+
+func volumeGet(ctx context.Context, cmd *cli.Command) error {
+	name := cmd.Args().First()
+	if name == "" {
+		return fmt.Errorf("volume name required")
+	}
+	resp, err := clientFrom(cmd).GetVolume(ctx, name)
+	if err != nil {
+		return wrapErr(err, "volume", name)
+	}
+	return output(cmd, resp, func() {
+		fmt.Printf("Name:         %s\n", resp.Name)
+		fmt.Printf("Size:         %s\n", utils.FormatBytes(resp.SizeBytes))
+		fmt.Printf("Used:         %s (%.0f%%)\n", utils.FormatBytes(resp.UsedBytes), usedPct(resp.UsedBytes, resp.SizeBytes))
+		fmt.Printf("Quota:        %s\n", utils.FormatBytes(resp.QuotaBytes))
+		fmt.Printf("Compression:  %s\n", resp.Compression)
+		fmt.Printf("NoCOW:        %v\n", resp.NoCOW)
+		fmt.Printf("UID:          %d\n", resp.UID)
+		fmt.Printf("GID:          %d\n", resp.GID)
+		fmt.Printf("Mode:         %s\n", resp.Mode)
+		printLabels("Labels:", resp.Labels, 14)
+		if len(resp.Clients) == 0 {
+			fmt.Printf("Clients:      none\n")
+		} else {
+			fmt.Printf("Clients:      %s\n", strings.Join(resp.Clients, ", "))
+		}
+		fmt.Printf("Created:      %s\n", resp.CreatedAt.Format(timeFmt))
+		fmt.Printf("Updated:      %s\n", resp.UpdatedAt.Format(timeFmt))
+	})
+}
+
+func volumeCreate(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() < 2 {
+		return fmt.Errorf("usage: volume create <name> <size>")
+	}
+	size, err := utils.ParseSize(cmd.Args().Get(1))
+	if err != nil {
+		return err
+	}
+	compression := cmd.String("compression")
+	if compression != "" && !utils.IsValidCompression(compression) {
+		return fmt.Errorf("invalid compression %q, expected: zstd, lzo, zlib (with optional level, e.g. zstd:3)", compression)
+	}
+	req := v1.VolumeCreateRequest{
+		Name:        cmd.Args().Get(0),
+		SizeBytes:   size,
+		Compression: compression,
+		NoCOW:       cmd.Bool("nocow"),
+		UID:         int(cmd.Int("uid")),
+		GID:         int(cmd.Int("gid")),
+		Mode:        cmd.String("mode"),
+		Labels:      labelsWithDefault(cmd, "created-by", cliIdentity()),
+	}
+	resp, err := clientFrom(cmd).CreateVolume(ctx, req)
+	if err != nil {
+		return wrapErr(err, "volume", req.Name)
+	}
+	return output(cmd, resp, func() {
+		fmt.Printf("volume %q created (%s)\n", resp.Name, utils.FormatBytes(resp.SizeBytes))
+	})
+}
+
+func volumeDelete(ctx context.Context, cmd *cli.Command) error {
+	names := cmd.Args().Slice()
+	if len(names) == 0 {
+		return fmt.Errorf("volume name required")
+	}
+	force := os.Getenv("BTRFS_NFS_CSI_FORCE") == "true"
+	confirmed := force || (cmd.Bool("confirm") && cmd.Bool("yes"))
+	c := clientFrom(cmd)
+	var protected []string
+	for _, name := range names {
+		if !confirmed {
+			vol, err := c.GetVolume(ctx, name)
+			if err != nil {
+				return wrapErr(err, "volume", name)
+			}
+			if vol.Labels["created-by"] != cliIdentity() {
+				protected = append(protected, name)
+				continue
+			}
+		}
+		if err := c.DeleteVolume(ctx, name); err != nil {
+			return wrapErr(err, "volume", name)
+		}
+		if !isJSON(cmd) {
+			fmt.Printf("volume %q deleted\n", name)
+		}
+	}
+	if len(protected) > 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "skipped %d protected volume(s) (created-by != cli):\n  btrfs-nfs-csi volume delete %s --confirm --yes\n", len(protected), strings.Join(protected, " "))
+	}
+	return nil
+}
+
+func volumeExpand(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() < 2 {
+		return fmt.Errorf("usage: volume expand <name> <size|+size>")
+	}
+	c := clientFrom(cmd)
+	name := cmd.Args().Get(0)
+	sizeArg := cmd.Args().Get(1)
+	var size uint64
+	if (sizeArg[0] == '+' || sizeArg[0] == '-') && len(sizeArg) > 1 && sizeArg[1] >= '0' && sizeArg[1] <= '9' {
+		delta, err := utils.ParseSize(sizeArg[1:])
+		if err != nil {
+			return err
+		}
+		vol, err := c.GetVolume(ctx, name)
+		if err != nil {
+			return wrapErr(err, "volume", name)
+		}
+		if sizeArg[0] == '+' {
+			size = vol.SizeBytes + delta
+		} else {
+			if delta > vol.SizeBytes {
+				return fmt.Errorf("cannot shrink below 0 (current %s, delta %s)", utils.FormatBytes(vol.SizeBytes), utils.FormatBytes(delta))
+			}
+			size = vol.SizeBytes - delta
+		}
+	} else {
+		var err error
+		size, err = utils.ParseSize(sizeArg)
+		if err != nil {
+			return err
+		}
+	}
+	resp, err := c.UpdateVolume(ctx, name, v1.VolumeUpdateRequest{SizeBytes: &size})
+	if err != nil {
+		return wrapErr(err, "volume", name)
+	}
+	return output(cmd, resp, func() {
+		fmt.Printf("volume %q expanded to %s\n", resp.Name, utils.FormatBytes(resp.SizeBytes))
+	})
+}
+
+func volumeClone(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() < 2 {
+		return fmt.Errorf("usage: volume clone <source> <name>")
+	}
+	resp, err := clientFrom(cmd).CloneVolume(ctx, v1.VolumeCloneRequest{Source: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
+	if err != nil {
+		return wrapErr(err, "volume", cmd.Args().Get(1))
+	}
+	return output(cmd, resp, func() {
+		fmt.Printf("volume %q cloned from %q\n", resp.Name, cmd.Args().Get(0))
+	})
+}
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,8 @@
 |---|---|---|
 | `AGENT_URL` | - | Agent API URL |
 | `AGENT_TOKEN` | - | Tenant token |
+| `BTRFS_NFS_CSI_IDENTITY` | `cli` | Caller identity for `created-by` label |
+| `BTRFS_NFS_CSI_FORCE` | `false` | Skip delete protection when `true` |
 
 Also configurable via `--agent-url` and `--agent-token` flags.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -159,7 +159,7 @@ The node driver runs a background health checker that detects and auto-heals sta
 2. Each mount is tested with a 5s stat timeout. A stale mount causes stat to hang or return ESTALE/EIO
 3. On stale detection: fresh NFS remount over the stale mount at the same staging path
 4. All existing bind mounts (running pods) heal automatically because they share the same VFS path
-5. A k8s Warning event is written on the PVC (`MountAutoHealed` or `MountRemountFailed`)
+5. A k8s event is written on the PVC (`MountRemounted`, `MountRemountFailed`, or `MountHealthy`)
 6. `VOLUME_CONDITION` is reported via `NodeGetVolumeStats` for kubelet visibility
 
 **No pod restarts required.** The remount at the staging path restores I/O for all pods using that volume.
@@ -247,49 +247,71 @@ export AGENT_URL=http://10.0.0.5:8080
 export AGENT_TOKEN=changeme
 
 btrfs-nfs-csi volume list
-btrfs-nfs-csi volume list -o wide
-btrfs-nfs-csi volume list -o json
+btrfs-nfs-csi volume ls -o wide
+btrfs-nfs-csi volume ls -o json
+btrfs-nfs-csi volume ls -c name              # single column, no header (pipeable)
+btrfs-nfs-csi volume ls -c name,size         # selected columns
+btrfs-nfs-csi volume ls -w                   # watch mode (2s refresh)
+btrfs-nfs-csi volume ls -w 500ms             # watch with custom interval
 btrfs-nfs-csi volume get my-vol
 btrfs-nfs-csi volume create my-vol 10Gi --compression zstd
 btrfs-nfs-csi volume create my-vol 10Gi --label env=prod --label team=backend
-btrfs-nfs-csi volume expand my-vol 20Gi
+btrfs-nfs-csi volume expand my-vol 20Gi      # absolute size
+btrfs-nfs-csi volume expand my-vol +5Gi      # relative expand
 btrfs-nfs-csi volume clone source-vol new-vol --label env=staging
-btrfs-nfs-csi volume list --label env=prod  # filter by label
-btrfs-nfs-csi volume delete my-vol --confirm --yes
+btrfs-nfs-csi volume ls -l env=prod          # filter by label
+btrfs-nfs-csi volume ls -l env=prod,team=be  # comma-separated (AND)
+btrfs-nfs-csi volume delete my-vol           # safe: only deletes if created-by matches caller
+btrfs-nfs-csi volume delete my-vol --confirm --yes  # force delete any volume
+
+# xargs pipeline: delete all CLI-created volumes matching a pattern
+btrfs-nfs-csi volume ls -c name | grep '^test-' | xargs btrfs-nfs-csi volume delete
 
 btrfs-nfs-csi snapshot list
-btrfs-nfs-csi snapshot list my-vol          # filter by volume
-btrfs-nfs-csi snapshot list --label env=prod
+btrfs-nfs-csi snapshot ls my-vol             # filter by volume
+btrfs-nfs-csi snapshot ls -l env=prod
 btrfs-nfs-csi snapshot create my-vol snap-1 --label env=prod
 btrfs-nfs-csi snapshot clone snap-1 new-vol --label env=dev
-btrfs-nfs-csi snapshot delete snap-1 --confirm --yes
+btrfs-nfs-csi snapshot delete snap-1
 
 btrfs-nfs-csi export list
 btrfs-nfs-csi export add my-vol 10.1.0.50
 btrfs-nfs-csi export remove my-vol 10.1.0.50
 
 btrfs-nfs-csi task list
-btrfs-nfs-csi task list --type scrub
-btrfs-nfs-csi task list --label created-by=cron
+btrfs-nfs-csi task ls -t scrub
+btrfs-nfs-csi task ls -l created-by=cron
+btrfs-nfs-csi task ls -w                     # watch tasks live
 btrfs-nfs-csi task get <id>
 btrfs-nfs-csi task cancel <id>
 btrfs-nfs-csi task create scrub
-btrfs-nfs-csi task create scrub --wait
+btrfs-nfs-csi task create scrub -W           # wait for completion
 btrfs-nfs-csi task create scrub --label created-by=cron
 btrfs-nfs-csi task create test
-btrfs-nfs-csi task create test --sleep 10s --wait
+btrfs-nfs-csi task create test --sleep 10s -W
 btrfs-nfs-csi stats
-btrfs-nfs-csi stats -o wide                 # per-device IO and error details
+btrfs-nfs-csi stats -o wide                  # per-device IO and error details
+btrfs-nfs-csi stats -w                       # watch stats live
 btrfs-nfs-csi health
 btrfs-nfs-csi version
 ```
 
 **Global flags:** `--agent-url`, `--agent-token`, `--output` / `-o` (table, wide, json).
 
-**Output formats:** `table` (default), `wide` (extra columns), `json` (raw API response). Combine with `-o json,wide` for detailed JSON.
+**Output formats:** `table` (default), `wide` (extra columns), `json` (raw API response). Combine with `-o json,wide` for detailed JSON. `-o json` suppresses output for mutation commands without API response (delete, export add/rm, task cancel).
+
+**Column filter:** `--columns` / `-c` selects which columns to display. Single column omits the header for clean piping to `xargs`, `wc`, etc.
+
+**Watch mode:** `--watch` / `-w` enables live-refresh in an alternate screen. Default 2s, configurable (e.g. `-w 500ms`). Available on all list commands and `stats`.
 
 **Sorting:** `--sort` / `-s` with `--asc` (default descending). Volume default: `used%`. Snapshot default: `created`.
 
-**Size values:** Supports `Ki`, `Mi`, `Gi` (binary) and `K`, `M`, `G` (decimal).
+**Label filter:** `--label` / `-l`, repeatable (AND). Supports comma-separated values: `-l env=prod,team=be`.
 
-**Default labels:** CLI create commands automatically add `created-by=cli`. Override with `--label created-by=myvalue`.
+**Size values:** Supports `Ki`, `Mi`, `Gi` (binary) and `K`, `M`, `G` (decimal). `volume expand` accepts relative sizes with `+`/`-` prefix.
+
+**Delete protection:** Volumes and snapshots with `created-by` != caller identity are protected. Only `--confirm --yes` or `BTRFS_NFS_CSI_FORCE=true` bypasses this. The caller identity defaults to `cli` and can be set via `BTRFS_NFS_CSI_IDENTITY`.
+
+**Default labels:** CLI create commands automatically add `created-by=<identity>` (default `cli`). `created-by` is a reserved label and cannot be overridden via PVC annotations.
+
+**Command aliases:** `volumes`/`vol`, `snapshots`/`snap`, `tasks`, `exports`. `list`/`ls` interchangeable.

--- a/driver/health.go
+++ b/driver/health.go
@@ -16,10 +16,18 @@ import (
 )
 
 const (
-	eventMountAutoHealed    = "MountAutoHealed"
+	eventMountHealthy       = "MountHealthy"
+	eventMountRemounted     = "MountRemounted"
 	eventMountRemountFailed = "MountRemountFailed"
 	apiCallTimeout          = 10 * time.Second
 )
+
+func eventType(reason string) string {
+	if reason == eventMountHealthy || reason == eventMountRemounted {
+		return corev1.EventTypeNormal
+	}
+	return corev1.EventTypeWarning
+}
 
 type volumeHealth struct {
 	abnormal bool
@@ -67,6 +75,15 @@ func (s *NodeServer) checkMountHealth(ctx context.Context) {
 		return vi, ok
 	}
 
+	hasUnhealthy := false
+	s.healthState.Range(func(_, v any) bool {
+		if h, _ := v.(*volumeHealth); h != nil && h.abnormal {
+			hasUnhealthy = true
+			return false
+		}
+		return true
+	})
+
 	for _, mp := range mounts {
 		if (mp.Type != "nfs" && mp.Type != "nfs4") || !strings.Contains(mp.Path, "globalmount") {
 			continue
@@ -76,6 +93,15 @@ func (s *NodeServer) checkMountHealth(ctx context.Context) {
 		err := statWithTimeout(dataPath, staleCheckTimeout)
 		if err == nil {
 			healthChecksTotal.WithLabelValues("healthy").Inc()
+			if hasUnhealthy {
+				if vi, ok := resolveVolume(mp.Device); ok {
+					if prev, loaded := s.healthState.LoadAndDelete(vi.volumeID); loaded {
+						if h, _ := prev.(*volumeHealth); h != nil && h.abnormal {
+							s.reportVolumeEvent(ctx, &vi, eventMountHealthy, "NFS mount is healthy again")
+						}
+					}
+				}
+			}
 			continue
 		}
 
@@ -119,7 +145,7 @@ func (s *NodeServer) healMount(ctx context.Context, mp mount.MountPoint, vi *vol
 	mountDuration.WithLabelValues("health_remount").Observe(time.Since(start).Seconds())
 	log.Info().Str("mountpoint", mp.Path).Msg("health check: remount succeeded, bind mounts healed")
 	healthChecksTotal.WithLabelValues("remounted").Inc()
-	s.reportVolumeEvent(ctx, vi, eventMountAutoHealed, "NFS mount was stale, auto-healed by health checker")
+	s.reportVolumeEvent(ctx, vi, eventMountRemounted, "NFS mount was stale, auto-healed by driver")
 }
 
 func (s *NodeServer) reportVolumeEvent(ctx context.Context, vi *volumeInfo, reason, message string) {
@@ -130,7 +156,7 @@ func (s *NodeServer) reportVolumeEvent(ctx context.Context, vi *volumeInfo, reas
 	if s.kubeClient != nil && vi.pvcName != "" && vi.pvcNamespace != "" {
 		event := &corev1.Event{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "btrfs-nfs-csi-",
+				GenerateName: config.DriverName + "-",
 				Namespace:    vi.pvcNamespace,
 			},
 			InvolvedObject: corev1.ObjectReference{
@@ -141,18 +167,22 @@ func (s *NodeServer) reportVolumeEvent(ctx context.Context, vi *volumeInfo, reas
 			},
 			Reason:  reason,
 			Message: message,
-			Type:    corev1.EventTypeWarning,
-			Source:  corev1.EventSource{Component: "btrfs-nfs-csi-node"},
+			Type:    eventType(reason),
+			Source:  corev1.EventSource{Component: config.DriverName + "-node"},
 		}
 		if _, err := s.kubeClient.CoreV1().Events(vi.pvcNamespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
 			log.Warn().Err(err).Str("pvc", vi.pvcNamespace+"/"+vi.pvcName).Msg("health check: failed to create PVC event")
 		}
 	}
 
-	s.healthState.Store(vi.volumeID, &volumeHealth{
-		abnormal: reason != eventMountAutoHealed,
-		message:  message,
-	})
+	if reason == eventMountRemounted || reason == eventMountHealthy {
+		s.healthState.Delete(vi.volumeID)
+	} else {
+		s.healthState.Store(vi.volumeID, &volumeHealth{
+			abnormal: true,
+			message:  message,
+		})
+	}
 }
 
 // buildVolumeMap fetches VolumeAttachments + PVs and builds a map of NFS source -> volumeInfo.

--- a/driver/health_test.go
+++ b/driver/health_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -114,11 +115,8 @@ func TestHealMount_SetsHealthStateHealed(t *testing.T) {
 
 	ns.healMount(context.Background(), mp, vi)
 
-	h, ok := ns.healthState.Load("sc|vol-123")
-	require.True(t, ok)
-	vh := h.(*volumeHealth)
-	assert.False(t, vh.abnormal)
-	assert.Contains(t, vh.message, "auto-healed")
+	_, ok := ns.healthState.Load("sc|vol-123")
+	assert.False(t, ok, "healthState should be cleared after auto-heal")
 }
 
 func TestHealMount_SetsHealthStateAbnormalOnFailure(t *testing.T) {
@@ -142,20 +140,20 @@ func TestReportVolumeEvent_CreatesK8sEvent(t *testing.T) {
 
 	vi := &volumeInfo{volumeID: "sc|vol-1", pvcName: "my-pvc", pvcNamespace: "default"}
 
-	ns.reportVolumeEvent(context.Background(), vi, eventMountAutoHealed, "NFS mount was stale, auto-healed")
+	ns.reportVolumeEvent(context.Background(), vi, eventMountRemounted, "NFS mount was stale, auto-healed")
 
 	events, err := ns.kubeClient.CoreV1().Events("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, events.Items, 1)
 
 	ev := events.Items[0]
-	assert.Equal(t, eventMountAutoHealed, ev.Reason)
+	assert.Equal(t, eventMountRemounted, ev.Reason)
 	assert.Equal(t, "NFS mount was stale, auto-healed", ev.Message)
 	assert.Equal(t, "PersistentVolumeClaim", ev.InvolvedObject.Kind)
 	assert.Equal(t, "my-pvc", ev.InvolvedObject.Name)
 	assert.Equal(t, "default", ev.InvolvedObject.Namespace)
-	assert.Equal(t, corev1.EventTypeWarning, ev.Type)
-	assert.Equal(t, "btrfs-nfs-csi-node", ev.Source.Component)
+	assert.Equal(t, corev1.EventTypeNormal, ev.Type)
+	assert.Equal(t, config.DriverName+"-node", ev.Source.Component)
 }
 
 func TestReportVolumeEvent_RemountFailedEvent(t *testing.T) {
@@ -174,29 +172,28 @@ func TestReportVolumeEvent_RemountFailedEvent(t *testing.T) {
 
 func TestReportVolumeEvent_NilVolumeInfo(t *testing.T) {
 	ns := newTestNodeServer(nil)
-	ns.reportVolumeEvent(context.Background(), nil, eventMountAutoHealed, "test")
+	ns.reportVolumeEvent(context.Background(), nil, eventMountRemounted, "test")
 }
 
 func TestReportVolumeEvent_NoKubeClient(t *testing.T) {
 	ns := newTestNodeServer(nil)
-	// kubeClient is nil, should still set healthState
+	// kubeClient is nil, should still clear healthState on auto-heal
 	vi := &volumeInfo{volumeID: "sc|vol-1", pvcName: "pvc", pvcNamespace: "ns"}
 
-	ns.reportVolumeEvent(context.Background(), vi, eventMountAutoHealed, "healed")
+	ns.reportVolumeEvent(context.Background(), vi, eventMountRemounted, "healed")
 
-	h, ok := ns.healthState.Load("sc|vol-1")
-	require.True(t, ok)
-	assert.False(t, h.(*volumeHealth).abnormal)
+	_, ok := ns.healthState.Load("sc|vol-1")
+	assert.False(t, ok, "healthState should be cleared after auto-heal")
 }
 
 func TestReportVolumeEvent_NoPVCSkipsEvent(t *testing.T) {
 	ns := newTestNodeServer(nil)
 	ns.kubeClient = fakekube.NewSimpleClientset()
 
-	// No pvcName/Namespace, should still set healthState but no event
+	// No pvcName/Namespace, should skip event but still manage healthState
 	vi := &volumeInfo{volumeID: "sc|vol-1"}
 
-	ns.reportVolumeEvent(context.Background(), vi, eventMountAutoHealed, "healed")
+	ns.reportVolumeEvent(context.Background(), vi, eventMountRemountFailed, "failed")
 
 	events, _ := ns.kubeClient.CoreV1().Events("").List(context.Background(), metav1.ListOptions{})
 	assert.Empty(t, events.Items)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/rs/zerolog v1.35.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.8.0
+	golang.org/x/sys v0.42.0
+	golang.org/x/term v0.41.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	k8s.io/api v0.35.3
@@ -51,8 +53,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect


### PR DESCRIPTION
Rework CLI output for scripting and interactive use. List commands gain column filtering and watch mode, delete commands gain label-based protection to prevent accidental deletion of non-CLI resources. Controller and driver now emit k8s events on PVCs for label validation issues and mount health transitions. **The web dashboard is deprecated in favor of the CLI.**

## Summary
- `--columns` / `-c` flag on all list commands, single column omits header for piping to xargs
- `--watch` / `-w` flag on all list commands and `stats`, alternate screen with echo suppression, configurable interval (default 2s)
- Delete protection: resources with `created-by` != `cliIdentity()` skipped, override with `--confirm --yes` or `BTRFS_NFS_CSI_FORCE=true`
- `BTRFS_NFS_CSI_IDENTITY` env var controls `created-by` label value (default `cli`)
- `volume expand` accepts relative sizes (`+5Gi`, `-2Gi`), fetches current size via GetVolume
- Label filters accept comma-separated values: `-l env=prod,team=be`
- Delete/export/cancel output printed immediately per item, `-o json` suppresses for commands without API response
- `created-by` added to `reservedLabelKeys`, cannot be overridden via PVC annotations
- `record.EventRecorder` on controller `Server`, fires `LabelSkipped`, `LabelInvalid`, `LabelsTruncated` on PVC
- Driver health event `MountAutoHealed` renamed to `MountRemounted`, new `MountHealthy` fires when previously failed mount recovers
- `hasUnhealthy` guard prevents `resolveVolume` API calls on healthy check cycles
- `healthState` entries cleaned up on heal (Delete instead of Store with `abnormal: false`)
- CLI action logic extracted from command structs, wiring separated into `ctl/model.go`
- `config.DriverName` used instead of hardcoded strings in event sources
