### PR TITLE
Export reference counting with labels and immutable label protection

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,7 +63,7 @@ func (a *Agent) Start(ctx context.Context) {
 	// storage layer + handler
 	store := storage.New(
 		a.cfg.BasePath, a.cfg.QuotaEnabled, exp, tenantNames,
-		a.cfg.DefaultDirMode, a.cfg.DefaultDataMode, a.cfg.BtrfsBin,
+		a.cfg.DefaultDirMode, a.cfg.DefaultDataMode, a.cfg.BtrfsBin, a.cfg.ImmutableLabels,
 		a.cfg.TaskMaxConcurrent, a.cfg.TaskDefaultTimeout, a.cfg.TaskScrubTimeout, a.cfg.TaskPollInterval,
 	)
 	h := &v1.Handler{Store: store}
@@ -81,9 +81,9 @@ func (a *Agent) Start(ctx context.Context) {
 	api.DELETE("/volumes/:name", h.DeleteVolume)
 
 	api.GET("/volumes/:name/snapshots", h.ListVolumeSnapshots)
-	api.POST("/volumes/:name/export", h.ExportVolume)
-	api.DELETE("/volumes/:name/export", h.UnexportVolume)
-	api.GET("/exports", h.ListExports)
+	api.POST("/volumes/:name/export", h.CreateVolumeExport)
+	api.DELETE("/volumes/:name/export", h.DeleteVolumeExport)
+	api.GET("/exports", h.ListVolumeExports)
 	api.GET("/dashboard", v1.ServeDashboard(a.cfg.DashboardRefresh))
 
 	api.GET("/stats", h.Stats)

--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -110,12 +110,12 @@ func (c *Client) CloneVolume(ctx context.Context, req VolumeCloneRequest) (*Volu
 	return &resp, nil
 }
 
-func (c *Client) ExportVolume(ctx context.Context, name string, cl string) error {
-	return c.do(ctx, http.MethodPost, "/v1/volumes/"+name+"/export", ExportRequest{Client: cl}, nil)
+func (c *Client) CreateVolumeExport(ctx context.Context, name string, cl string, labels map[string]string) error {
+	return c.do(ctx, http.MethodPost, "/v1/volumes/"+name+"/export", VolumeExportCreateRequest{Client: cl, Labels: labels}, nil)
 }
 
-func (c *Client) UnexportVolume(ctx context.Context, name string, cl string) error {
-	return c.do(ctx, http.MethodDelete, "/v1/volumes/"+name+"/export", ExportRequest{Client: cl}, nil)
+func (c *Client) DeleteVolumeExport(ctx context.Context, name string, cl string, labels map[string]string) error {
+	return c.do(ctx, http.MethodDelete, "/v1/volumes/"+name+"/export", VolumeExportDeleteRequest{Client: cl, Labels: labels}, nil)
 }
 
 func (c *Client) ListVolumes(ctx context.Context, opts ListOpts) (*VolumeListResponse, error) {
@@ -188,9 +188,19 @@ func (c *Client) GetSnapshot(ctx context.Context, name string) (*SnapshotDetailR
 	return &resp, nil
 }
 
-func (c *Client) ListExports(ctx context.Context) (*ExportListResponse, error) {
+func (c *Client) ListVolumeExports(ctx context.Context, opts ListOpts) (*ExportListResponse, error) {
 	var resp ExportListResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/exports", nil, &resp); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/v1/exports?"+opts.query().Encode(), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) ListVolumeExportsDetail(ctx context.Context, opts ListOpts) (*ExportDetailListResponse, error) {
+	var resp ExportDetailListResponse
+	q := opts.query()
+	q.Set("detail", "true")
+	if err := c.do(ctx, http.MethodGet, "/v1/exports?"+q.Encode(), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -32,7 +32,7 @@ func volumeResponseFrom(meta *storage.VolumeMetadata) VolumeResponse {
 		Name:      meta.Name,
 		SizeBytes: meta.SizeBytes,
 		UsedBytes: meta.UsedBytes,
-		Clients:   len(meta.Clients),
+		Exports:   storage.CountUniqueExportIPs(meta.Exports),
 		CreatedAt: meta.CreatedAt,
 	}
 }
@@ -87,9 +87,14 @@ func (h *Handler) ListVolumes(c *echo.Context) error {
 }
 
 func volumeDetailResponseFrom(meta *storage.VolumeMetadata) VolumeDetailResponse {
-	clients := meta.Clients
-	if clients == nil {
-		clients = []string{}
+	exports := make([]ExportDetailResponse, len(meta.Exports))
+	for i, e := range meta.Exports {
+		exports[i] = ExportDetailResponse{
+			Name:      meta.Name,
+			Client:    e.IP,
+			Labels:    e.Labels,
+			CreatedAt: e.CreatedAt,
+		}
 	}
 	return VolumeDetailResponse{
 		Name:         meta.Name,
@@ -103,7 +108,7 @@ func volumeDetailResponseFrom(meta *storage.VolumeMetadata) VolumeDetailResponse
 		GID:          meta.GID,
 		Mode:         meta.Mode,
 		Labels:       meta.Labels,
-		Clients:      clients,
+		Exports:      exports,
 		CreatedAt:    meta.CreatedAt,
 		UpdatedAt:    meta.UpdatedAt,
 		LastAttachAt: meta.LastAttachAt,
@@ -148,53 +153,75 @@ func (h *Handler) DeleteVolume(c *echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-func (h *Handler) ExportVolume(c *echo.Context) error {
+func (h *Handler) CreateVolumeExport(c *echo.Context) error {
 	tenant := c.Get("tenant").(string)
 	name := c.Param("name")
 
-	var req ExportRequest
+	var req VolumeExportCreateRequest
 	if err := c.Bind(&req); err != nil || req.Client == "" {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "client is required", Code: "BAD_REQUEST"})
 	}
 
-	if err := h.Store.ExportVolume(c.Request().Context(), tenant, name, req.Client); err != nil {
+	if err := h.Store.CreateVolumeExport(c.Request().Context(), tenant, name, req.Client, req.Labels); err != nil {
 		return StorageError(c, err)
 	}
 
 	return c.NoContent(http.StatusNoContent)
 }
 
-func (h *Handler) UnexportVolume(c *echo.Context) error {
+func (h *Handler) DeleteVolumeExport(c *echo.Context) error {
 	tenant := c.Get("tenant").(string)
 	name := c.Param("name")
 
-	var req ExportRequest
+	var req VolumeExportDeleteRequest
 	if err := c.Bind(&req); err != nil || req.Client == "" {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "client is required", Code: "BAD_REQUEST"})
 	}
 
-	if err := h.Store.UnexportVolume(c.Request().Context(), tenant, name, req.Client); err != nil {
+	if err := h.Store.DeleteVolumeExport(c.Request().Context(), tenant, name, req.Client, req.Labels); err != nil {
 		return StorageError(c, err)
 	}
 
 	return c.NoContent(http.StatusNoContent)
 }
 
-func (h *Handler) ListExports(c *echo.Context) error {
+func exportResponseFrom(e *storage.ExportEntry) ExportResponse {
+	return ExportResponse{Name: e.Name, Client: e.Client, CreatedAt: e.CreatedAt}
+}
+
+func exportDetailResponseFrom(e *storage.ExportEntry) ExportDetailResponse {
+	return ExportDetailResponse{Name: e.Name, Client: e.Client, Labels: e.Labels, CreatedAt: e.CreatedAt}
+}
+
+func (h *Handler) ListVolumeExports(c *echo.Context) error {
 	tenant := c.Get("tenant").(string)
 	after, limit := parsePageParams(c)
 
-	page, err := h.Store.ListExportsPaginated(c.Request().Context(), tenant, after, limit)
+	page, err := h.Store.ListVolumeExportsPaginated(tenant, after, limit)
 	if err != nil {
 		return StorageError(c, err)
 	}
 
-	exports := page.Items
-	if exports == nil {
-		exports = []storage.ExportEntry{}
+	items := page.Items
+	total := page.Total
+	if filters := c.QueryParams()["label"]; len(filters) > 0 {
+		items = filterByLabels(items, filters)
+		total = len(items)
 	}
 
-	return c.JSON(http.StatusOK, ExportListResponse{Exports: exports, Total: page.Total, Next: page.Next})
+	if c.QueryParam("detail") == "true" {
+		resp := make([]ExportDetailResponse, len(items))
+		for i := range items {
+			resp[i] = exportDetailResponseFrom(&items[i])
+		}
+		return c.JSON(http.StatusOK, ExportDetailListResponse{Exports: resp, Total: total, Next: page.Next})
+	}
+
+	resp := make([]ExportResponse, len(items))
+	for i := range items {
+		resp[i] = exportResponseFrom(&items[i])
+	}
+	return c.JSON(http.StatusOK, ExportListResponse{Exports: resp, Total: total, Next: page.Next})
 }
 
 func (h *Handler) Stats(c *echo.Context) error {

--- a/agent/api/v1/labels_test.go
+++ b/agent/api/v1/labels_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,6 +36,26 @@ func TestMatchLabels(t *testing.T) {
 			assert.Equal(t, tt.want, matchLabels(tt.labels, tt.filters))
 		})
 	}
+}
+
+func TestFilterByLabels_ExportEntry(t *testing.T) {
+	items := []storage.ExportEntry{
+		{Name: "vol1", Client: "10.0.0.1", Labels: map[string]string{"created-by": "csi", "kubernetes.volume.id": "vol1"}},
+		{Name: "vol1", Client: "10.0.0.2", Labels: map[string]string{"created-by": "cli"}},
+		{Name: "vol2", Client: "10.0.0.3", Labels: map[string]string{"created-by": "csi", "kubernetes.volume.id": "vol2"}},
+	}
+
+	filtered := filterByLabels(items, []string{"created-by=csi"})
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, "10.0.0.1", filtered[0].Client)
+	assert.Equal(t, "10.0.0.3", filtered[1].Client)
+
+	filtered = filterByLabels(items, []string{"kubernetes.volume.id=vol1"})
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "10.0.0.1", filtered[0].Client)
+
+	filtered = filterByLabels(items, []string{"created-by"})
+	assert.Len(t, filtered, 3, "bare key should match all")
 }
 
 func TestGenerateLabelQuery(t *testing.T) {

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -18,7 +18,6 @@ type (
 	VolumeCloneRequest    = storage.VolumeCloneRequest
 	VolumeMetadata        = storage.VolumeMetadata
 	SnapshotMetadata      = storage.SnapshotMetadata
-	ExportEntry           = storage.ExportEntry
 )
 
 const (
@@ -37,8 +36,14 @@ const (
 
 // request models (HTTP-layer only)
 
-type ExportRequest struct {
-	Client string `json:"client"`
+type VolumeExportCreateRequest struct {
+	Client string            `json:"client"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type VolumeExportDeleteRequest struct {
+	Client string            `json:"client"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // response models
@@ -47,7 +52,7 @@ type VolumeResponse struct {
 	Name      string    `json:"name"`
 	SizeBytes uint64    `json:"size_bytes"`
 	UsedBytes uint64    `json:"used_bytes"`
-	Clients   int       `json:"clients"`
+	Exports   int       `json:"clients"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -63,7 +68,7 @@ type VolumeDetailResponse struct {
 	GID          int               `json:"gid"`
 	Mode         string            `json:"mode"`
 	Labels       map[string]string `json:"labels,omitempty"`
-	Clients      []string          `json:"clients"`
+	Exports      []ExportDetailResponse `json:"clients"`
 	CreatedAt    time.Time         `json:"created_at"`
 	UpdatedAt    time.Time         `json:"updated_at"`
 	LastAttachAt *time.Time        `json:"last_attach_at,omitempty"`
@@ -114,10 +119,29 @@ type SnapshotDetailListResponse struct {
 	Next      string                   `json:"next,omitempty"`
 }
 
+type ExportResponse struct {
+	Name      string    `json:"name"`
+	Client    string    `json:"client"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type ExportDetailResponse struct {
+	Name      string            `json:"name"`
+	Client    string            `json:"client"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
+}
+
 type ExportListResponse struct {
-	Exports []ExportEntry `json:"exports"`
-	Total   int           `json:"total"`
-	Next    string        `json:"next,omitempty"`
+	Exports []ExportResponse `json:"exports"`
+	Total   int              `json:"total"`
+	Next    string           `json:"next,omitempty"`
+}
+
+type ExportDetailListResponse struct {
+	Exports []ExportDetailResponse `json:"exports"`
+	Total   int                    `json:"total"`
+	Next    string                 `json:"next,omitempty"`
 }
 
 type StatsResponse struct {

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -57,21 +57,21 @@ type VolumeResponse struct {
 }
 
 type VolumeDetailResponse struct {
-	Name         string            `json:"name"`
-	Path         string            `json:"path"`
-	SizeBytes    uint64            `json:"size_bytes"`
-	NoCOW        bool              `json:"nocow"`
-	Compression  string            `json:"compression"`
-	QuotaBytes   uint64            `json:"quota_bytes"`
-	UsedBytes    uint64            `json:"used_bytes"`
-	UID          int               `json:"uid"`
-	GID          int               `json:"gid"`
-	Mode         string            `json:"mode"`
-	Labels       map[string]string `json:"labels,omitempty"`
+	Name         string                 `json:"name"`
+	Path         string                 `json:"path"`
+	SizeBytes    uint64                 `json:"size_bytes"`
+	NoCOW        bool                   `json:"nocow"`
+	Compression  string                 `json:"compression"`
+	QuotaBytes   uint64                 `json:"quota_bytes"`
+	UsedBytes    uint64                 `json:"used_bytes"`
+	UID          int                    `json:"uid"`
+	GID          int                    `json:"gid"`
+	Mode         string                 `json:"mode"`
+	Labels       map[string]string      `json:"labels,omitempty"`
 	Exports      []ExportDetailResponse `json:"clients"`
-	CreatedAt    time.Time         `json:"created_at"`
-	UpdatedAt    time.Time         `json:"updated_at"`
-	LastAttachAt *time.Time        `json:"last_attach_at,omitempty"`
+	CreatedAt    time.Time              `json:"created_at"`
+	UpdatedAt    time.Time              `json:"updated_at"`
+	LastAttachAt *time.Time             `json:"last_attach_at,omitempty"`
 }
 
 type VolumeListResponse struct {

--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -24,7 +24,7 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
-	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+	if err := requireImmutableLabels(s.immutableLabelKeys, req.Labels); err != nil {
 		return nil, err
 	}
 	srcData := s.snapshots.DataPath(tenant, req.Snapshot)

--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -24,6 +24,9 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
+	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+		return nil, err
+	}
 	srcData := s.snapshots.DataPath(tenant, req.Snapshot)
 	snapMeta, err := s.snapshots.Get(tenant, req.Snapshot)
 	if err != nil {

--- a/agent/storage/export.go
+++ b/agent/storage/export.go
@@ -5,37 +5,38 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
 )
 
-func (s *Storage) ExportVolume(ctx context.Context, tenant, name, client string) error {
+func (s *Storage) CreateVolumeExport(ctx context.Context, tenant, name, client string, labels map[string]string) error {
 	if _, err := s.tenantPath(tenant); err != nil {
 		return err
 	}
 	if err := validateName(name); err != nil {
 		return err
 	}
+	if err := validateLabels(labels); err != nil {
+		return err
+	}
+	if err := requireImmutableLabels(s.immutableLabelKeys,labels); err != nil {
+		return err
+	}
 
 	volDir := s.volumes.Dir(tenant, name)
 
 	// metadata first - if export fails, reconciler will re-export
+	var firstRef bool
 	if _, err := s.volumes.Update(tenant, name, func(meta *VolumeMetadata) {
-		found := false
-		for _, c := range meta.Clients {
-			if c == client {
-				found = true
-				break
-			}
-		}
 		now := time.Now().UTC()
 		meta.LastAttachAt = &now
 		meta.UpdatedAt = now
-		if !found {
-			meta.Clients = append(meta.Clients, client)
+		if hasExport(meta.Exports, client, labels) {
+			return
 		}
+		firstRef = exportsForIP(meta.Exports, client) == 0
+		meta.Exports = append(meta.Exports, ExportMetadata{IP: client, Labels: labels, CreatedAt: now})
 	}); err != nil {
 		if os.IsNotExist(err) {
 			return &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("volume %q not found", name)}
@@ -44,34 +45,50 @@ func (s *Storage) ExportVolume(ctx context.Context, tenant, name, client string)
 		return fmt.Errorf("failed to persist client in metadata: %w", err)
 	}
 
-	if err := s.exporter.Export(ctx, volDir, client); err != nil {
-		log.Error().Err(err).Str("name", name).Str("client", client).Msg("failed to export, reconciler will retry")
-		return fmt.Errorf("nfs export failed: %w", err)
+	if firstRef {
+		if err := s.exporter.Export(ctx, volDir, client); err != nil {
+			log.Error().Err(err).Str("name", name).Str("client", client).Msg("failed to export, reconciler will retry")
+			return fmt.Errorf("nfs export failed: %w", err)
+		}
 	}
 
 	log.Info().Str("tenant", tenant).Str("name", name).Str("client", client).Msg("NFS export added")
 	return nil
 }
 
-func (s *Storage) UnexportVolume(ctx context.Context, tenant, name, client string) error {
+func (s *Storage) DeleteVolumeExport(ctx context.Context, tenant, name, client string, labels map[string]string) error {
 	if _, err := s.tenantPath(tenant); err != nil {
 		return err
 	}
 	if err := validateName(name); err != nil {
 		return err
 	}
+	if err := validateLabels(labels); err != nil {
+		return err
+	}
 
 	volDir := s.volumes.Dir(tenant, name)
 
 	// metadata first - if unexport fails, reconciler will clean up
+	var lastRef bool
 	if _, err := s.volumes.Update(tenant, name, func(meta *VolumeMetadata) {
-		filtered := meta.Clients[:0]
-		for _, c := range meta.Clients {
-			if c != client {
+		var removed bool
+		filtered := meta.Exports[:0]
+		for _, c := range meta.Exports {
+			if c.IP != client {
 				filtered = append(filtered, c)
+				continue
+			}
+			// labels == nil: remove all refs for this IP
+			// labels != nil: remove only matching entry
+			if labels != nil && !labelsContain(c.Labels, labels) {
+				filtered = append(filtered, c)
+			} else {
+				removed = true
 			}
 		}
-		meta.Clients = filtered
+		meta.Exports = filtered
+		lastRef = removed && exportsForIP(filtered, client) == 0
 		meta.UpdatedAt = time.Now().UTC()
 	}); err != nil {
 		if os.IsNotExist(err) {
@@ -81,46 +98,39 @@ func (s *Storage) UnexportVolume(ctx context.Context, tenant, name, client strin
 		return fmt.Errorf("failed to update client list in metadata: %w", err)
 	}
 
-	if err := s.exporter.Unexport(ctx, volDir, client); err != nil {
-		log.Error().Err(err).Str("name", name).Str("client", client).Msg("failed to unexport, reconciler will clean up")
-		return fmt.Errorf("nfs unexport failed: %w", err)
+	if lastRef {
+		if err := s.exporter.Unexport(ctx, volDir, client); err != nil {
+			log.Error().Err(err).Str("name", name).Str("client", client).Msg("failed to unexport, reconciler will clean up")
+			return fmt.Errorf("nfs unexport failed: %w", err)
+		}
 	}
 
 	log.Info().Str("tenant", tenant).Str("name", name).Str("client", client).Msg("NFS export removed")
 	return nil
 }
 
-func (s *Storage) ListExports(ctx context.Context, tenant string) ([]ExportEntry, error) {
-	bp, err := s.tenantPath(tenant)
-	if err != nil {
+func (s *Storage) ListVolumeExportsPaginated(tenant, after string, limit int) (*PaginatedResult[ExportEntry], error) {
+	if _, err := s.tenantPath(tenant); err != nil {
 		return nil, err
-	}
-
-	exports, err := s.exporter.ListExports(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list exports failed: %w", err)
 	}
 
 	var entries []ExportEntry
-	for _, e := range exports {
-		if strings.HasPrefix(e.Path, bp+"/") {
-			entries = append(entries, ExportEntry{Path: e.Path, Client: e.Client})
+	s.volumes.Range(func(t, name string, meta *VolumeMetadata) bool {
+		if t != tenant {
+			return true
 		}
-	}
-	log.Debug().Str("tenant", tenant).Int("count", len(entries)).Msg("exports listed")
-	return entries, nil
-}
-
-func (s *Storage) ListExportsPaginated(ctx context.Context, tenant, after string, limit int) (*PaginatedResult[ExportEntry], error) {
-	entries, err := s.ListExports(ctx, tenant)
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].Path != entries[j].Path {
-			return entries[i].Path < entries[j].Path
+		for _, c := range meta.Exports {
+			entries = append(entries, ExportEntry{
+				Name:      name,
+				Client:    c.IP,
+				Labels:    c.Labels,
+				CreatedAt: c.CreatedAt,
+			})
 		}
-		return entries[i].Client < entries[j].Client
+		return true
 	})
-	return paginateSlice(entries, func(e ExportEntry) string { return e.Path + "|" + e.Client }, after, limit), nil
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].CreatedAt.After(entries[j].CreatedAt)
+	})
+	return paginateSlice(entries, func(e ExportEntry) string { return e.Name + "|" + e.Client }, after, limit), nil
 }

--- a/agent/storage/export.go
+++ b/agent/storage/export.go
@@ -20,7 +20,7 @@ func (s *Storage) CreateVolumeExport(ctx context.Context, tenant, name, client s
 	if err := validateLabels(labels); err != nil {
 		return err
 	}
-	if err := requireImmutableLabels(s.immutableLabelKeys,labels); err != nil {
+	if err := requireImmutableLabels(s.immutableLabelKeys, labels); err != nil {
 		return err
 	}
 

--- a/agent/storage/export_test.go
+++ b/agent/storage/export_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -257,20 +258,22 @@ func TestListExportsPaginated(t *testing.T) {
 		vol2 := filepath.Join(bp, "vol2")
 		require.NoError(t, os.MkdirAll(vol1, 0o755))
 		require.NoError(t, os.MkdirAll(vol2, 0o755))
+		now := time.Now().UTC()
 		writeTestMetadata(t, s, vol1, VolumeMetadata{
 			Name: "vol1", Exports: []ExportMetadata{
-				{IP: "10.0.0.1", Labels: map[string]string{"created-by": "csi"}},
-				{IP: "10.0.0.2"},
+				{IP: "10.0.0.1", Labels: map[string]string{"created-by": "csi"}, CreatedAt: now},
+				{IP: "10.0.0.2", CreatedAt: now.Add(-time.Minute)},
 			},
 		})
 		writeTestMetadata(t, s, vol2, VolumeMetadata{
-			Name: "vol2", Exports: []ExportMetadata{{IP: "10.0.0.3"}},
+			Name: "vol2", Exports: []ExportMetadata{{IP: "10.0.0.3", CreatedAt: now.Add(-2 * time.Minute)}},
 		})
 
 		page, err := s.ListVolumeExportsPaginated("test", "", 0)
 		require.NoError(t, err)
 		assert.Equal(t, 3, page.Total)
 		require.Len(t, page.Items, 3)
+		// sorted newest first
 		assert.Equal(t, "10.0.0.1", page.Items[0].Client)
 		assert.Equal(t, "csi", page.Items[0].Labels["created-by"])
 		assert.Equal(t, "10.0.0.3", page.Items[2].Client)

--- a/agent/storage/export_test.go
+++ b/agent/storage/export_test.go
@@ -7,15 +7,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/nfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-// --- TestExportVolume ---
+// --- TestCreateVolumeExport ---
 
-func TestExportVolume(t *testing.T) {
+func TestCreateVolumeExport(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("success", func(t *testing.T) {
@@ -27,44 +26,44 @@ func TestExportVolume(t *testing.T) {
 
 		exporter.On("Export", mock.Anything, volDir, "10.0.0.1").Return(nil)
 
-		err := s.ExportVolume(ctx, "test", "myvol", "10.0.0.1")
-		require.NoError(t, err, "ExportVolume")
+		err := s.CreateVolumeExport(ctx, "test", "myvol", "10.0.0.1", nil)
+		require.NoError(t, err, "CreateVolumeExport")
 
 		meta := readVolumeMeta(t, volDir)
-		assert.Contains(t, meta.Clients, "10.0.0.1", "client should be in metadata")
+		require.Len(t, meta.Exports, 1)
+		assert.Equal(t, "10.0.0.1", meta.Exports[0].IP)
 		assert.NotNil(t, meta.LastAttachAt, "LastAttachAt should be set")
 		exporter.AssertExpectations(t)
 	})
 
 	t.Run("idempotent_client", func(t *testing.T) {
-		s, bp, _, exporter := newTestStorage(t)
+		s, bp, _, _ := newTestStorage(t)
 
 		volDir := filepath.Join(bp, "myvol")
 		require.NoError(t, os.MkdirAll(volDir, 0o755))
 		writeTestMetadata(t, s, volDir, VolumeMetadata{
-			Name: "myvol", Clients: []string{"10.0.0.1"},
+			Name: "myvol", Exports: []ExportMetadata{{IP: "10.0.0.1"}},
 		})
 
-		exporter.On("Export", mock.Anything, volDir, "10.0.0.1").Return(nil)
-
-		err := s.ExportVolume(ctx, "test", "myvol", "10.0.0.1")
-		require.NoError(t, err, "ExportVolume (idempotent)")
+		// idempotent: same IP+labels already exists, no Export call expected
+		err := s.CreateVolumeExport(ctx, "test", "myvol", "10.0.0.1", nil)
+		require.NoError(t, err, "CreateVolumeExport (idempotent)")
 
 		meta := readVolumeMeta(t, volDir)
 		count := 0
-		for _, c := range meta.Clients {
-			if c == "10.0.0.1" {
+		for _, c := range meta.Exports {
+			if c.IP == "10.0.0.1" {
 				count++
 			}
 		}
 		assert.Equal(t, 1, count,
-			"expected exactly 1 entry for 10.0.0.1, got %d in: %v", count, meta.Clients)
+			"expected exactly 1 entry for 10.0.0.1, got %d in: %v", count, meta.Exports)
 	})
 
 	t.Run("not_found", func(t *testing.T) {
 		s, _, _, _ := newTestStorage(t)
 
-		err := s.ExportVolume(ctx, "test", "nonexistent", "10.0.0.1")
+		err := s.CreateVolumeExport(ctx, "test", "nonexistent", "10.0.0.1", nil)
 		requireStorageError(t, err, ErrNotFound)
 	})
 
@@ -77,22 +76,44 @@ func TestExportVolume(t *testing.T) {
 
 		exporter.On("Export", mock.Anything, volDir, "10.0.0.1").Return(fmt.Errorf("nfs error"))
 
-		err := s.ExportVolume(ctx, "test", "myvol", "10.0.0.1")
+		err := s.CreateVolumeExport(ctx, "test", "myvol", "10.0.0.1", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nfs export failed")
 
 		// metadata should already have the client (written before export call)
 		meta := readVolumeMeta(t, volDir)
-		assert.Contains(t, meta.Clients, "10.0.0.1",
-			"client should be persisted in metadata even though export failed")
+		require.Len(t, meta.Exports, 1)
+		assert.Equal(t, "10.0.0.1", meta.Exports[0].IP)
 		assert.NotNil(t, meta.LastAttachAt)
+		exporter.AssertExpectations(t)
+	})
+
+	t.Run("ref_counting_same_ip", func(t *testing.T) {
+		s, bp, _, exporter := newTestStorage(t)
+
+		volDir := filepath.Join(bp, "myvol")
+		require.NoError(t, os.MkdirAll(volDir, 0o755))
+		writeTestMetadata(t, s, volDir, VolumeMetadata{Name: "myvol"})
+
+		// first export for this IP: Export called
+		exporter.On("Export", mock.Anything, volDir, "10.0.0.1").Return(nil).Once()
+
+		labels1 := map[string]string{"kubernetes.volume.id": "vol1"}
+		labels2 := map[string]string{"kubernetes.volume.id": "vol2"}
+
+		require.NoError(t, s.CreateVolumeExport(ctx, "test", "myvol", "10.0.0.1", labels1))
+		// second export for same IP with different labels: no Export call
+		require.NoError(t, s.CreateVolumeExport(ctx, "test", "myvol", "10.0.0.1", labels2))
+
+		meta := readVolumeMeta(t, volDir)
+		assert.Len(t, meta.Exports, 2, "should have 2 client refs")
 		exporter.AssertExpectations(t)
 	})
 }
 
-// --- TestUnexportVolume ---
+// --- TestDeleteVolumeExport ---
 
-func TestUnexportVolume(t *testing.T) {
+func TestDeleteVolumeExport(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("success", func(t *testing.T) {
@@ -101,17 +122,17 @@ func TestUnexportVolume(t *testing.T) {
 		volDir := filepath.Join(bp, "myvol")
 		require.NoError(t, os.MkdirAll(volDir, 0o755))
 		writeTestMetadata(t, s, volDir, VolumeMetadata{
-			Name: "myvol", Clients: []string{"10.0.0.1", "10.0.0.2"},
+			Name: "myvol", Exports: []ExportMetadata{{IP: "10.0.0.1"}, {IP: "10.0.0.2"}},
 		})
 
 		exporter.On("Unexport", mock.Anything, volDir, "10.0.0.1").Return(nil)
 
-		err := s.UnexportVolume(ctx, "test", "myvol", "10.0.0.1")
-		require.NoError(t, err, "UnexportVolume")
+		err := s.DeleteVolumeExport(ctx, "test", "myvol", "10.0.0.1", nil)
+		require.NoError(t, err, "DeleteVolumeExport")
 
 		meta := readVolumeMeta(t, volDir)
-		assert.NotContains(t, meta.Clients, "10.0.0.1", "removed client should be gone")
-		assert.Contains(t, meta.Clients, "10.0.0.2", "other client should remain")
+		require.Len(t, meta.Exports, 1)
+		assert.Equal(t, "10.0.0.2", meta.Exports[0].IP, "other client should remain")
 		exporter.AssertExpectations(t)
 	})
 
@@ -121,16 +142,17 @@ func TestUnexportVolume(t *testing.T) {
 		volDir := filepath.Join(bp, "myvol")
 		require.NoError(t, os.MkdirAll(volDir, 0o755))
 		writeTestMetadata(t, s, volDir, VolumeMetadata{
-			Name: "myvol", Clients: []string{"10.0.0.1"},
+			Name: "myvol", Exports: []ExportMetadata{{IP: "10.0.0.1"}},
 		})
 
-		exporter.On("Unexport", mock.Anything, volDir, "10.0.0.99").Return(nil)
-
-		err := s.UnexportVolume(ctx, "test", "myvol", "10.0.0.99")
-		require.NoError(t, err, "UnexportVolume (client not in list)")
+		// IP was never present -> no Unexport call
+		err := s.DeleteVolumeExport(ctx, "test", "myvol", "10.0.0.99", nil)
+		require.NoError(t, err, "DeleteVolumeExport (client not in list)")
 
 		meta := readVolumeMeta(t, volDir)
-		assert.Contains(t, meta.Clients, "10.0.0.1", "existing client should be preserved")
+		require.Len(t, meta.Exports, 1)
+		assert.Equal(t, "10.0.0.1", meta.Exports[0].IP, "existing client should be preserved")
+		exporter.AssertNotCalled(t, "Unexport", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("metadata_first_on_unexport_failure", func(t *testing.T) {
@@ -139,60 +161,126 @@ func TestUnexportVolume(t *testing.T) {
 		volDir := filepath.Join(bp, "myvol")
 		require.NoError(t, os.MkdirAll(volDir, 0o755))
 		writeTestMetadata(t, s, volDir, VolumeMetadata{
-			Name: "myvol", Clients: []string{"10.0.0.1"},
+			Name: "myvol", Exports: []ExportMetadata{{IP: "10.0.0.1"}},
 		})
 
 		exporter.On("Unexport", mock.Anything, volDir, "10.0.0.1").Return(fmt.Errorf("nfs error"))
 
-		err := s.UnexportVolume(ctx, "test", "myvol", "10.0.0.1")
+		err := s.DeleteVolumeExport(ctx, "test", "myvol", "10.0.0.1", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nfs unexport failed")
 
 		// metadata should already have client removed (written before unexport call)
 		meta := readVolumeMeta(t, volDir)
-		assert.NotContains(t, meta.Clients, "10.0.0.1",
+		assert.Empty(t, meta.Exports,
 			"client should be removed from metadata even though unexport failed")
+		exporter.AssertExpectations(t)
+	})
+
+	t.Run("unexport_with_labels_keeps_other", func(t *testing.T) {
+		s, bp, _, exporter := newTestStorage(t)
+
+		volDir := filepath.Join(bp, "myvol")
+		require.NoError(t, os.MkdirAll(volDir, 0o755))
+		labels1 := map[string]string{"kubernetes.volume.id": "vol1"}
+		labels2 := map[string]string{"kubernetes.volume.id": "vol2"}
+		writeTestMetadata(t, s, volDir, VolumeMetadata{
+			Name: "myvol", Exports: []ExportMetadata{
+				{IP: "10.0.0.1", Labels: labels1},
+				{IP: "10.0.0.1", Labels: labels2},
+			},
+		})
+
+		// remove only one ref; IP still has another -> no Unexport call
+		err := s.DeleteVolumeExport(ctx, "test", "myvol", "10.0.0.1", labels1)
+		require.NoError(t, err)
+
+		meta := readVolumeMeta(t, volDir)
+		require.Len(t, meta.Exports, 1)
+		assert.Equal(t, labels2, meta.Exports[0].Labels)
+		exporter.AssertExpectations(t) // no Unexport called
+	})
+
+	t.Run("unexport_last_entry_triggers_unexport", func(t *testing.T) {
+		s, bp, _, exporter := newTestStorage(t)
+
+		volDir := filepath.Join(bp, "myvol")
+		require.NoError(t, os.MkdirAll(volDir, 0o755))
+		labels1 := map[string]string{"kubernetes.volume.id": "vol1"}
+		writeTestMetadata(t, s, volDir, VolumeMetadata{
+			Name: "myvol", Exports: []ExportMetadata{
+				{IP: "10.0.0.1", Labels: labels1},
+			},
+		})
+
+		exporter.On("Unexport", mock.Anything, volDir, "10.0.0.1").Return(nil)
+
+		err := s.DeleteVolumeExport(ctx, "test", "myvol", "10.0.0.1", labels1)
+		require.NoError(t, err)
+
+		meta := readVolumeMeta(t, volDir)
+		assert.Empty(t, meta.Exports)
+		exporter.AssertExpectations(t) // Unexport called
+	})
+
+	t.Run("unexport_nil_labels_removes_all", func(t *testing.T) {
+		s, bp, _, exporter := newTestStorage(t)
+
+		volDir := filepath.Join(bp, "myvol")
+		require.NoError(t, os.MkdirAll(volDir, 0o755))
+		writeTestMetadata(t, s, volDir, VolumeMetadata{
+			Name: "myvol", Exports: []ExportMetadata{
+				{IP: "10.0.0.1", Labels: map[string]string{"kubernetes.volume.id": "vol1"}},
+				{IP: "10.0.0.1", Labels: map[string]string{"kubernetes.volume.id": "vol2"}},
+			},
+		})
+
+		exporter.On("Unexport", mock.Anything, volDir, "10.0.0.1").Return(nil)
+
+		// nil labels -> remove all refs for this IP
+		err := s.DeleteVolumeExport(ctx, "test", "myvol", "10.0.0.1", nil)
+		require.NoError(t, err)
+
+		meta := readVolumeMeta(t, volDir)
+		assert.Empty(t, meta.Exports)
 		exporter.AssertExpectations(t)
 	})
 }
 
-// --- TestListExports ---
+// --- TestListExportsPaginated ---
 
-func TestListExports(t *testing.T) {
-	ctx := context.Background()
+func TestListExportsPaginated(t *testing.T) {
+	t.Run("from_metadata", func(t *testing.T) {
+		s, bp, _, _ := newTestStorage(t)
 
-	t.Run("filter_by_tenant", func(t *testing.T) {
-		s, bp, _, exporter := newTestStorage(t)
+		vol1 := filepath.Join(bp, "vol1")
+		vol2 := filepath.Join(bp, "vol2")
+		require.NoError(t, os.MkdirAll(vol1, 0o755))
+		require.NoError(t, os.MkdirAll(vol2, 0o755))
+		writeTestMetadata(t, s, vol1, VolumeMetadata{
+			Name: "vol1", Exports: []ExportMetadata{
+				{IP: "10.0.0.1", Labels: map[string]string{"created-by": "csi"}},
+				{IP: "10.0.0.2"},
+			},
+		})
+		writeTestMetadata(t, s, vol2, VolumeMetadata{
+			Name: "vol2", Exports: []ExportMetadata{{IP: "10.0.0.3"}},
+		})
 
-		exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo{
-			{Path: filepath.Join(bp, "vol1"), Client: "10.0.0.1"},
-			{Path: filepath.Join(bp, "vol2"), Client: "10.0.0.2"},
-			{Path: "/other/tenant/vol", Client: "10.0.0.99"},
-		}, nil)
-
-		entries, err := s.ListExports(ctx, "test")
-		require.NoError(t, err, "ListExports")
-		assert.Len(t, entries, 2, "should only include exports under tenant path")
-		exporter.AssertExpectations(t)
+		page, err := s.ListVolumeExportsPaginated("test", "", 0)
+		require.NoError(t, err)
+		assert.Equal(t, 3, page.Total)
+		require.Len(t, page.Items, 3)
+		assert.Equal(t, "10.0.0.1", page.Items[0].Client)
+		assert.Equal(t, "csi", page.Items[0].Labels["created-by"])
+		assert.Equal(t, "10.0.0.3", page.Items[2].Client)
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		s, _, _, exporter := newTestStorage(t)
+		s, _, _, _ := newTestStorage(t)
 
-		exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo{}, nil)
-
-		entries, err := s.ListExports(ctx, "test")
-		require.NoError(t, err, "ListExports")
-		assert.Empty(t, entries)
-	})
-
-	t.Run("error", func(t *testing.T) {
-		s, _, _, exporter := newTestStorage(t)
-
-		exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo(nil), fmt.Errorf("rpc error"))
-
-		_, err := s.ListExports(ctx, "test")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "list exports failed")
+		page, err := s.ListVolumeExportsPaginated("test", "", 0)
+		require.NoError(t, err)
+		assert.Empty(t, page.Items)
 	})
 }

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -23,7 +23,7 @@ type VolumeMetadata struct {
 	GID          int               `json:"gid"`
 	Mode         string            `json:"mode"`
 	Labels       map[string]string `json:"labels,omitempty"`
-	Exports      []ExportMetadata       `json:"clients,omitempty"`
+	Exports      []ExportMetadata  `json:"clients,omitempty"`
 	CreatedAt    time.Time         `json:"created_at"`
 	UpdatedAt    time.Time         `json:"updated_at"`
 	LastAttachAt *time.Time        `json:"last_attach_at,omitempty"`

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -1,6 +1,13 @@
 package storage
 
-import "time"
+import (
+	"encoding/json"
+	"maps"
+	"sort"
+	"time"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+)
 
 // Persisted metadata types
 
@@ -16,7 +23,7 @@ type VolumeMetadata struct {
 	GID          int               `json:"gid"`
 	Mode         string            `json:"mode"`
 	Labels       map[string]string `json:"labels,omitempty"`
-	Clients      []string          `json:"clients,omitempty"`
+	Exports      []ExportMetadata       `json:"clients,omitempty"`
 	CreatedAt    time.Time         `json:"created_at"`
 	UpdatedAt    time.Time         `json:"updated_at"`
 	LastAttachAt *time.Time        `json:"last_attach_at,omitempty"`
@@ -110,6 +117,98 @@ func paginateSlice[T any](items []T, keyFn func(T) string, after string, limit i
 }
 
 type ExportEntry struct {
-	Path   string `json:"path"`
-	Client string `json:"client"`
+	Name      string
+	Client    string
+	Labels    map[string]string
+	CreatedAt time.Time
+}
+
+func (e ExportEntry) GetLabels() map[string]string { return e.Labels }
+
+type ExportMetadata struct {
+	IP        string            `json:"ip"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
+}
+
+func uniqueExportIPs(clients []ExportMetadata) []string {
+	seen := map[string]struct{}{}
+	for _, c := range clients {
+		seen[c.IP] = struct{}{}
+	}
+	ips := make([]string, 0, len(seen))
+	for ip := range seen {
+		ips = append(ips, ip)
+	}
+	sort.Strings(ips)
+	return ips
+}
+
+func CountUniqueExportIPs(clients []ExportMetadata) int {
+	seen := map[string]struct{}{}
+	for _, c := range clients {
+		seen[c.IP] = struct{}{}
+	}
+	return len(seen)
+}
+
+func hasExport(clients []ExportMetadata, ip string, labels map[string]string) bool {
+	for _, c := range clients {
+		if c.IP == ip && maps.Equal(c.Labels, labels) {
+			return true
+		}
+	}
+	return false
+}
+
+func exportsForIP(clients []ExportMetadata, ip string) int {
+	n := 0
+	for _, c := range clients {
+		if c.IP == ip {
+			n++
+		}
+	}
+	return n
+}
+
+// labelsContain reports whether stored contains all key-value pairs from match.
+func labelsContain(stored, match map[string]string) bool {
+	for k, v := range match {
+		if stored[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *VolumeMetadata) UnmarshalJSON(data []byte) error {
+	type Alias VolumeMetadata
+	aux := &struct {
+		Exports json.RawMessage `json:"clients,omitempty"`
+		*Alias
+	}{Alias: (*Alias)(m)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.Exports) == 0 {
+		return nil
+	}
+	var refs []ExportMetadata
+	if err := json.Unmarshal(aux.Exports, &refs); err == nil {
+		m.Exports = refs
+		return nil
+	}
+	var ips []string
+	if err := json.Unmarshal(aux.Exports, &ips); err != nil {
+		return err
+	}
+	m.Exports = make([]ExportMetadata, len(ips))
+	for i, ip := range ips {
+		m.Exports[i] = ExportMetadata{
+			IP:        ip,
+			Labels:    map[string]string{config.LabelCreatedBy: "migrated"},
+			CreatedAt: time.Now().UTC(),
+		}
+	}
+	return nil
 }

--- a/agent/storage/model_test.go
+++ b/agent/storage/model_test.go
@@ -1,0 +1,127 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVolumeMetadata_UnmarshalJSON_Migration(t *testing.T) {
+	t.Run("old_format_string_array", func(t *testing.T) {
+		data := `{"name":"vol","clients":["10.0.0.1","10.0.0.2"]}`
+		var m VolumeMetadata
+		require.NoError(t, json.Unmarshal([]byte(data), &m))
+		require.Len(t, m.Exports, 2)
+		assert.Equal(t, "10.0.0.1", m.Exports[0].IP)
+		assert.Equal(t, "migrated", m.Exports[0].Labels["created-by"])
+		assert.False(t, m.Exports[0].CreatedAt.IsZero(), "migrated exports should have a created_at")
+		assert.Equal(t, "10.0.0.2", m.Exports[1].IP)
+		assert.Equal(t, "vol", m.Name)
+	})
+
+	t.Run("new_format_client_ref", func(t *testing.T) {
+		data := `{"name":"vol","clients":[{"ip":"10.0.0.1","labels":{"created-by":"csi"}}]}`
+		var m VolumeMetadata
+		require.NoError(t, json.Unmarshal([]byte(data), &m))
+		require.Len(t, m.Exports, 1)
+		assert.Equal(t, "10.0.0.1", m.Exports[0].IP)
+		assert.Equal(t, "csi", m.Exports[0].Labels["created-by"])
+	})
+
+	t.Run("null_clients", func(t *testing.T) {
+		data := `{"name":"vol","clients":null}`
+		var m VolumeMetadata
+		require.NoError(t, json.Unmarshal([]byte(data), &m))
+		assert.Nil(t, m.Exports)
+	})
+
+	t.Run("empty_array", func(t *testing.T) {
+		data := `{"name":"vol","clients":[]}`
+		var m VolumeMetadata
+		require.NoError(t, json.Unmarshal([]byte(data), &m))
+		assert.Empty(t, m.Exports)
+	})
+
+	t.Run("no_clients_field", func(t *testing.T) {
+		data := `{"name":"vol"}`
+		var m VolumeMetadata
+		require.NoError(t, json.Unmarshal([]byte(data), &m))
+		assert.Nil(t, m.Exports)
+	})
+
+	t.Run("roundtrip_new_format", func(t *testing.T) {
+		orig := VolumeMetadata{
+			Name: "vol",
+			Exports: []ExportMetadata{
+				{IP: "10.0.0.1", Labels: map[string]string{"kubernetes.volume.id": "sc|vol1"}},
+				{IP: "10.0.0.2"},
+			},
+		}
+		data, err := json.Marshal(orig)
+		require.NoError(t, err)
+
+		var m VolumeMetadata
+		require.NoError(t, json.Unmarshal(data, &m))
+		assert.Equal(t, orig.Exports, m.Exports)
+	})
+}
+
+func TestUniqueClientIPs(t *testing.T) {
+	clients := []ExportMetadata{
+		{IP: "10.0.0.2"},
+		{IP: "10.0.0.1"},
+		{IP: "10.0.0.2"},
+		{IP: "10.0.0.3"},
+	}
+	ips := uniqueExportIPs(clients)
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, ips)
+}
+
+func TestCountUniqueExportIPs(t *testing.T) {
+	clients := []ExportMetadata{
+		{IP: "10.0.0.1"},
+		{IP: "10.0.0.1", Labels: map[string]string{"a": "b"}},
+		{IP: "10.0.0.2"},
+	}
+	assert.Equal(t, 2, CountUniqueExportIPs(clients))
+	assert.Equal(t, 0, CountUniqueExportIPs(nil))
+}
+
+func TestHasClientEntry(t *testing.T) {
+	clients := []ExportMetadata{
+		{IP: "10.0.0.1", Labels: map[string]string{"k": "v"}},
+		{IP: "10.0.0.2"},
+	}
+	assert.True(t, hasExport(clients, "10.0.0.1", map[string]string{"k": "v"}))
+	assert.False(t, hasExport(clients, "10.0.0.1", nil))
+	assert.True(t, hasExport(clients, "10.0.0.2", nil))
+	assert.False(t, hasExport(clients, "10.0.0.3", nil))
+}
+
+func TestRefsForIP(t *testing.T) {
+	clients := []ExportMetadata{
+		{IP: "10.0.0.1"},
+		{IP: "10.0.0.1", Labels: map[string]string{"a": "b"}},
+		{IP: "10.0.0.2"},
+	}
+	assert.Equal(t, 2, exportsForIP(clients, "10.0.0.1"))
+	assert.Equal(t, 1, exportsForIP(clients, "10.0.0.2"))
+	assert.Equal(t, 0, exportsForIP(clients, "10.0.0.3"))
+}
+
+func TestLabelsContain(t *testing.T) {
+	stored := map[string]string{"created-by": "csi", "kubernetes.volume.id": "vol1", "kubernetes.node.name": "w1"}
+
+	assert.True(t, labelsContain(stored, map[string]string{"kubernetes.volume.id": "vol1"}), "subset match")
+	assert.True(t, labelsContain(stored, map[string]string{"kubernetes.volume.id": "vol1", "created-by": "csi"}), "multi-key subset")
+	assert.True(t, labelsContain(stored, map[string]string{}), "empty match matches everything")
+	assert.True(t, labelsContain(stored, nil), "nil match matches everything")
+	assert.False(t, labelsContain(stored, map[string]string{"kubernetes.volume.id": "vol2"}), "wrong value")
+	assert.False(t, labelsContain(stored, map[string]string{"missing-key": "x"}), "missing key")
+	assert.True(t, labelsContain(nil, nil), "both nil")
+	assert.True(t, labelsContain(nil, map[string]string{}), "nil stored, empty match")
+	assert.False(t, labelsContain(nil, map[string]string{"a": "b"}), "nil stored, non-empty match")
+}
+

--- a/agent/storage/model_test.go
+++ b/agent/storage/model_test.go
@@ -124,4 +124,3 @@ func TestLabelsContain(t *testing.T) {
 	assert.True(t, labelsContain(nil, map[string]string{}), "nil stored, empty match")
 	assert.False(t, labelsContain(nil, map[string]string{"a": "b"}), "nil stored, non-empty match")
 }
-

--- a/agent/storage/reconciler.go
+++ b/agent/storage/reconciler.go
@@ -74,13 +74,13 @@ func (s *Storage) reconcileExports(ctx context.Context, tenant string) {
 		}
 		volDir := s.volumes.Dir(tenant, name)
 		actual := actualExports[volDir]
-		for _, client := range meta.Clients {
-			if actual != nil && actual[client] {
+		for _, ip := range uniqueExportIPs(meta.Exports) {
+			if actual != nil && actual[ip] {
 				continue
 			}
-			log.Warn().Str("path", volDir).Str("client", client).Msg("nfs reconciler: re-exporting missing export")
-			if err := s.exporter.Export(ctx, volDir, client); err != nil {
-				log.Error().Err(err).Str("path", volDir).Str("client", client).Msg("nfs reconciler: failed to re-export")
+			log.Warn().Str("path", volDir).Str("client", ip).Msg("nfs reconciler: re-exporting missing export")
+			if err := s.exporter.Export(ctx, volDir, ip); err != nil {
+				log.Error().Err(err).Str("path", volDir).Str("client", ip).Msg("nfs reconciler: failed to re-export")
 				continue
 			}
 			restored++

--- a/agent/storage/reconciler_test.go
+++ b/agent/storage/reconciler_test.go
@@ -72,11 +72,11 @@ func TestReconcileExports(t *testing.T) {
 		require.NoError(t, os.MkdirAll(vol2, 0o755))
 		writeTestMetadata(t, s, vol1, VolumeMetadata{
 			Name:    "vol1",
-			Clients: []string{"10.0.0.1", "10.0.0.2"},
+			Exports: []ExportMetadata{{IP: "10.0.0.1"}, {IP: "10.0.0.2"}},
 		})
 		writeTestMetadata(t, s, vol2, VolumeMetadata{
 			Name:    "vol2",
-			Clients: []string{"10.0.0.3"},
+			Exports: []ExportMetadata{{IP: "10.0.0.3"}},
 		})
 
 		exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo{
@@ -101,7 +101,7 @@ func TestReconcileExports(t *testing.T) {
 		require.NoError(t, os.MkdirAll(healthy, 0o755))
 		writeTestMetadata(t, s, healthy, VolumeMetadata{
 			Name:    "healthy",
-			Clients: []string{"10.0.0.1"},
+			Exports: []ExportMetadata{{IP: "10.0.0.1"}},
 		})
 
 		deletedPath := filepath.Join(bp, "deleted-vol")
@@ -128,14 +128,14 @@ func TestReconcileExports(t *testing.T) {
 		require.NoError(t, os.MkdirAll(vol1, 0o755))
 		writeTestMetadata(t, s, vol1, VolumeMetadata{
 			Name:    "vol1",
-			Clients: []string{"10.0.0.1", "10.0.0.2"},
+			Exports: []ExportMetadata{{IP: "10.0.0.1"}, {IP: "10.0.0.2"}},
 		})
 
 		vol2 := filepath.Join(bp, "vol2")
 		require.NoError(t, os.MkdirAll(vol2, 0o755))
 		writeTestMetadata(t, s, vol2, VolumeMetadata{
 			Name:    "vol2",
-			Clients: []string{"10.0.0.3"},
+			Exports: []ExportMetadata{{IP: "10.0.0.3"}},
 		})
 
 		exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo{
@@ -159,7 +159,7 @@ func TestReconcileExports(t *testing.T) {
 		require.NoError(t, os.MkdirAll(healthy, 0o755))
 		writeTestMetadata(t, s, healthy, VolumeMetadata{
 			Name:    "healthy",
-			Clients: []string{"10.0.0.10"},
+			Exports: []ExportMetadata{{IP: "10.0.0.10"}},
 		})
 
 		orphan1 := filepath.Join(bp, "orphan1")
@@ -199,7 +199,7 @@ func TestReconcileExports(t *testing.T) {
 		require.NoError(t, os.MkdirAll(healthy, 0o755))
 		writeTestMetadata(t, s, healthy, VolumeMetadata{
 			Name:    "healthy",
-			Clients: []string{"10.0.0.1"},
+			Exports: []ExportMetadata{{IP: "10.0.0.1"}},
 		})
 
 		exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo{}, nil)
@@ -220,7 +220,7 @@ func TestReconcileExports(t *testing.T) {
 		require.NoError(t, os.MkdirAll(vol1, 0o755))
 		writeTestMetadata(t, s, vol1, VolumeMetadata{
 			Name:    "vol1",
-			Clients: []string{"10.0.0.1"},
+			Exports: []ExportMetadata{{IP: "10.0.0.1"}},
 		})
 
 		exporter.On("ListExports", mock.Anything).Return([]nfs.ExportInfo{

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -25,6 +25,9 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
+	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+		return nil, err
+	}
 	volMeta, err := s.volumes.Get(tenant, req.Volume)
 	if err != nil {
 		return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("source volume %q not found", req.Volume)}

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -25,7 +25,7 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
-	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+	if err := requireImmutableLabels(s.immutableLabelKeys, req.Labels); err != nil {
 		return nil, err
 	}
 	volMeta, err := s.volumes.Get(tenant, req.Volume)

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -34,6 +34,8 @@ type Storage struct {
 	taskDefaultTimeout time.Duration
 	taskScrubTimeout   time.Duration
 
+	immutableLabelKeys []string
+
 	volumes   *meta.Store[VolumeMetadata]
 	snapshots *meta.Store[SnapshotMetadata]
 
@@ -47,7 +49,7 @@ type Storage struct {
 	cachedFilesystem atomic.Pointer[btrfs.FilesystemUsage]
 }
 
-func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin string, taskMaxConcurrent int, taskDefaultTimeout, taskScrubTimeout, taskPollInterval time.Duration) *Storage {
+func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin, immutableLabels string, taskMaxConcurrent int, taskDefaultTimeout, taskScrubTimeout, taskPollInterval time.Duration) *Storage {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -118,7 +120,7 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 		initialStates[i] = DeviceState{BTRFSDevice: d}
 	}
 	taskDir := filepath.Join(basePath, config.TasksDir)
-	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, tasks: task.NewManager(taskDir, taskMaxConcurrent, taskPollInterval), taskDefaultTimeout: taskDefaultTimeout, taskScrubTimeout: taskScrubTimeout, volumes: meta.NewStore[VolumeMetadata](basePath), snapshots: meta.NewStore[SnapshotMetadata](basePath, config.SnapshotsDir)}
+	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, immutableLabelKeys: config.ImmutableLabelKeys(immutableLabels), tasks: task.NewManager(taskDir, taskMaxConcurrent, taskPollInterval), taskDefaultTimeout: taskDefaultTimeout, taskScrubTimeout: taskScrubTimeout, volumes: meta.NewStore[VolumeMetadata](basePath), snapshots: meta.NewStore[SnapshotMetadata](basePath, config.SnapshotsDir)}
 	s.cachedDevices.Store(&initialStates)
 	s.loadCache()
 	return s

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -346,21 +346,22 @@ func (s *StorageIntegrationSuite) TestExportMetadataPersistence() {
 	exporter.On("Unexport", mock.Anything, volDir, "10.0.0.1").Return(nil)
 
 	// Export
-	err = s.storage.ExportVolume(s.ctx, "test", "export-vol", "10.0.0.1")
+	err = s.storage.CreateVolumeExport(s.ctx, "test", "export-vol", "10.0.0.1", nil)
 	s.Require().NoError(err)
 
 	var meta VolumeMetadata
 	readTestJSON(s.T(), filepath.Join(volDir, config.MetadataFile), &meta)
-	s.Assert().Contains(meta.Clients, "10.0.0.1")
+	s.Require().Len(meta.Exports, 1)
+	s.Assert().Equal("10.0.0.1", meta.Exports[0].IP)
 	s.Assert().NotNil(meta.LastAttachAt)
 
 	// Unexport
-	err = s.storage.UnexportVolume(s.ctx, "test", "export-vol", "10.0.0.1")
+	err = s.storage.DeleteVolumeExport(s.ctx, "test", "export-vol", "10.0.0.1", nil)
 	s.Require().NoError(err)
 
 	var afterUnexport VolumeMetadata
 	readTestJSON(s.T(), filepath.Join(volDir, config.MetadataFile), &afterUnexport)
-	s.Assert().NotContains(afterUnexport.Clients, "10.0.0.1")
+	s.Assert().Empty(afterUnexport.Exports)
 
 	exporter.AssertExpectations(s.T())
 

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -48,6 +48,27 @@ func validateLabels(labels map[string]string) error {
 	return nil
 }
 
+func requireImmutableLabels(keys []string, labels map[string]string) error {
+	for _, k := range keys {
+		if labels[k] == "" {
+			return &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("label %q is required", k)}
+		}
+	}
+	return nil
+}
+
+func protectImmutableLabels(keys []string, cur, updated map[string]string) error {
+	for _, k := range keys {
+		if v, ok := updated[k]; ok && v != cur[k] {
+			return &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("label %q cannot be changed", k)}
+		}
+		if v := cur[k]; v != "" {
+			updated[k] = v
+		}
+	}
+	return nil
+}
+
 // --- File mode ---
 
 // fileMode converts a traditional Unix octal mode (e.g. 0o2750) to an os.FileMode.

--- a/agent/storage/utils_test.go
+++ b/agent/storage/utils_test.go
@@ -40,16 +40,16 @@ func testStorageWithRunner(t *testing.T, runner *utils.MockRunner, exporter *nfs
 
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 	s := &Storage{
-		basePath:           base,
-		mountPoint:         base,
-		btrfs:              mgr,
-		exporter:           exporter,
-		tenants:            []string{tenant},
-		defaultDirMode:     0o755,
-		defaultDataMode:    "2770",
+		basePath:        base,
+		mountPoint:      base,
+		btrfs:           mgr,
+		exporter:        exporter,
+		tenants:         []string{tenant},
+		defaultDirMode:  0o755,
+		defaultDataMode: "2770",
 		// immutableLabelKeys left nil to avoid requiring created-by in every test
-		volumes:            meta.NewStore[VolumeMetadata](base),
-		snapshots:          meta.NewStore[SnapshotMetadata](base, config.SnapshotsDir),
+		volumes:   meta.NewStore[VolumeMetadata](base),
+		snapshots: meta.NewStore[SnapshotMetadata](base, config.SnapshotsDir),
 	}
 	return s, tenantPath
 }

--- a/agent/storage/utils_test.go
+++ b/agent/storage/utils_test.go
@@ -40,15 +40,16 @@ func testStorageWithRunner(t *testing.T, runner *utils.MockRunner, exporter *nfs
 
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 	s := &Storage{
-		basePath:        base,
-		mountPoint:      base,
-		btrfs:           mgr,
-		exporter:        exporter,
-		tenants:         []string{tenant},
-		defaultDirMode:  0o755,
-		defaultDataMode: "2770",
-		volumes:         meta.NewStore[VolumeMetadata](base),
-		snapshots:       meta.NewStore[SnapshotMetadata](base, config.SnapshotsDir),
+		basePath:           base,
+		mountPoint:         base,
+		btrfs:              mgr,
+		exporter:           exporter,
+		tenants:            []string{tenant},
+		defaultDirMode:     0o755,
+		defaultDataMode:    "2770",
+		// immutableLabelKeys left nil to avoid requiring created-by in every test
+		volumes:            meta.NewStore[VolumeMetadata](base),
+		snapshots:          meta.NewStore[SnapshotMetadata](base, config.SnapshotsDir),
 	}
 	return s, tenantPath
 }
@@ -216,6 +217,38 @@ func TestValidateLabels(t *testing.T) {
 			requireStorageError(t, err, ErrInvalid)
 		})
 	}
+}
+
+func TestRequireImmutableLabels(t *testing.T) {
+	keys := []string{"created-by"}
+
+	assert.NoError(t, requireImmutableLabels(keys, map[string]string{"created-by": "csi"}))
+	assert.NoError(t, requireImmutableLabels(keys, map[string]string{"created-by": "cli", "extra": "ok"}))
+	requireStorageError(t, requireImmutableLabels(keys, map[string]string{"extra": "ok"}), ErrInvalid)
+	requireStorageError(t, requireImmutableLabels(keys, map[string]string{}), ErrInvalid)
+	requireStorageError(t, requireImmutableLabels(keys, nil), ErrInvalid)
+	assert.NoError(t, requireImmutableLabels(nil, nil), "nil keys = no requirements")
+}
+
+func TestProtectImmutableLabels(t *testing.T) {
+	keys := []string{"created-by"}
+
+	t.Run("preserves_on_omit", func(t *testing.T) {
+		updated := map[string]string{"env": "prod"}
+		require.NoError(t, protectImmutableLabels(keys, map[string]string{"created-by": "csi"}, updated))
+		assert.Equal(t, "csi", updated["created-by"], "should be preserved")
+	})
+
+	t.Run("rejects_change", func(t *testing.T) {
+		updated := map[string]string{"created-by": "hacker"}
+		err := protectImmutableLabels(keys, map[string]string{"created-by": "csi"}, updated)
+		requireStorageError(t, err, ErrInvalid)
+	})
+
+	t.Run("allows_same_value", func(t *testing.T) {
+		updated := map[string]string{"created-by": "csi", "env": "prod"}
+		require.NoError(t, protectImmutableLabels(keys, map[string]string{"created-by": "csi"}, updated))
+	})
 }
 
 func TestFileMode(t *testing.T) {

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -37,7 +37,7 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
-	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+	if err := requireImmutableLabels(s.immutableLabelKeys, req.Labels); err != nil {
 		return nil, err
 	}
 	if req.Mode == "" {
@@ -315,7 +315,7 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
-	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+	if err := requireImmutableLabels(s.immutableLabelKeys, req.Labels); err != nil {
 		return nil, err
 	}
 

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -37,6 +37,9 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
+	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+		return nil, err
+	}
 	if req.Mode == "" {
 		req.Mode = s.defaultDataMode
 	}
@@ -196,6 +199,9 @@ func (s *Storage) UpdateVolume(ctx context.Context, tenant, name string, req Vol
 		if err := validateLabels(*req.Labels); err != nil {
 			return nil, err
 		}
+		if err := protectImmutableLabels(s.immutableLabelKeys, cur.Labels, *req.Labels); err != nil {
+			return nil, err
+		}
 	}
 	if req.SizeBytes != nil && *req.SizeBytes <= cur.SizeBytes {
 		return nil, &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("new size %d must be larger than current size %d", *req.SizeBytes, cur.SizeBytes)}
@@ -309,6 +315,9 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 	if err := validateLabels(req.Labels); err != nil {
 		return nil, err
 	}
+	if err := requireImmutableLabels(s.immutableLabelKeys,req.Labels); err != nil {
+		return nil, err
+	}
 
 	src, err := s.GetVolume(tenant, req.Source)
 	if err != nil {
@@ -394,7 +403,7 @@ func (s *Storage) DeleteVolume(ctx context.Context, tenant, name string) error {
 		}
 		return fmt.Errorf("failed to read volume metadata: %w", err)
 	}
-	if len(meta.Clients) > 0 {
+	if len(meta.Exports) > 0 {
 		return &StorageError{Code: ErrBusy, Message: fmt.Sprintf("volume %q still has active NFS exports", name)}
 	}
 

--- a/agent/storage/volume_test.go
+++ b/agent/storage/volume_test.go
@@ -609,7 +609,7 @@ func TestDeleteVolume(t *testing.T) {
 
 	t.Run("busy_with_exports", func(t *testing.T) {
 		s, bp, _, _ := newTestStorage(t)
-		seedVolume(t, s, "test", bp, VolumeMetadata{Name: "myvol", Clients: []string{"10.0.0.1"}})
+		seedVolume(t, s, "test", bp, VolumeMetadata{Name: "myvol", Exports: []ExportMetadata{{IP: "10.0.0.1"}}})
 
 		err := s.DeleteVolume(ctx, "test", "myvol")
 		requireStorageError(t, err, ErrBusy)

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -41,7 +42,35 @@ const (
 
 	VolumeIDSep = "|"
 	NodeIDSep   = "|"
+
+	LabelCreatedBy              = "created-by"
+	LabelKubernetesNodeName     = "kubernetes.node.name"
+	LabelKubernetesVolumeID     = "kubernetes.pvc.id"
+	LabelKubernetesStorageClass = "kubernetes.pvc.storageclass"
 )
+
+// DefaultImmutableLabelKeys are always immutable. Additional keys can be added via AGENT_IMMUTABLE_LABELS.
+var DefaultImmutableLabelKeys = []string{LabelCreatedBy}
+
+// ImmutableLabelKeys returns the merged list of default + configured immutable label keys.
+func ImmutableLabelKeys(extra string) []string {
+	seen := map[string]bool{}
+	var keys []string
+	for _, k := range DefaultImmutableLabelKeys {
+		if !seen[k] {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	for _, k := range strings.Split(extra, ",") {
+		k = strings.TrimSpace(k)
+		if k != "" && !seen[k] {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	return keys
+}
 
 // Storage engine settings
 const (
@@ -63,8 +92,9 @@ type AgentConfig struct {
 	NFSExporter          string        `env:"AGENT_NFS_EXPORTER" envDefault:"kernel"`
 	ExportfsBin          string        `env:"AGENT_EXPORTFS_BIN" envDefault:"exportfs"`
 	KernelExportOptions  string        `env:"AGENT_KERNEL_EXPORT_OPTIONS" envDefault:"rw,nohide,crossmnt,no_root_squash,no_subtree_check"`
+	ImmutableLabels      string        `env:"AGENT_IMMUTABLE_LABELS"`
 	BtrfsBin             string        `env:"AGENT_BTRFS_BIN" envDefault:"btrfs"`
-	NFSReconcileInterval time.Duration `env:"AGENT_NFS_RECONCILE_INTERVAL" envDefault:"10m"`
+	NFSReconcileInterval time.Duration `env:"AGENT_NFS_RECONCILE_INTERVAL" envDefault:"60s"`
 	DeviceIOInterval     time.Duration `env:"AGENT_DEVICE_IO_INTERVAL" envDefault:"5s"`
 	DeviceStatsInterval  time.Duration `env:"AGENT_DEVICE_STATS_INTERVAL" envDefault:"1m"`
 	DashboardRefresh     int           `env:"AGENT_DASHBOARD_REFRESH_SECONDS" envDefault:"5"`

--- a/controller/publish.go
+++ b/controller/publish.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	agentAPI "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
@@ -60,7 +61,13 @@ func (s *Server) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	exportCtx, cancel := context.WithTimeout(ctx, exportTimeout)
 	defer cancel()
 	start := time.Now()
-	if err := client.ExportVolume(exportCtx, name, nodeIP); err != nil {
+	exportLabels := map[string]string{
+		config.LabelCreatedBy:              "k8s",
+		config.LabelKubernetesNodeName:     parseNodeHostname(req.NodeId),
+		config.LabelKubernetesVolumeID:     name,
+		config.LabelKubernetesStorageClass: sc,
+	}
+	if err := client.CreateVolumeExport(exportCtx, name, nodeIP, exportLabels); err != nil {
 		agentDuration.WithLabelValues("export", sc).Observe(time.Since(start).Seconds())
 		agentOpsTotal.WithLabelValues("export", "error", sc).Inc()
 		return nil, status.Errorf(codes.Internal, "export volume %s to node %s via %s: %v", name, nodeIP, sc, err)
@@ -99,7 +106,12 @@ func (s *Server) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 	unexportCtx, cancel2 := context.WithTimeout(ctx, exportTimeout)
 	defer cancel2()
 	start2 := time.Now()
-	unexportErr := client.UnexportVolume(unexportCtx, name, nodeIP)
+	unexportLabels := map[string]string{
+		config.LabelKubernetesNodeName:     parseNodeHostname(req.NodeId),
+		config.LabelKubernetesVolumeID:     name,
+		config.LabelKubernetesStorageClass: sc,
+	}
+	unexportErr := client.DeleteVolumeExport(unexportCtx, name, nodeIP, unexportLabels)
 	agentDuration.WithLabelValues("unexport", sc).Observe(time.Since(start2).Seconds())
 	if unexportErr != nil {
 		if agentAPI.IsNotFound(unexportErr) {

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -53,6 +53,11 @@ func parseNodeIP(nodeID string) (string, error) {
 	return parts[1], nil
 }
 
+func parseNodeHostname(nodeID string) string {
+	parts := strings.SplitN(nodeID, config.NodeIDSep, 2)
+	return parts[0]
+}
+
 func agentClientFromSecrets(agentURL string, secrets map[string]string) (*agentAPI.Client, error) {
 	token := secrets[secretAgentToken]
 	if token == "" {

--- a/controller/utils_test.go
+++ b/controller/utils_test.go
@@ -95,3 +95,9 @@ func TestParseNodeIP(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNodeHostname(t *testing.T) {
+	assert.Equal(t, "worker-1", parseNodeHostname("worker-1|10.0.0.1"))
+	assert.Equal(t, "node", parseNodeHostname("node|"))
+	assert.Equal(t, "single", parseNodeHostname("single"))
+}

--- a/ctl/export.go
+++ b/ctl/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
 	"github.com/urfave/cli/v3"
 )
 
@@ -12,7 +13,8 @@ func exportAdd(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("usage: export add <volume> <client-ip>")
 	}
 	vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
-	if err := clientFrom(cmd).ExportVolume(ctx, vol, client); err != nil {
+	labels := parseLabelsFlag(cmd)
+	if err := clientFrom(cmd).CreateVolumeExport(ctx, vol, client, labels); err != nil {
 		return wrapErr(err, "volume", vol)
 	}
 	if !isJSON(cmd) {
@@ -26,7 +28,8 @@ func exportRemove(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("usage: export remove <volume> <client-ip>")
 	}
 	vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
-	if err := clientFrom(cmd).UnexportVolume(ctx, vol, client); err != nil {
+	labels := parseLabelsFlag(cmd)
+	if err := clientFrom(cmd).DeleteVolumeExport(ctx, vol, client, labels); err != nil {
 		return wrapErr(err, "volume", vol)
 	}
 	if !isJSON(cmd) {
@@ -35,20 +38,50 @@ func exportRemove(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func exportList(ctx context.Context, cmd *cli.Command) error {
-	c := clientFrom(cmd)
-	return runWatch(ctx, cmd, func() error {
-		resp, err := c.ListExports(ctx)
+func listExports(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy string, rev bool, opts v1.ListOpts) error {
+	if isWide(cmd) {
+		resp, err := c.ListVolumeExportsDetail(ctx, opts)
 		if err != nil {
 			return err
 		}
+		sortExportsDetailList(resp.Exports, sortBy, rev)
 		return output(cmd, resp, func() {
-			tw := newTableWriter(cmd, []string{"PATH", "CLIENT"})
+			tw := newTableWriter(cmd, []string{"NAME", "CLIENT", "LABELS", "CREATED"})
 			tw.writeHeader()
 			for _, e := range resp.Exports {
-				tw.writeRow(map[string]string{"PATH": e.Path, "CLIENT": e.Client})
+				created := ""
+				if !e.CreatedAt.IsZero() {
+					created = e.CreatedAt.Format(timeFmt)
+				}
+				tw.writeRow(map[string]string{
+					"NAME":    e.Name,
+					"CLIENT":  e.Client,
+					"LABELS":  formatLabelsShort(e.Labels),
+					"CREATED": created,
+				})
 			}
 			tw.flush()
 		})
+	}
+	resp, err := c.ListVolumeExports(ctx, opts)
+	if err != nil {
+		return err
+	}
+	sortExportsList(resp.Exports, sortBy, rev)
+	return output(cmd, resp, func() {
+		tw := newTableWriter(cmd, []string{"NAME", "CLIENT", "CREATED"})
+		tw.writeHeader()
+		for _, e := range resp.Exports {
+			created := ""
+			if !e.CreatedAt.IsZero() {
+				created = e.CreatedAt.Format(timeFmt)
+			}
+			tw.writeRow(map[string]string{
+				"NAME":    e.Name,
+				"CLIENT":  e.Client,
+				"CREATED": created,
+			})
+		}
+		tw.flush()
 	})
 }

--- a/ctl/model.go
+++ b/ctl/model.go
@@ -150,6 +150,7 @@ func exportCmd() *cli.Command {
 				Name:      "add",
 				Usage:     "add NFS export",
 				ArgsUsage: "<volume> <client-ip>",
+				Flags:     []cli.Flag{labelFlag()},
 				Action:    exportAdd,
 			},
 			{
@@ -157,14 +158,23 @@ func exportCmd() *cli.Command {
 				Aliases:   []string{"rm"},
 				Usage:     "remove NFS export",
 				ArgsUsage: "<volume> <client-ip>",
+				Flags:     []cli.Flag{labelFlag()},
 				Action:    exportRemove,
 			},
 			{
 				Name:    "list",
 				Aliases: []string{"ls"},
 				Usage:   "list active NFS exports",
-				Flags:   []cli.Flag{columnsFlag(), watchFlag()},
-				Action:  exportList,
+				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					c := clientFrom(cmd)
+					sortBy := cmd.String("sort")
+					rev := !cmd.Bool("asc")
+					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					return runWatch(ctx, cmd, func() error {
+						return listExports(ctx, cmd, c, sortBy, rev, opts)
+					})
+				},
 			},
 		},
 	}

--- a/ctl/utils.go
+++ b/ctl/utils.go
@@ -29,7 +29,7 @@ const (
 	sortUsed    = "used"
 	sortUsedPct = "used%"
 	sortCreated = "created"
-	sortClients = "clients"
+	sortExports = "clients"
 	sortVolume  = "volume"
 )
 
@@ -90,6 +90,21 @@ func formatLabelsShort(labels map[string]string) string {
 		return s[:45] + "..."
 	}
 	return s
+}
+
+func formatExports(refs []v1.ExportDetailResponse) string {
+	parts := make([]string, 0, len(refs))
+	for _, r := range refs {
+		s := r.Client
+		if len(r.Labels) > 0 {
+			s += " (" + formatLabelsShort(r.Labels) + ")"
+		}
+		if !r.CreatedAt.IsZero() {
+			s += " since " + r.CreatedAt.Format(timeFmt)
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func splitLabelsFlag(cmd *cli.Command) []string {
@@ -269,8 +284,8 @@ func sortVolumes(vols []v1.VolumeResponse, field string, reverse bool) {
 			less = usedPct(vols[i].UsedBytes, vols[i].SizeBytes) < usedPct(vols[j].UsedBytes, vols[j].SizeBytes)
 		case sortCreated:
 			less = vols[i].CreatedAt.Before(vols[j].CreatedAt)
-		case sortClients:
-			less = vols[i].Clients < vols[j].Clients
+		case sortExports:
+			less = vols[i].Exports < vols[j].Exports
 		default:
 			less = vols[i].Name < vols[j].Name
 		}
@@ -293,8 +308,8 @@ func sortVolumesDetail(vols []v1.VolumeDetailResponse, field string, reverse boo
 			less = usedPct(vols[i].UsedBytes, vols[i].SizeBytes) < usedPct(vols[j].UsedBytes, vols[j].SizeBytes)
 		case sortCreated:
 			less = vols[i].CreatedAt.Before(vols[j].CreatedAt)
-		case sortClients:
-			less = len(vols[i].Clients) < len(vols[j].Clients)
+		case sortExports:
+			less = len(vols[i].Exports) < len(vols[j].Exports)
 		default:
 			less = vols[i].Name < vols[j].Name
 		}
@@ -341,6 +356,42 @@ func sortSnapshotsDetail(snaps []v1.SnapshotDetailResponse, field string, revers
 			less = snaps[i].Volume < snaps[j].Volume
 		default:
 			less = snaps[i].Name < snaps[j].Name
+		}
+		if reverse {
+			return !less
+		}
+		return less
+	})
+}
+
+func sortExportsList(exports []v1.ExportResponse, field string, reverse bool) {
+	sort.Slice(exports, func(i, j int) bool {
+		var less bool
+		switch field {
+		case "client":
+			less = exports[i].Client < exports[j].Client
+		case sortCreated:
+			less = exports[i].CreatedAt.Before(exports[j].CreatedAt)
+		default:
+			less = exports[i].Name < exports[j].Name
+		}
+		if reverse {
+			return !less
+		}
+		return less
+	})
+}
+
+func sortExportsDetailList(exports []v1.ExportDetailResponse, field string, reverse bool) {
+	sort.Slice(exports, func(i, j int) bool {
+		var less bool
+		switch field {
+		case "client":
+			less = exports[i].Client < exports[j].Client
+		case sortCreated:
+			less = exports[i].CreatedAt.Before(exports[j].CreatedAt)
+		default:
+			less = exports[i].Name < exports[j].Name
 		}
 		if reverse {
 			return !less

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -26,7 +26,7 @@ func listVolumes(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy str
 					"NAME": v.Name, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
 					"QUOTA": utils.FormatBytes(v.QuotaBytes), "COMPRESSION": v.Compression, "NOCOW": fmt.Sprintf("%v", v.NoCOW),
 					"UID": fmt.Sprintf("%d", v.UID), "GID": fmt.Sprintf("%d", v.GID), "MODE": v.Mode,
-					"LABELS": formatLabelsShort(v.Labels), "CLIENTS": fmt.Sprintf("%d", len(v.Clients)), "CREATED": v.CreatedAt.Format(timeFmt),
+					"LABELS": formatLabelsShort(v.Labels), "CLIENTS": fmt.Sprintf("%d", len(v.Exports)), "CREATED": v.CreatedAt.Format(timeFmt),
 				})
 			}
 			tw.flush()
@@ -44,7 +44,7 @@ func listVolumes(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy str
 			tw.writeRow(map[string]string{
 				"NAME": v.Name, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
 				"USED%":   fmt.Sprintf("%.0f%%", usedPct(v.UsedBytes, v.SizeBytes)),
-				"CLIENTS": fmt.Sprintf("%d", v.Clients), "CREATED": v.CreatedAt.Format(timeFmt),
+				"CLIENTS": fmt.Sprintf("%d", v.Exports), "CREATED": v.CreatedAt.Format(timeFmt),
 			})
 		}
 		tw.flush()
@@ -71,10 +71,10 @@ func volumeGet(ctx context.Context, cmd *cli.Command) error {
 		fmt.Printf("GID:          %d\n", resp.GID)
 		fmt.Printf("Mode:         %s\n", resp.Mode)
 		printLabels("Labels:", resp.Labels, 14)
-		if len(resp.Clients) == 0 {
-			fmt.Printf("Clients:      none\n")
+		if len(resp.Exports) == 0 {
+			fmt.Printf("Exports:      none\n")
 		} else {
-			fmt.Printf("Clients:      %s\n", strings.Join(resp.Clients, ", "))
+			fmt.Printf("Exports:      %s\n", formatExports(resp.Exports))
 		}
 		fmt.Printf("Created:      %s\n", resp.CreatedAt.Format(timeFmt))
 		fmt.Printf("Updated:      %s\n", resp.UpdatedAt.Format(timeFmt))

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -28,7 +28,7 @@ Token resolves to tenant via `AGENT_TENANTS`. All `/v1/*` endpoints require auth
 
 ## Labels
 
-Volumes, snapshots, clones, and tasks support user-defined labels (`map[string]string`). Labels are optional on create requests and returned in detail responses.
+Volumes, snapshots, clones, tasks, and NFS exports support user-defined labels (`map[string]string`). Labels are optional on create requests and returned in detail responses.
 
 | Constraint | Rule |
 |---|---|
@@ -123,7 +123,7 @@ Returns a summary list. Supports pagination (`?after=&limit=`), label filtering 
 }
 ```
 
-With `?detail=true`, each volume includes the full detail fields (same as `GET /v1/volumes/:name`): `path`, `quota_bytes`, `compression`, `nocow`, `uid`, `gid`, `mode`, `labels`, `clients` (as array), `updated_at`, `last_attach_at`.
+With `?detail=true`, each volume includes the full detail fields (same as `GET /v1/volumes/:name`): `path`, `quota_bytes`, `compression`, `nocow`, `uid`, `gid`, `mode`, `labels`, `clients` (as array of `{name, client, labels, created_at}`), `updated_at`, `last_attach_at`.
 
 ### GET /v1/volumes/:name
 
@@ -140,7 +140,14 @@ With `?detail=true`, each volume includes the full detail fields (same as `GET /
   "gid": 1000,
   "mode": "0750",
   "labels": {"env": "prod", "team": "backend"},
-  "clients": ["10.1.0.50"],
+  "clients": [
+    {
+      "name": "vol-1",
+      "client": "10.1.0.50",
+      "labels": {"created-by": "k8s", "kubernetes.pvc.id": "vol-1", "kubernetes.pvc.storageclass": "btrfs-nfs", "kubernetes.node.name": "worker-1"},
+      "created_at": "2025-01-15T11:00:00Z"
+    }
+  ],
   "created_at": "2025-01-15T10:30:00Z",
   "updated_at": "2025-01-15T10:30:00Z",
   "last_attach_at": "2025-01-15T11:00:00Z"
@@ -169,36 +176,60 @@ All fields optional. `size_bytes` must be larger than current. `labels` replaces
 
 ## NFS Exports
 
+Exports are reference-counted per client IP. Each export carries labels identifying who created it. The NFS kernel export is only created on the first reference for an IP and removed when the last reference is gone.
+
 ### POST /v1/volumes/:name/export
 
 ```json
 {
-  "client": "10.1.0.50"
+  "client": "10.1.0.50",
+  "labels": {"created-by": "k8s", "kubernetes.pvc.id": "vol-1"}
 }
 ```
 
-204 No Content. Reconciler retries on failure.
+204 No Content. `labels` is optional. Duplicate entries (same IP + labels) are idempotent. Reconciler retries on failure.
 
 ### DELETE /v1/volumes/:name/export
 
 ```json
 {
-  "client": "10.1.0.50"
+  "client": "10.1.0.50",
+  "labels": {"kubernetes.pvc.id": "vol-1"}
 }
 ```
 
-204 No Content.
+204 No Content. With `labels`: removes only the matching entry (subset match). Without `labels`: removes all entries for that IP.
 
 ### GET /v1/exports
+
+Returns exports from metadata. Supports pagination (`?after=&limit=`) and `?detail=true`.
 
 ```json
 {
   "exports": [
     {
-      "path": "/srv/csi/default/vol-1",
-      "client": "10.1.0.50"
+      "name": "vol-1",
+      "client": "10.1.0.50",
+      "created_at": "2025-01-15T11:00:00Z"
     }
-  ]
+  ],
+  "total": 1
+}
+```
+
+With `?detail=true`, each export includes `labels`:
+
+```json
+{
+  "exports": [
+    {
+      "name": "vol-1",
+      "client": "10.1.0.50",
+      "labels": {"created-by": "k8s", "kubernetes.pvc.id": "vol-1", "kubernetes.pvc.storageclass": "btrfs-nfs"},
+      "created_at": "2025-01-15T11:00:00Z"
+    }
+  ],
+  "total": 1
 }
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -134,9 +134,11 @@ Default mode: `2770` (configurable via `AGENT_DEFAULT_DATA_MODE`). Applied at cr
 
 Export options: `rw,nohide,crossmnt,no_root_squash,no_subtree_check,fsid=<crc32>`
 
-**Lifecycle:** ControllerPublish → `exportfs` add → NodeStage (NFS mount) → NodePublish (bind mount) → reverse on detach.
+**Lifecycle:** ControllerPublish → agent CreateVolumeExport (with labels: `created-by`, `kubernetes.pvc.id`, `kubernetes.pvc.storageclass`, `kubernetes.node.name`) → `exportfs` add → NodeStage (NFS mount) → NodePublish (bind mount) → reverse on detach.
 
-**Reconciler** (every `AGENT_NFS_RECONCILE_INTERVAL`):
+Exports are reference-counted per client IP. The NFS kernel export is only created on the first reference for an IP and removed when the last reference is gone. Each export carries labels identifying who created it (`created-by` is immutable).
+
+**Reconciler** (every `AGENT_NFS_RECONCILE_INTERVAL`, default 60s):
 - Removes orphaned exports (path deleted)
 - Re-adds missing exports from metadata (agent restart recovery)
 


### PR DESCRIPTION
NFS exports were tracked as plain IP strings, so the first ControllerUnpublish for a node would remove the export for all PVCs on that node. This PR replaces the simple IP list with labeled, reference-counted export metadata so the kernel export is only removed when the last reference for an IP is gone. The `created-by` label is now immutable across all resource types to prevent accidental identity changes.

## Summary
- NFS exports are reference-counted per client IP with labels (`ExportMetadata`), preventing premature unexport when multiple PVCs share a volume on the same node
- Each export carries labels: `created-by`, `kubernetes.pvc.id`, `kubernetes.pvc.storageclass`, `kubernetes.node.name` and a `created_at` timestamp
- The `created-by` label is immutable (required on create, rejected on update, configurable via `AGENT_IMMUTABLE_LABELS`)
- Export list reads from metadata with `?detail=true` and `?label=` filter support, matching the Volume/Snapshot API pattern
- CLI: `export add/rm` support `--label`, `export ls` supports `--sort`, `--asc`, `--label`, `-o wide`
- Migration: old `[]string` client format auto-converts to `[]ExportMetadata` with `created-by=migrated`
- NFS reconciler default interval changed from 10m to 60s
- Label key constants in `config.go` for all `kubernetes.*` export labels