### PR TITLE
Client identity injection, TLS/timeout env config, controller client caching

### DIFF
--- a/agent/api/v1/client.go
+++ b/agent/api/v1/client.go
@@ -3,13 +3,18 @@ package v1
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"time"
+
+	env "github.com/caarlos0/env/v11"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 )
 
 func generateLabelQuery(labels []string) url.Values {
@@ -37,23 +42,64 @@ func (o ListOpts) query() url.Values {
 	return q
 }
 
-type Client struct {
-	url   string
-	token string
-	http  *http.Client
+const DefaultTimeout = 30 * time.Second
+
+type ClientConfig struct {
+	Timeout       time.Duration `env:"AGENT_HTTP_CLIENT_TIMEOUT" envDefault:"30s"`
+	TLSSkipVerify bool          `env:"AGENT_HTTP_CLIENT_TLS_SKIP_VERIFY"`
+	Identity      string        `env:"AGENT_CSI_IDENTITY"`
 }
 
-func NewClient(url, token string) *Client {
+type Client struct {
+	url      string
+	token    string
+	http     *http.Client
+	identity string
+}
+
+// NewClient creates a client, parsing AGENT_HTTP_CLIENT_* and AGENT_CSI_IDENTITY env vars.
+// identity is the fallback when AGENT_CSI_IDENTITY is unset.
+func NewClient(url, token, identity string) *Client {
+	cfg, err := env.ParseAs[ClientConfig]()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: invalid client env config: %v, using defaults\n", err)
+		cfg = ClientConfig{Timeout: DefaultTimeout}
+	}
+	if cfg.Identity == "" {
+		cfg.Identity = identity
+	}
+	return newClient(url, token, cfg)
+}
+
+func newClient(url, token string, cfg ClientConfig) *Client {
+	hc := &http.Client{Timeout: cfg.Timeout}
+	if cfg.TLSSkipVerify {
+		hc.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	}
 	return &Client{
-		url:   url,
-		token: token,
-		http: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		url:      url,
+		token:    token,
+		http:     hc,
+		identity: cfg.Identity,
 	}
 }
 
+func (c *Client) Identity() string {
+	return c.identity
+}
+
+func (c *Client) ensureIdentity(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if _, ok := labels[config.LabelCreatedBy]; !ok {
+		labels[config.LabelCreatedBy] = c.Identity()
+	}
+	return labels
+}
+
 func (c *Client) CreateVolume(ctx context.Context, req VolumeCreateRequest) (*VolumeDetailResponse, error) {
+	req.Labels = c.ensureIdentity(req.Labels)
 	var resp VolumeDetailResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/volumes", req, &resp); err != nil {
 		if IsConflict(err) {
@@ -77,6 +123,7 @@ func (c *Client) UpdateVolume(ctx context.Context, name string, req VolumeUpdate
 }
 
 func (c *Client) CreateSnapshot(ctx context.Context, req SnapshotCreateRequest) (*SnapshotDetailResponse, error) {
+	req.Labels = c.ensureIdentity(req.Labels)
 	var resp SnapshotDetailResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/snapshots", req, &resp); err != nil {
 		return nil, err
@@ -89,6 +136,7 @@ func (c *Client) DeleteSnapshot(ctx context.Context, name string) error {
 }
 
 func (c *Client) CreateClone(ctx context.Context, req CloneCreateRequest) (*VolumeDetailResponse, error) {
+	req.Labels = c.ensureIdentity(req.Labels)
 	var resp VolumeDetailResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/clones", req, &resp); err != nil {
 		if IsConflict(err) {
@@ -100,6 +148,7 @@ func (c *Client) CreateClone(ctx context.Context, req CloneCreateRequest) (*Volu
 }
 
 func (c *Client) CloneVolume(ctx context.Context, req VolumeCloneRequest) (*VolumeDetailResponse, error) {
+	req.Labels = c.ensureIdentity(req.Labels)
 	var resp VolumeDetailResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/volumes/clone", req, &resp); err != nil {
 		if IsConflict(err) {
@@ -111,7 +160,7 @@ func (c *Client) CloneVolume(ctx context.Context, req VolumeCloneRequest) (*Volu
 }
 
 func (c *Client) CreateVolumeExport(ctx context.Context, name string, cl string, labels map[string]string) error {
-	return c.do(ctx, http.MethodPost, "/v1/volumes/"+name+"/export", VolumeExportCreateRequest{Client: cl, Labels: labels}, nil)
+	return c.do(ctx, http.MethodPost, "/v1/volumes/"+name+"/export", VolumeExportCreateRequest{Client: cl, Labels: c.ensureIdentity(labels)}, nil)
 }
 
 func (c *Client) DeleteVolumeExport(ctx context.Context, name string, cl string, labels map[string]string) error {
@@ -207,6 +256,7 @@ func (c *Client) ListVolumeExportsDetail(ctx context.Context, opts ListOpts) (*E
 }
 
 func (c *Client) CreateTask(ctx context.Context, taskType string, req TaskCreateRequest) (*TaskCreateResponse, error) {
+	req.Labels = c.ensureIdentity(req.Labels)
 	var resp TaskCreateResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/tasks/"+taskType, req, &resp); err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,9 @@ const (
 	MaxLabels      = 32
 	MaxUserLabels  = 8
 	LabelCreatedBy = "created-by"
+
+	IdentityCLI           = "cli"
+	IdentityK8sController = "k8s"
 )
 
 const (
@@ -22,9 +25,10 @@ const (
 	LabelCloneSourceName = "clone.source.name"
 )
 
-// SoftReservedLabelKeys are set automatically by the system (e.g. clone source tracking).
-// Reserved in the K8s controller (cannot be set via annotations) but allowed via agent API/CLI.
-var SoftReservedLabelKeys = []string{LabelCloneSourceType, LabelCloneSourceName}
+// SoftReservedLabelKeys are managed automatically (identity, clone source tracking).
+// Cannot be set via K8s annotations or CLI flags. Agent API consumers should use v1.Client
+// which handles these automatically.
+var SoftReservedLabelKeys = []string{LabelCreatedBy, LabelCloneSourceType, LabelCloneSourceName}
 
 const (
 	DataDir      = "data"

--- a/controller/agenttracker.go
+++ b/controller/agenttracker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	agentAPI "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/csiserver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Just a prive thinggy here
 type agentInfo struct {
 	scName   string
 	agentURL string
@@ -54,6 +54,15 @@ func (t *AgentTracker) Track(url string, client *agentAPI.Client) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.agents[url] = client
+}
+
+func (t *AgentTracker) Client(scName string) *agentAPI.Client {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if url, ok := t.scToURL[scName]; ok {
+		return t.agents[url]
+	}
+	return nil
 }
 
 func (t *AgentTracker) Agents() map[string]*agentAPI.Client {
@@ -149,7 +158,7 @@ func (t *AgentTracker) discoverFromStorageClasses(ctx context.Context) {
 		known[a.agentURL] = true
 
 		if _, exists := t.agents[a.agentURL]; !exists {
-			t.agents[a.agentURL] = agentAPI.NewClient(a.agentURL, a.token)
+			t.agents[a.agentURL] = agentAPI.NewClient(a.agentURL, a.token, config.IdentityK8sController)
 			log.Info().Str("agent", a.agentURL).Str("sc", a.scName).Msg("discovered agent from StorageClass")
 		}
 	}

--- a/controller/agenttracker_test.go
+++ b/controller/agenttracker_test.go
@@ -1,0 +1,151 @@
+package controller
+
+import (
+	"sync"
+	"testing"
+
+	agentAPI "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestTracker() *AgentTracker {
+	return &AgentTracker{
+		agents:  make(map[string]*agentAPI.Client),
+		scToURL: make(map[string]string),
+	}
+}
+
+func TestAgentTrackerClient(t *testing.T) {
+	t.Run("returns_cached_client", func(t *testing.T) {
+		tr := newTestTracker()
+		c := agentAPI.NewClient("http://agent:8080", "tok", config.IdentityK8sController)
+		tr.agents["http://agent:8080"] = c
+		tr.scToURL["my-sc"] = "http://agent:8080"
+
+		got := tr.Client("my-sc")
+		assert.Same(t, c, got)
+	})
+
+	t.Run("returns_nil_unknown_sc", func(t *testing.T) {
+		tr := newTestTracker()
+		assert.Nil(t, tr.Client("unknown"))
+	})
+
+	t.Run("returns_nil_sc_without_agent", func(t *testing.T) {
+		tr := newTestTracker()
+		tr.scToURL["orphan-sc"] = "http://gone:8080"
+
+		assert.Nil(t, tr.Client("orphan-sc"))
+	})
+}
+
+func TestAgentTrackerAgentURL(t *testing.T) {
+	t.Run("known", func(t *testing.T) {
+		tr := newTestTracker()
+		tr.scToURL["my-sc"] = "http://agent:8080"
+
+		url, err := tr.AgentURL("my-sc")
+		require.NoError(t, err)
+		assert.Equal(t, "http://agent:8080", url)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		tr := newTestTracker()
+		_, err := tr.AgentURL("missing")
+		require.Error(t, err)
+	})
+}
+
+func TestAgentTrackerTrack(t *testing.T) {
+	tr := newTestTracker()
+	c := agentAPI.NewClient("http://agent:8080", "tok", config.IdentityK8sController)
+	tr.Track("http://agent:8080", c)
+
+	tr.mu.RLock()
+	got := tr.agents["http://agent:8080"]
+	tr.mu.RUnlock()
+	assert.Same(t, c, got)
+}
+
+func TestAgentTrackerAgents(t *testing.T) {
+	tr := newTestTracker()
+	c1 := agentAPI.NewClient("http://a1:8080", "tok", config.IdentityK8sController)
+	c2 := agentAPI.NewClient("http://a2:8080", "tok", config.IdentityK8sController)
+	tr.agents["http://a1:8080"] = c1
+	tr.agents["http://a2:8080"] = c2
+	tr.scToURL["sc-1"] = "http://a1:8080"
+	tr.scToURL["sc-2"] = "http://a2:8080"
+
+	agents := tr.Agents()
+	assert.Len(t, agents, 2)
+	assert.Same(t, c1, agents["sc-1"])
+	assert.Same(t, c2, agents["sc-2"])
+}
+
+func TestAgentTrackerConcurrent(t *testing.T) {
+	tr := newTestTracker()
+	c := agentAPI.NewClient("http://agent:8080", "tok", config.IdentityK8sController)
+	tr.agents["http://agent:8080"] = c
+	tr.scToURL["my-sc"] = "http://agent:8080"
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			tr.Client("my-sc")
+		}()
+		go func() {
+			defer wg.Done()
+			tr.AgentURL("my-sc")
+		}()
+		go func() {
+			defer wg.Done()
+			tr.Agents()
+		}()
+		go func() {
+			defer wg.Done()
+			tr.Track("http://agent:8080", c)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestAgentClientFromStorageClass(t *testing.T) {
+	t.Run("uses_cached_client", func(t *testing.T) {
+		tr := newTestTracker()
+		c := agentAPI.NewClient("http://agent:8080", "tok", config.IdentityK8sController)
+		tr.agents["http://agent:8080"] = c
+		tr.scToURL["my-sc"] = "http://agent:8080"
+
+		got, err := agentClientFromStorageClass(tr, "my-sc", map[string]string{"agentToken": "tok"})
+		require.NoError(t, err)
+		assert.Same(t, c, got)
+	})
+
+	t.Run("falls_back_to_secrets", func(t *testing.T) {
+		tr := newTestTracker()
+		tr.scToURL["my-sc"] = "http://agent:8080"
+		// no cached client in tr.agents
+
+		got, err := agentClientFromStorageClass(tr, "my-sc", map[string]string{"agentToken": "tok"})
+		require.NoError(t, err)
+		assert.NotNil(t, got)
+	})
+
+	t.Run("unknown_sc", func(t *testing.T) {
+		tr := newTestTracker()
+		_, err := agentClientFromStorageClass(tr, "missing", map[string]string{"agentToken": "tok"})
+		require.Error(t, err)
+	})
+
+	t.Run("missing_token", func(t *testing.T) {
+		tr := newTestTracker()
+		tr.scToURL["my-sc"] = "http://agent:8080"
+
+		_, err := agentClientFromStorageClass(tr, "my-sc", map[string]string{})
+		require.Error(t, err)
+	})
+}

--- a/controller/agenttracker_test.go
+++ b/controller/agenttracker_test.go
@@ -99,7 +99,7 @@ func TestAgentTrackerConcurrent(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			tr.AgentURL("my-sc")
+			_, _ = tr.AgentURL("my-sc")
 		}()
 		go func() {
 			defer wg.Done()

--- a/controller/config.go
+++ b/controller/config.go
@@ -3,7 +3,6 @@ package controller
 import "github.com/erikmagkekse/btrfs-nfs-csi/csiserver"
 
 const (
-	controllerIdentity = "k8s"
 	paramAgentURL      = "agentURL"
 	secretAgentToken   = "agentToken"
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -3,8 +3,8 @@ package controller
 import "github.com/erikmagkekse/btrfs-nfs-csi/csiserver"
 
 const (
-	paramAgentURL      = "agentURL"
-	secretAgentToken   = "agentToken"
+	paramAgentURL    = "agentURL"
+	secretAgentToken = "agentToken"
 
 	// Volume labels (set on agent volumes from PVC metadata)
 	labelPVCName         = "kubernetes.pvc.name"

--- a/controller/publish.go
+++ b/controller/publish.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	agentAPI "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
-	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/csiserver"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
@@ -65,7 +64,6 @@ func (s *Server) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	start := time.Now()
 	vaName := fmt.Sprintf("csi-%x", sha256.Sum256([]byte(req.VolumeId+csiserver.DriverName+nodeHostname)))
 	exportLabels := map[string]string{
-		config.LabelCreatedBy:     controllerIdentity,
 		labelNodeName:             nodeHostname,
 		labelPVName:               name,
 		labelPVStorageClass:       sc,

--- a/controller/pvc.go
+++ b/controller/pvc.go
@@ -112,10 +112,9 @@ func (s *Server) resolveVolumeParams(ctx context.Context, params map[string]stri
 	scName := ptr.Deref(pvc.Spec.StorageClassName, "")
 	vp.StorageClass = scName
 	vp.Labels = map[string]string{
-		labelPVCName:          pvcName,
-		labelPVCNamespace:     pvcNamespace,
-		labelPVCStorageClass:  scName,
-		config.LabelCreatedBy: controllerIdentity,
+		labelPVCName:         pvcName,
+		labelPVCNamespace:    pvcNamespace,
+		labelPVCStorageClass: scName,
 	}
 	for k, v := range envDefaultLabels {
 		if _, exists := vp.Labels[k]; !exists {
@@ -243,9 +242,8 @@ func (s *Server) pvcFromVolumeHandle(ctx context.Context, volumeID string) (*cor
 
 func (s *Server) resolveSnapshotLabels(ctx context.Context, params map[string]string, sourceVolumeID, sc, pvName string) map[string]string {
 	labels := map[string]string{
-		config.LabelCreatedBy: controllerIdentity,
-		labelPVName:           pvName,
-		labelPVStorageClass:   sc,
+		labelPVName:         pvName,
+		labelPVStorageClass: sc,
 	}
 	for k, v := range envDefaultLabels {
 		if _, exists := labels[k]; !exists {

--- a/controller/pvc_test.go
+++ b/controller/pvc_test.go
@@ -197,7 +197,6 @@ func TestResolveVolumeParams(t *testing.T) {
 		assert.Equal(t, "my-pvc", vp.Labels["kubernetes.pvc.name"])
 		assert.Equal(t, "default", vp.Labels["kubernetes.pvc.namespace"])
 		assert.Equal(t, "my-sc", vp.Labels["kubernetes.pvc.storageclassname"])
-		assert.Equal(t, "k8s", vp.Labels["created-by"])
 	})
 
 	t.Run("no_pvc_info", func(t *testing.T) {

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	agentAPI "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,13 +41,21 @@ func agentClientFromSecrets(agentURL string, secrets map[string]string) (*agentA
 	if token == "" {
 		return nil, status.Error(codes.InvalidArgument, "missing agentToken secret")
 	}
-	return agentAPI.NewClient(agentURL, token), nil
+	return agentAPI.NewClient(agentURL, token, config.IdentityK8sController), nil
 }
 
 func agentClientFromStorageClass(tracker *AgentTracker, scName string, secrets map[string]string) (*agentAPI.Client, error) {
+	if c := tracker.Client(scName); c != nil {
+		return c, nil
+	}
 	agentURL, err := tracker.AgentURL(scName)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "resolve agent for storage class %q: %v", scName, err)
 	}
-	return agentClientFromSecrets(agentURL, secrets)
+	c, err := agentClientFromSecrets(agentURL, secrets)
+	if err != nil {
+		return nil, err
+	}
+	tracker.Track(agentURL, c)
+	return c, nil
 }

--- a/ctl/ctl.go
+++ b/ctl/ctl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/urfave/cli/v3"
@@ -15,9 +16,8 @@ var (
 )
 
 func showStats(ctx context.Context, cmd *cli.Command) error {
-	c := clientFrom(cmd)
 	return runWatch(ctx, cmd, func() error {
-		resp, err := c.Stats(ctx)
+		resp, err := apiClient.Stats(ctx)
 		if err != nil {
 			return err
 		}
@@ -75,7 +75,7 @@ func showStats(ctx context.Context, cmd *cli.Command) error {
 }
 
 func showHealth(ctx context.Context, cmd *cli.Command) error {
-	resp, err := clientFrom(cmd).Healthz(ctx)
+	resp, err := apiClient.Healthz(ctx)
 	if err != nil {
 		return err
 	}
@@ -89,8 +89,14 @@ func Run(args []string) {
 	app := &cli.Command{
 		Name:  "btrfs-nfs-csi",
 		Usage: "btrfs-nfs-csi agent CLI",
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			initClient(cmd)
+			cmdStart = time.Now()
+			return ctx, nil
+		},
 		After: func(ctx context.Context, cmd *cli.Command) error {
-			if !isJSON(cmd) && !cmd.IsSet("watch") {
+			if !isJSON(cmd) && !cmd.IsSet("watch") && cmd.String("columns") == "" {
+				printTiming()
 				fmt.Println()
 			}
 			return nil
@@ -110,6 +116,11 @@ func Run(args []string) {
 				Usage: "show CLI version",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					fmt.Printf("btrfs-nfs-csi %s (%s)\n", Version, Commit)
+					if cmd.Root().String("agent-url") != "" && cmd.Root().String("agent-token") != "" {
+						if h, err := apiClient.Healthz(ctx); err == nil {
+							fmt.Printf("agent         %s (%s)\n", h.Version, h.Commit)
+						}
+					}
 					return nil
 				},
 			},

--- a/ctl/export.go
+++ b/ctl/export.go
@@ -14,7 +14,7 @@ func exportAdd(ctx context.Context, cmd *cli.Command) error {
 	}
 	vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
 	labels := parseLabelsFlag(cmd)
-	if err := clientFrom(cmd).CreateVolumeExport(ctx, vol, client, labels); err != nil {
+	if err := apiClient.CreateVolumeExport(ctx, vol, client, labels); err != nil {
 		return wrapErr(err, "volume", vol)
 	}
 	if !isJSON(cmd) {
@@ -29,7 +29,7 @@ func exportRemove(ctx context.Context, cmd *cli.Command) error {
 	}
 	vol, client := cmd.Args().Get(0), cmd.Args().Get(1)
 	labels := parseLabelsFlag(cmd)
-	if err := clientFrom(cmd).DeleteVolumeExport(ctx, vol, client, labels); err != nil {
+	if err := apiClient.DeleteVolumeExport(ctx, vol, client, labels); err != nil {
 		return wrapErr(err, "volume", vol)
 	}
 	if !isJSON(cmd) {
@@ -38,9 +38,9 @@ func exportRemove(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func listExports(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy string, rev bool, opts v1.ListOpts) error {
+func listExports(ctx context.Context, cmd *cli.Command, sortBy string, rev bool, opts v1.ListOpts) error {
 	if isWide(cmd) {
-		resp, err := c.ListVolumeExportsDetail(ctx, opts)
+		resp, err := apiClient.ListVolumeExportsDetail(ctx, opts)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func listExports(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy str
 			tw.flush()
 		})
 	}
-	resp, err := c.ListVolumeExports(ctx, opts)
+	resp, err := apiClient.ListVolumeExports(ctx, opts)
 	if err != nil {
 		return err
 	}

--- a/ctl/model.go
+++ b/ctl/model.go
@@ -19,7 +19,6 @@ func volumeCmd() *cli.Command {
 				Usage:   "list all volumes",
 				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					c := clientFrom(cmd)
 					sortBy := cmd.String("sort")
 					if sortBy == "" {
 						sortBy = sortUsedPct
@@ -27,7 +26,7 @@ func volumeCmd() *cli.Command {
 					rev := !cmd.Bool("asc")
 					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
 					return runWatch(ctx, cmd, func() error {
-						return listVolumes(ctx, cmd, c, sortBy, rev, opts)
+						return listVolumes(ctx, cmd, sortBy, rev, opts)
 					})
 				},
 			},
@@ -92,7 +91,6 @@ func snapshotCmd() *cli.Command {
 				ArgsUsage: "[volume]",
 				Flags:     []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					c := clientFrom(cmd)
 					sortBy := cmd.String("sort")
 					if sortBy == "" {
 						sortBy = sortCreated
@@ -101,7 +99,7 @@ func snapshotCmd() *cli.Command {
 					vol := cmd.Args().First()
 					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
 					return runWatch(ctx, cmd, func() error {
-						return listSnapshots(ctx, cmd, c, vol, sortBy, rev, opts)
+						return listSnapshots(ctx, cmd, vol, sortBy, rev, opts)
 					})
 				},
 			},
@@ -167,12 +165,11 @@ func exportCmd() *cli.Command {
 				Usage:   "list active NFS exports",
 				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					c := clientFrom(cmd)
 					sortBy := cmd.String("sort")
 					rev := !cmd.Bool("asc")
 					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
 					return runWatch(ctx, cmd, func() error {
-						return listExports(ctx, cmd, c, sortBy, rev, opts)
+						return listExports(ctx, cmd, sortBy, rev, opts)
 					})
 				},
 			},
@@ -197,11 +194,10 @@ func taskCmd() *cli.Command {
 					watchFlag(),
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					c := clientFrom(cmd)
 					taskType := cmd.String("type")
 					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
 					return runWatch(ctx, cmd, func() error {
-						return listTasks(ctx, cmd, c, taskType, opts)
+						return listTasks(ctx, cmd, taskType, opts)
 					})
 				},
 			},

--- a/ctl/snapshot.go
+++ b/ctl/snapshot.go
@@ -12,14 +12,14 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func listSnapshots(ctx context.Context, cmd *cli.Command, c *v1.Client, vol, sortBy string, rev bool, opts v1.ListOpts) error {
+func listSnapshots(ctx context.Context, cmd *cli.Command, vol, sortBy string, rev bool, opts v1.ListOpts) error {
 	if isWide(cmd) {
 		var resp *v1.SnapshotDetailListResponse
 		var err error
 		if vol != "" {
-			resp, err = c.ListVolumeSnapshotsDetail(ctx, vol, opts)
+			resp, err = apiClient.ListVolumeSnapshotsDetail(ctx, vol, opts)
 		} else {
-			resp, err = c.ListSnapshotsDetail(ctx, opts)
+			resp, err = apiClient.ListSnapshotsDetail(ctx, opts)
 		}
 		if err != nil {
 			return err
@@ -41,9 +41,9 @@ func listSnapshots(ctx context.Context, cmd *cli.Command, c *v1.Client, vol, sor
 	var resp *v1.SnapshotListResponse
 	var err error
 	if vol != "" {
-		resp, err = c.ListVolumeSnapshots(ctx, vol, opts)
+		resp, err = apiClient.ListVolumeSnapshots(ctx, vol, opts)
 	} else {
-		resp, err = c.ListSnapshots(ctx, opts)
+		resp, err = apiClient.ListSnapshots(ctx, opts)
 	}
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func snapshotGet(ctx context.Context, cmd *cli.Command) error {
 	if name == "" {
 		return fmt.Errorf("snapshot name required")
 	}
-	resp, err := clientFrom(cmd).GetSnapshot(ctx, name)
+	resp, err := apiClient.GetSnapshot(ctx, name)
 	if err != nil {
 		return wrapErr(err, "snapshot", name)
 	}
@@ -88,7 +88,7 @@ func snapshotCreate(ctx context.Context, cmd *cli.Command) error {
 	if cmd.NArg() < 2 {
 		return fmt.Errorf("usage: snapshot create <volume> <name>")
 	}
-	resp, err := clientFrom(cmd).CreateSnapshot(ctx, v1.SnapshotCreateRequest{Volume: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: labelsWithDefault(cmd, config.LabelCreatedBy, cliIdentity())})
+	resp, err := apiClient.CreateSnapshot(ctx, v1.SnapshotCreateRequest{Volume: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
 	if err != nil {
 		return wrapErr(err, "snapshot", cmd.Args().Get(1))
 	}
@@ -102,20 +102,19 @@ func snapshotDelete(ctx context.Context, cmd *cli.Command) error {
 	}
 	force := os.Getenv("BTRFS_NFS_CSI_FORCE") == "true"
 	confirmed := force || (cmd.Bool("confirm") && cmd.Bool("yes"))
-	c := clientFrom(cmd)
 	var protected []string
 	for _, name := range names {
 		if !confirmed {
-			snap, err := c.GetSnapshot(ctx, name)
+			snap, err := apiClient.GetSnapshot(ctx, name)
 			if err != nil {
 				return wrapErr(err, "snapshot", name)
 			}
-			if snap.Labels[config.LabelCreatedBy] != cliIdentity() {
+			if snap.Labels[config.LabelCreatedBy] != apiClient.Identity() {
 				protected = append(protected, name)
 				continue
 			}
 		}
-		if err := c.DeleteSnapshot(ctx, name); err != nil {
+		if err := apiClient.DeleteSnapshot(ctx, name); err != nil {
 			return wrapErr(err, "snapshot", name)
 		}
 		if !isJSON(cmd) {
@@ -132,7 +131,7 @@ func snapshotClone(ctx context.Context, cmd *cli.Command) error {
 	if cmd.NArg() < 2 {
 		return fmt.Errorf("usage: snapshot clone <snapshot> <name>")
 	}
-	resp, err := clientFrom(cmd).CreateClone(ctx, v1.CloneCreateRequest{Snapshot: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
+	resp, err := apiClient.CreateClone(ctx, v1.CloneCreateRequest{Snapshot: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
 	if err != nil {
 		return wrapErr(err, "clone", cmd.Args().Get(1))
 	}

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -10,7 +10,6 @@ import (
 
 	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/btrfs"
-	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
 	"github.com/urfave/cli/v3"
 )
@@ -103,9 +102,9 @@ func taskTimeout(t string) string {
 	return "-"
 }
 
-func listTasks(ctx context.Context, cmd *cli.Command, c *v1.Client, taskType string, opts v1.ListOpts) error {
+func listTasks(ctx context.Context, cmd *cli.Command, taskType string, opts v1.ListOpts) error {
 	if isWide(cmd) {
-		resp, err := c.ListTasksDetail(ctx, taskType, opts)
+		resp, err := apiClient.ListTasksDetail(ctx, taskType, opts)
 		if err != nil {
 			return err
 		}
@@ -133,7 +132,7 @@ func listTasks(ctx context.Context, cmd *cli.Command, c *v1.Client, taskType str
 			tw.flush()
 		})
 	}
-	resp, err := c.ListTasks(ctx, taskType, opts)
+	resp, err := apiClient.ListTasks(ctx, taskType, opts)
 	if err != nil {
 		return err
 	}
@@ -159,7 +158,7 @@ func taskGet(ctx context.Context, cmd *cli.Command) error {
 	if id == "" {
 		return fmt.Errorf("task ID required")
 	}
-	resp, err := clientFrom(cmd).GetTask(ctx, id)
+	resp, err := apiClient.GetTask(ctx, id)
 	if err != nil {
 		return wrapErr(err, "task", id)
 	}
@@ -201,7 +200,7 @@ func taskCancel(ctx context.Context, cmd *cli.Command) error {
 	if id == "" {
 		return fmt.Errorf("task ID required")
 	}
-	if err := clientFrom(cmd).CancelTask(ctx, id); err != nil {
+	if err := apiClient.CancelTask(ctx, id); err != nil {
 		return wrapErr(err, "task", id)
 	}
 	if !isJSON(cmd) {
@@ -211,12 +210,11 @@ func taskCancel(ctx context.Context, cmd *cli.Command) error {
 }
 
 func taskCreateScrub(ctx context.Context, cmd *cli.Command) error {
-	c := clientFrom(cmd)
-	req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, config.LabelCreatedBy, cliIdentity())}
+	req := v1.TaskCreateRequest{Labels: parseLabelsFlag(cmd)}
 	if t := cmd.Duration("timeout"); t > 0 {
 		req.Timeout = t.String()
 	}
-	resp, err := c.CreateTask(ctx, v1.TaskTypeScrub, req)
+	resp, err := apiClient.CreateTask(ctx, v1.TaskTypeScrub, req)
 	if err != nil {
 		return err
 	}
@@ -226,19 +224,18 @@ func taskCreateScrub(ctx context.Context, cmd *cli.Command) error {
 		})
 	}
 	fmt.Printf("scrub started (task %s)\n", resp.TaskID)
-	return waitForTask(ctx, c, resp.TaskID)
+	return waitForTask(ctx, resp.TaskID)
 }
 
 func taskCreateTest(ctx context.Context, cmd *cli.Command) error {
-	c := clientFrom(cmd)
-	req := v1.TaskCreateRequest{Labels: labelsWithDefault(cmd, config.LabelCreatedBy, cliIdentity())}
+	req := v1.TaskCreateRequest{Labels: parseLabelsFlag(cmd)}
 	if s := cmd.Duration("sleep"); s > 0 {
 		req.Opts = map[string]string{"sleep": s.String()}
 	}
 	if t := cmd.Duration("timeout"); t > 0 {
 		req.Timeout = t.String()
 	}
-	resp, err := c.CreateTask(ctx, v1.TaskTypeTest, req)
+	resp, err := apiClient.CreateTask(ctx, v1.TaskTypeTest, req)
 	if err != nil {
 		return err
 	}
@@ -248,10 +245,10 @@ func taskCreateTest(ctx context.Context, cmd *cli.Command) error {
 		})
 	}
 	fmt.Printf("test task started (task %s)\n", resp.TaskID)
-	return waitForTask(ctx, c, resp.TaskID)
+	return waitForTask(ctx, resp.TaskID)
 }
 
-func waitForTask(ctx context.Context, c *v1.Client, id string) error {
+func waitForTask(ctx context.Context, id string) error {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -259,7 +256,7 @@ func waitForTask(ctx context.Context, c *v1.Client, id string) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			t, err := c.GetTask(ctx, id)
+			t, err := apiClient.GetTask(ctx, id)
 			if err != nil {
 				return wrapErr(err, "task", id)
 			}

--- a/ctl/utils.go
+++ b/ctl/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"slices"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -132,25 +133,11 @@ func parseLabelsFlag(cmd *cli.Command) map[string]string {
 	labels := make(map[string]string, len(raw))
 	for _, pair := range raw {
 		k, v, _ := strings.Cut(pair, "=")
+		if slices.Contains(config.SoftReservedLabelKeys, k) {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: label %q is reserved, skipping\n", k)
+			continue
+		}
 		labels[k] = v
-	}
-	return labels
-}
-
-func cliIdentity() string {
-	if id := os.Getenv("BTRFS_NFS_CSI_IDENTITY"); id != "" {
-		return id
-	}
-	return "cli"
-}
-
-func labelsWithDefault(cmd *cli.Command, key, value string) map[string]string {
-	labels := parseLabelsFlag(cmd)
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	if _, ok := labels[key]; !ok {
-		labels[key] = value
 	}
 	return labels
 }
@@ -201,10 +188,11 @@ func runWatch(ctx context.Context, cmd *cli.Command, fn func() error) error {
 	defer ticker.Stop()
 	for {
 		fmt.Print("\033[H")
+		start := time.Now()
 		if err := fn(); err != nil {
 			return err
 		}
-		fmt.Printf("\nupdated %s, refresh %s\n", time.Now().Format("15:04:05"), interval)
+		fmt.Fprintf(os.Stderr, "\ntook %s, updated %s, refresh %s\n", fmtDuration(time.Since(start)), time.Now().Format("15:04:05"), interval)
 		fmt.Print("\033[J")
 		select {
 		case <-ctx.Done():
@@ -400,8 +388,17 @@ func sortExportsDetailList(exports []v1.ExportDetailResponse, field string, reve
 	})
 }
 
-func clientFrom(cmd *cli.Command) *v1.Client {
-	return v1.NewClient(cmd.Root().String("agent-url"), cmd.Root().String("agent-token"))
+var (
+	apiClient *v1.Client
+	cmdStart  time.Time
+)
+
+func initClient(cmd *cli.Command) {
+	apiClient = v1.NewClient(cmd.Root().String("agent-url"), cmd.Root().String("agent-token"), config.IdentityCLI)
+}
+
+func printTiming() {
+	fmt.Fprintf(os.Stderr, "took %s, %s\n", fmtDuration(time.Since(cmdStart)), time.Now().Format("2006-01-02 15:04:05"))
 }
 
 func outputFormat(cmd *cli.Command) string {

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -12,9 +12,9 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func listVolumes(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy string, rev bool, opts v1.ListOpts) error {
+func listVolumes(ctx context.Context, cmd *cli.Command, sortBy string, rev bool, opts v1.ListOpts) error {
 	if isWide(cmd) {
-		resp, err := c.ListVolumesDetail(ctx, opts)
+		resp, err := apiClient.ListVolumesDetail(ctx, opts)
 		if err != nil {
 			return err
 		}
@@ -33,7 +33,7 @@ func listVolumes(ctx context.Context, cmd *cli.Command, c *v1.Client, sortBy str
 			tw.flush()
 		})
 	}
-	resp, err := c.ListVolumes(ctx, opts)
+	resp, err := apiClient.ListVolumes(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func volumeGet(ctx context.Context, cmd *cli.Command) error {
 	if name == "" {
 		return fmt.Errorf("volume name required")
 	}
-	resp, err := clientFrom(cmd).GetVolume(ctx, name)
+	resp, err := apiClient.GetVolume(ctx, name)
 	if err != nil {
 		return wrapErr(err, "volume", name)
 	}
@@ -102,9 +102,9 @@ func volumeCreate(ctx context.Context, cmd *cli.Command) error {
 		UID:         int(cmd.Int("uid")),
 		GID:         int(cmd.Int("gid")),
 		Mode:        cmd.String("mode"),
-		Labels:      labelsWithDefault(cmd, config.LabelCreatedBy, cliIdentity()),
+		Labels:      parseLabelsFlag(cmd),
 	}
-	resp, err := clientFrom(cmd).CreateVolume(ctx, req)
+	resp, err := apiClient.CreateVolume(ctx, req)
 	if err != nil {
 		return wrapErr(err, "volume", req.Name)
 	}
@@ -120,20 +120,19 @@ func volumeDelete(ctx context.Context, cmd *cli.Command) error {
 	}
 	force := os.Getenv("BTRFS_NFS_CSI_FORCE") == "true"
 	confirmed := force || (cmd.Bool("confirm") && cmd.Bool("yes"))
-	c := clientFrom(cmd)
 	var protected []string
 	for _, name := range names {
 		if !confirmed {
-			vol, err := c.GetVolume(ctx, name)
+			vol, err := apiClient.GetVolume(ctx, name)
 			if err != nil {
 				return wrapErr(err, "volume", name)
 			}
-			if vol.Labels[config.LabelCreatedBy] != cliIdentity() {
+			if vol.Labels[config.LabelCreatedBy] != apiClient.Identity() {
 				protected = append(protected, name)
 				continue
 			}
 		}
-		if err := c.DeleteVolume(ctx, name); err != nil {
+		if err := apiClient.DeleteVolume(ctx, name); err != nil {
 			return wrapErr(err, "volume", name)
 		}
 		if !isJSON(cmd) {
@@ -150,7 +149,6 @@ func volumeExpand(ctx context.Context, cmd *cli.Command) error {
 	if cmd.NArg() < 2 {
 		return fmt.Errorf("usage: volume expand <name> <size|+size>")
 	}
-	c := clientFrom(cmd)
 	name := cmd.Args().Get(0)
 	sizeArg := cmd.Args().Get(1)
 	var size uint64
@@ -159,7 +157,7 @@ func volumeExpand(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		vol, err := c.GetVolume(ctx, name)
+		vol, err := apiClient.GetVolume(ctx, name)
 		if err != nil {
 			return wrapErr(err, "volume", name)
 		}
@@ -178,7 +176,7 @@ func volumeExpand(ctx context.Context, cmd *cli.Command) error {
 			return err
 		}
 	}
-	resp, err := c.UpdateVolume(ctx, name, v1.VolumeUpdateRequest{SizeBytes: &size})
+	resp, err := apiClient.UpdateVolume(ctx, name, v1.VolumeUpdateRequest{SizeBytes: &size})
 	if err != nil {
 		return wrapErr(err, "volume", name)
 	}
@@ -191,7 +189,7 @@ func volumeClone(ctx context.Context, cmd *cli.Command) error {
 	if cmd.NArg() < 2 {
 		return fmt.Errorf("usage: volume clone <source> <name>")
 	}
-	resp, err := clientFrom(cmd).CloneVolume(ctx, v1.VolumeCloneRequest{Source: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
+	resp, err := apiClient.CloneVolume(ctx, v1.VolumeCloneRequest{Source: cmd.Args().Get(0), Name: cmd.Args().Get(1), Labels: parseLabelsFlag(cmd)})
 	if err != nil {
 		return wrapErr(err, "volume", cmd.Args().Get(1))
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,13 +29,22 @@
 | `AGENT_TASK_POLL_INTERVAL` | `5s` | Progress update interval for background tasks |
 | `LOG_LEVEL` | `info` | `trace`, `debug`, `info`, `warn`, `error` |
 
+## API Client Environment Variables
+
+Shared by CLI and controller (any `v1.Client` user).
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_CSI_IDENTITY` | `cli` (CLI), `k8s` (controller) | Caller identity for `created-by` label, injected automatically on every create |
+| `AGENT_HTTP_CLIENT_TIMEOUT` | `30s` | API request timeout (Go duration) |
+| `AGENT_HTTP_CLIENT_TLS_SKIP_VERIFY` | `false` | Skip TLS certificate verification |
+
 ## CLI Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
 | `AGENT_URL` | - | Agent API URL |
 | `AGENT_TOKEN` | - | Tenant token |
-| `BTRFS_NFS_CSI_IDENTITY` | `cli` | Caller identity for `created-by` label |
 | `BTRFS_NFS_CSI_FORCE` | `false` | Skip delete protection when `true` |
 
 Also configurable via `--agent-url` and `--agent-token` flags.
@@ -168,3 +177,5 @@ stringData:
 ## TLS
 
 Set `AGENT_TLS_CERT` + `AGENT_TLS_KEY` → agent listens HTTPS (min TLS 1.2). Use `https://` in `agentURL`.
+
+For self-signed certificates, set `AGENT_HTTP_CLIENT_TLS_SKIP_VERIFY=true`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -212,7 +212,8 @@ Description=btrfs scrub via CSI agent
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/default/btrfs-nfs-csi
-ExecStart=btrfs-nfs-csi task create scrub --label created-by=systemd-timer --wait
+Environment=AGENT_CSI_IDENTITY=systemd-timer
+ExecStart=btrfs-nfs-csi task create scrub --wait
 ```
 
 ```ini
@@ -288,7 +289,6 @@ btrfs-nfs-csi task get <id>
 btrfs-nfs-csi task cancel <id>
 btrfs-nfs-csi task create scrub
 btrfs-nfs-csi task create scrub -W           # wait for completion
-btrfs-nfs-csi task create scrub --label created-by=cron
 btrfs-nfs-csi task create test
 btrfs-nfs-csi task create test --sleep 10s -W
 btrfs-nfs-csi stats
@@ -312,8 +312,8 @@ btrfs-nfs-csi version
 
 **Size values:** Supports `Ki`, `Mi`, `Gi` (binary) and `K`, `M`, `G` (decimal). `volume expand` accepts relative sizes with `+`/`-` prefix.
 
-**Delete protection:** Volumes and snapshots with `created-by` != caller identity are protected. Only `--confirm --yes` or `BTRFS_NFS_CSI_FORCE=true` bypasses this. The caller identity defaults to `cli` and can be set via `BTRFS_NFS_CSI_IDENTITY`.
+**Delete protection:** Volumes and snapshots with `created-by` != caller identity are protected. Only `--confirm --yes` or `BTRFS_NFS_CSI_FORCE=true` bypasses this. The caller identity defaults to `cli` and can be set via `AGENT_CSI_IDENTITY`.
 
-**Default labels:** CLI create commands automatically add `created-by=<identity>` (default `cli`). `created-by` is a reserved label and cannot be overridden via PVC annotations.
+**Default labels:** Every create command automatically adds `created-by=<identity>` (default `cli`). The `created-by` label cannot be set via `--label` flag or PVC annotations.
 
 **Command aliases:** `volumes`/`vol`, `snapshots`/`snap`, `tasks`, `exports`. `list`/`ls` interchangeable.


### PR DESCRIPTION
This is almost release-ready. The core refactoring is complete, tested, and all existing tests pass including E2E. Some parts of the documentation are still missing.

## Summary
- Move `created-by` label injection from scattered call sites into `v1.Client.ensureIdentity()`, called automatically on every create operation
- Replace per-call `clientFrom(cmd)` with single `apiClient` initialized in CLI `Before` hook
- Add `ClientConfig` with `env.ParseAs` for `AGENT_HTTP_CLIENT_TIMEOUT`, `AGENT_HTTP_CLIENT_TLS_SKIP_VERIFY`, `AGENT_CSI_IDENTITY`
- Cache agent clients via `AgentTracker.Client()` to avoid per-request client/transport allocation in the controller
- Add identity constants `config.IdentityCLI` / `config.IdentityK8sController`
- Add `created-by` to `SoftReservedLabelKeys` (blocked in CLI and K8s annotations, auto-set by client)
- CLI timing output on stderr, suppressed for `--columns` / JSON / watch
- Remove dead CLI flags `--timeout` / `--tls-skip-verify` (env-only config)
- Rename `BTRFS_NFS_CSI_IDENTITY` to `AGENT_CSI_IDENTITY`