### PR TITLE
CLI default filter, created_by field, delete protection UX, task labe…

### DIFF
--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 
 	"github.com/labstack/echo/v5"
 )
@@ -30,6 +31,7 @@ type Handler struct {
 func volumeResponseFrom(meta *storage.VolumeMetadata) VolumeResponse {
 	return VolumeResponse{
 		Name:      meta.Name,
+		CreatedBy: meta.Labels[config.LabelCreatedBy],
 		SizeBytes: meta.SizeBytes,
 		UsedBytes: meta.UsedBytes,
 		Exports:   storage.CountUniqueExportIPs(meta.Exports),
@@ -98,6 +100,7 @@ func volumeDetailResponseFrom(meta *storage.VolumeMetadata) VolumeDetailResponse
 	}
 	return VolumeDetailResponse{
 		Name:         meta.Name,
+		CreatedBy:    meta.Labels[config.LabelCreatedBy],
 		Path:         meta.Path,
 		SizeBytes:    meta.SizeBytes,
 		NoCOW:        meta.NoCOW,
@@ -291,6 +294,7 @@ func (h *Handler) Stats(c *echo.Context) error {
 func snapshotResponseFrom(meta *storage.SnapshotMetadata) SnapshotResponse {
 	return SnapshotResponse{
 		Name:      meta.Name,
+		CreatedBy: meta.Labels[config.LabelCreatedBy],
 		Volume:    meta.Volume,
 		SizeBytes: meta.SizeBytes,
 		UsedBytes: meta.UsedBytes,
@@ -355,6 +359,7 @@ func (h *Handler) ListVolumeSnapshots(c *echo.Context) error {
 func snapshotDetailResponseFrom(meta *storage.SnapshotMetadata) SnapshotDetailResponse {
 	return SnapshotDetailResponse{
 		Name:           meta.Name,
+		CreatedBy:      meta.Labels[config.LabelCreatedBy],
 		Volume:         meta.Volume,
 		Path:           meta.Path,
 		SizeBytes:      meta.SizeBytes,
@@ -449,6 +454,10 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 		if err != nil {
 			return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid timeout: " + req.Timeout, Code: storage.ErrInvalid})
 		}
+	}
+
+	if req.Labels[config.LabelCreatedBy] == "" {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "label \"" + config.LabelCreatedBy + "\" is required", Code: storage.ErrInvalid})
 	}
 
 	var taskID string

--- a/agent/api/v1/model.go
+++ b/agent/api/v1/model.go
@@ -50,6 +50,7 @@ type VolumeExportDeleteRequest struct {
 
 type VolumeResponse struct {
 	Name      string    `json:"name"`
+	CreatedBy string    `json:"created_by,omitempty"`
 	SizeBytes uint64    `json:"size_bytes"`
 	UsedBytes uint64    `json:"used_bytes"`
 	Exports   int       `json:"clients"`
@@ -58,6 +59,7 @@ type VolumeResponse struct {
 
 type VolumeDetailResponse struct {
 	Name         string                 `json:"name"`
+	CreatedBy    string                 `json:"created_by,omitempty"`
 	Path         string                 `json:"path"`
 	SizeBytes    uint64                 `json:"size_bytes"`
 	NoCOW        bool                   `json:"nocow"`
@@ -88,6 +90,7 @@ type VolumeDetailListResponse struct {
 
 type SnapshotResponse struct {
 	Name      string    `json:"name"`
+	CreatedBy string    `json:"created_by,omitempty"`
 	Volume    string    `json:"volume"`
 	SizeBytes uint64    `json:"size_bytes"`
 	UsedBytes uint64    `json:"used_bytes"`
@@ -96,6 +99,7 @@ type SnapshotResponse struct {
 
 type SnapshotDetailResponse struct {
 	Name           string            `json:"name"`
+	CreatedBy      string            `json:"created_by,omitempty"`
 	Volume         string            `json:"volume"`
 	Path           string            `json:"path"`
 	SizeBytes      uint64            `json:"size_bytes"`

--- a/ctl/export.go
+++ b/ctl/export.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
 	"github.com/urfave/cli/v3"
 )
 
@@ -38,9 +37,9 @@ func exportRemove(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func listExports(ctx context.Context, cmd *cli.Command, sortBy string, rev bool, opts v1.ListOpts) error {
+func listExports(ctx context.Context, cmd *cli.Command, sortBy string, rev bool, opts cliListOpts) error {
 	if isWide(cmd) {
-		resp, err := apiClient.ListVolumeExportsDetail(ctx, opts)
+		resp, err := apiClient.ListVolumeExportsDetail(ctx, opts.ListOpts)
 		if err != nil {
 			return err
 		}
@@ -61,9 +60,10 @@ func listExports(ctx context.Context, cmd *cli.Command, sortBy string, rev bool,
 				})
 			}
 			tw.flush()
+			emptyHint("exports", len(resp.Exports), opts.allSet, opts.labelSet)
 		})
 	}
-	resp, err := apiClient.ListVolumeExports(ctx, opts)
+	resp, err := apiClient.ListVolumeExports(ctx, opts.ListOpts)
 	if err != nil {
 		return err
 	}
@@ -83,5 +83,6 @@ func listExports(ctx context.Context, cmd *cli.Command, sortBy string, rev bool,
 			})
 		}
 		tw.flush()
+		emptyHint("exports", len(resp.Exports), opts.allSet, opts.labelSet)
 	})
 }

--- a/ctl/flags.go
+++ b/ctl/flags.go
@@ -1,0 +1,120 @@
+package ctl
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	v1 "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/urfave/cli/v3"
+)
+
+func labelFlag() cli.Flag {
+	return &cli.StringSliceFlag{Name: "label", Aliases: []string{"l"}, Usage: "label filter key=value (repeatable, AND)"}
+}
+
+func allFlag() cli.Flag {
+	return &cli.BoolFlag{Name: "all", Aliases: []string{"A"}, Usage: "show all (default: only created-by=cli)"}
+}
+
+func sortFlag() cli.Flag {
+	return &cli.StringFlag{Name: "sort", Aliases: []string{"s"}, Usage: "sort by: name, size, used, used%, created, clients"}
+}
+
+func ascFlag() cli.Flag {
+	return &cli.BoolFlag{Name: "asc", Usage: "ascending sort (default is descending)"}
+}
+
+func watchFlag() cli.Flag {
+	return &cli.DurationFlag{Name: "watch", Aliases: []string{"w"}, Value: 2 * time.Second, Usage: "watch mode with interval (default 2s)"}
+}
+
+func columnsFlag() cli.Flag {
+	return &cli.StringFlag{Name: "columns", Aliases: []string{"c"}, Usage: "comma-separated columns to display (omits header if single column)"}
+}
+
+func splitLabelsFlag(cmd *cli.Command) []string {
+	raw := cmd.StringSlice("label")
+	var out []string
+	for _, entry := range raw {
+		for _, part := range strings.Split(entry, ",") {
+			if p := strings.TrimSpace(part); p != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func parseLabelsFlag(cmd *cli.Command) map[string]string {
+	raw := splitLabelsFlag(cmd)
+	if len(raw) == 0 {
+		return nil
+	}
+	if len(raw) > config.MaxUserLabels {
+		_, _ = fmt.Fprintf(os.Stderr, "warning: too many labels (%d), max %d user labels allowed\n", len(raw), config.MaxUserLabels)
+		raw = raw[:config.MaxUserLabels]
+	}
+	labels := make(map[string]string, len(raw))
+	for _, pair := range raw {
+		k, v, _ := strings.Cut(pair, "=")
+		if slices.Contains(config.SoftReservedLabelKeys, k) {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: label %q is reserved, skipping\n", k)
+			continue
+		}
+		labels[k] = v
+	}
+	return labels
+}
+
+type cliListOpts struct {
+	v1.ListOpts
+	allSet   bool
+	labelSet bool
+}
+
+func buildListOpts(cmd *cli.Command) cliListOpts {
+	labels := splitLabelsFlag(cmd)
+	allSet := cmd.Bool("all")
+	if !allSet {
+		labels = append(labels, config.LabelCreatedBy+"="+config.IdentityCLI)
+	}
+	return cliListOpts{
+		ListOpts: v1.ListOpts{Labels: labels},
+		allSet:   allSet,
+		labelSet: cmd.IsSet("label"),
+	}
+}
+
+// injectWatchDefault inserts "2s" after bare -w/--watch flags so urfave/cli
+// can parse them as DurationFlag (which always requires a value).
+func injectWatchDefault(args []string) []string {
+	for i, a := range args {
+		if a == "-w" || a == "--watch" {
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				out := make([]string, 0, len(args)+1)
+				out = append(out, args[:i+1]...)
+				out = append(out, "2s")
+				out = append(out, args[i+1:]...)
+				return out
+			}
+		}
+	}
+	return args
+}
+
+func emptyHint(resource string, count int, allSet, labelSet bool) {
+	if count > 0 {
+		return
+	}
+	msg := "no " + resource + " found"
+	if labelSet {
+		msg += " (label filter active)"
+	} else if !allSet {
+		msg += " (use -A to show all)"
+	}
+	fmt.Printf("  %s\n", msg)
+}

--- a/ctl/flags_test.go
+++ b/ctl/flags_test.go
@@ -1,0 +1,39 @@
+package ctl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInjectWatchDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		out  []string
+	}{
+		{"bare -w at end", []string{"volume", "ls", "-w"}, []string{"volume", "ls", "-w", "2s"}},
+		{"bare --watch at end", []string{"volume", "ls", "--watch"}, []string{"volume", "ls", "--watch", "2s"}},
+		{"-w with value", []string{"volume", "ls", "-w", "500ms"}, []string{"volume", "ls", "-w", "500ms"}},
+		{"-w followed by flag", []string{"volume", "ls", "-w", "-l", "env=prod"}, []string{"volume", "ls", "-w", "2s", "-l", "env=prod"}},
+		{"no -w", []string{"volume", "ls"}, []string{"volume", "ls"}},
+		{"empty", []string{}, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, injectWatchDefault(tt.in))
+		})
+	}
+}
+
+func TestEmptyHint_NoOutput(t *testing.T) {
+	// count > 0 should not print
+	emptyHint("volumes", 1, false, false)
+}
+
+func TestFmtDuration(t *testing.T) {
+	assert.Equal(t, "0ms", fmtDuration(0))
+	assert.Equal(t, "50ms", fmtDuration(50_000_000))
+	assert.Equal(t, "1s", fmtDuration(1_000_000_000))
+	assert.Equal(t, "10s", fmtDuration(10_000_000_000))
+}

--- a/ctl/model.go
+++ b/ctl/model.go
@@ -52,14 +52,14 @@ func volumeCmd() *cli.Command {
 				Name:    "list",
 				Aliases: []string{"ls"},
 				Usage:   "list all volumes",
-				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
+				Flags:   []cli.Flag{allFlag(), sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					sortBy := cmd.String("sort")
 					if sortBy == "" {
 						sortBy = sortUsedPct
 					}
 					rev := !cmd.Bool("asc")
-					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					opts := buildListOpts(cmd)
 					return runWatch(ctx, cmd, func() error {
 						return listVolumes(ctx, cmd, sortBy, rev, opts)
 					})
@@ -125,7 +125,7 @@ func snapshotCmd() *cli.Command {
 				Aliases:   []string{"ls"},
 				Usage:     "list snapshots (optionally filter by volume)",
 				ArgsUsage: "[volume]",
-				Flags:     []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
+				Flags:     []cli.Flag{allFlag(), sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					sortBy := cmd.String("sort")
 					if sortBy == "" {
@@ -133,7 +133,7 @@ func snapshotCmd() *cli.Command {
 					}
 					rev := !cmd.Bool("asc")
 					vol := cmd.Args().First()
-					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					opts := buildListOpts(cmd)
 					return runWatch(ctx, cmd, func() error {
 						return listSnapshots(ctx, cmd, vol, sortBy, rev, opts)
 					})
@@ -200,11 +200,11 @@ func exportCmd() *cli.Command {
 				Name:    "list",
 				Aliases: []string{"ls"},
 				Usage:   "list active NFS exports",
-				Flags:   []cli.Flag{sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
+				Flags:   []cli.Flag{allFlag(), sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					sortBy := cmd.String("sort")
 					rev := !cmd.Bool("asc")
-					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					opts := buildListOpts(cmd)
 					return runWatch(ctx, cmd, func() error {
 						return listExports(ctx, cmd, sortBy, rev, opts)
 					})
@@ -226,6 +226,7 @@ func taskCmd() *cli.Command {
 				Usage:   "list tasks",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "filter by type (e.g. scrub)"},
+					allFlag(),
 					sortFlag(),
 					ascFlag(),
 					labelFlag(),
@@ -239,7 +240,7 @@ func taskCmd() *cli.Command {
 						sortBy = sortCreated
 					}
 					rev := !cmd.Bool("asc")
-					opts := v1.ListOpts{Labels: splitLabelsFlag(cmd)}
+					opts := buildListOpts(cmd)
 					return runWatch(ctx, cmd, func() error {
 						return listTasks(ctx, cmd, taskType, sortBy, rev, opts)
 					})

--- a/ctl/snapshot.go
+++ b/ctl/snapshot.go
@@ -12,53 +12,55 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func listSnapshots(ctx context.Context, cmd *cli.Command, vol, sortBy string, rev bool, opts v1.ListOpts) error {
+func listSnapshots(ctx context.Context, cmd *cli.Command, vol, sortBy string, rev bool, opts cliListOpts) error {
 	if isWide(cmd) {
 		var resp *v1.SnapshotDetailListResponse
 		var err error
 		if vol != "" {
-			resp, err = apiClient.ListVolumeSnapshotsDetail(ctx, vol, opts)
+			resp, err = apiClient.ListVolumeSnapshotsDetail(ctx, vol, opts.ListOpts)
 		} else {
-			resp, err = apiClient.ListSnapshotsDetail(ctx, opts)
+			resp, err = apiClient.ListSnapshotsDetail(ctx, opts.ListOpts)
 		}
 		if err != nil {
 			return err
 		}
 		sortSnapshotsDetail(resp.Snapshots, sortBy, rev)
 		return output(cmd, resp, func() {
-			tw := newTableWriter(cmd, []string{"NAME", "VOLUME", "SIZE", "USED", "EXCLUSIVE", "READONLY", "LABELS", "CREATED"})
+			tw := newTableWriter(cmd, []string{"NAME", "CREATED BY", "VOLUME", "SIZE", "USED", "EXCLUSIVE", "READONLY", "LABELS", "CREATED"})
 			tw.writeHeader()
 			for _, s := range resp.Snapshots {
 				tw.writeRow(map[string]string{
-					"NAME": s.Name, "VOLUME": s.Volume, "SIZE": utils.FormatBytes(s.SizeBytes), "USED": utils.FormatBytes(s.UsedBytes),
+					"NAME": s.Name, "CREATED BY": s.CreatedBy, "VOLUME": s.Volume, "SIZE": utils.FormatBytes(s.SizeBytes), "USED": utils.FormatBytes(s.UsedBytes),
 					"EXCLUSIVE": utils.FormatBytes(s.ExclusiveBytes), "READONLY": fmt.Sprintf("%v", s.ReadOnly),
 					"LABELS": formatLabelsShort(s.Labels), "CREATED": s.CreatedAt.Format(timeFmt),
 				})
 			}
 			tw.flush()
+			emptyHint("snapshots", len(resp.Snapshots), opts.allSet, opts.labelSet)
 		})
 	}
 	var resp *v1.SnapshotListResponse
 	var err error
 	if vol != "" {
-		resp, err = apiClient.ListVolumeSnapshots(ctx, vol, opts)
+		resp, err = apiClient.ListVolumeSnapshots(ctx, vol, opts.ListOpts)
 	} else {
-		resp, err = apiClient.ListSnapshots(ctx, opts)
+		resp, err = apiClient.ListSnapshots(ctx, opts.ListOpts)
 	}
 	if err != nil {
 		return err
 	}
 	sortSnapshots(resp.Snapshots, sortBy, rev)
 	return output(cmd, resp, func() {
-		tw := newTableWriter(cmd, []string{"NAME", "VOLUME", "SIZE", "USED", "CREATED"})
+		tw := newTableWriter(cmd, []string{"NAME", "CREATED BY", "VOLUME", "SIZE", "USED", "CREATED"})
 		tw.writeHeader()
 		for _, s := range resp.Snapshots {
 			tw.writeRow(map[string]string{
-				"NAME": s.Name, "VOLUME": s.Volume, "SIZE": utils.FormatBytes(s.SizeBytes),
+				"NAME": s.Name, "CREATED BY": s.CreatedBy, "VOLUME": s.Volume, "SIZE": utils.FormatBytes(s.SizeBytes),
 				"USED": utils.FormatBytes(s.UsedBytes), "CREATED": s.CreatedAt.Format(timeFmt),
 			})
 		}
 		tw.flush()
+		emptyHint("snapshots", len(resp.Snapshots), opts.allSet, opts.labelSet)
 	})
 }
 
@@ -110,6 +112,11 @@ func snapshotDelete(ctx context.Context, cmd *cli.Command) error {
 				return wrapErr(err, "snapshot", name)
 			}
 			if snap.Labels[config.LabelCreatedBy] != apiClient.Identity() {
+				owner := snap.Labels[config.LabelCreatedBy]
+				if owner == "" {
+					owner = "unknown"
+				}
+				_, _ = fmt.Fprintf(os.Stderr, "skipped %q (created-by: %s)\n", name, owner)
 				protected = append(protected, name)
 				continue
 			}
@@ -122,7 +129,7 @@ func snapshotDelete(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 	if len(protected) > 0 {
-		_, _ = fmt.Fprintf(os.Stderr, "skipped %d protected snapshot(s) (created-by != cli):\n  btrfs-nfs-csi snapshot delete %s --confirm --yes\n", len(protected), strings.Join(protected, " "))
+		_, _ = fmt.Fprintf(os.Stderr, "to force:  btrfs-nfs-csi snapshot delete %s --confirm --yes\n", strings.Join(protected, " "))
 	}
 	return nil
 }

--- a/ctl/task.go
+++ b/ctl/task.go
@@ -102,9 +102,9 @@ func taskTimeout(t string) string {
 	return "-"
 }
 
-func listTasks(ctx context.Context, cmd *cli.Command, taskType, sortBy string, rev bool, opts v1.ListOpts) error {
+func listTasks(ctx context.Context, cmd *cli.Command, taskType, sortBy string, rev bool, opts cliListOpts) error {
 	if isWide(cmd) {
-		resp, err := apiClient.ListTasksDetail(ctx, taskType, opts)
+		resp, err := apiClient.ListTasksDetail(ctx, taskType, opts.ListOpts)
 		if err != nil {
 			return err
 		}
@@ -128,9 +128,10 @@ func listTasks(ctx context.Context, cmd *cli.Command, taskType, sortBy string, r
 				})
 			}
 			tw.flush()
+			emptyHint("tasks", len(resp.Tasks), opts.allSet, opts.labelSet)
 		})
 	}
-	resp, err := apiClient.ListTasks(ctx, taskType, opts)
+	resp, err := apiClient.ListTasks(ctx, taskType, opts.ListOpts)
 	if err != nil {
 		return err
 	}
@@ -146,6 +147,7 @@ func listTasks(ctx context.Context, cmd *cli.Command, taskType, sortBy string, r
 			})
 		}
 		tw.flush()
+		emptyHint("tasks", len(resp.Tasks), opts.allSet, opts.labelSet)
 	})
 }
 

--- a/ctl/utils.go
+++ b/ctl/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"slices"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -35,10 +34,6 @@ const (
 	sortType    = "type"
 	sortStatus  = "status"
 )
-
-func labelFlag() cli.Flag {
-	return &cli.StringSliceFlag{Name: "label", Aliases: []string{"l"}, Usage: "label filter key=value (repeatable, AND)"}
-}
 
 func formatLabels(labels map[string]string) string {
 	if len(labels) == 0 {
@@ -110,67 +105,6 @@ func formatExports(refs []v1.ExportDetailResponse) string {
 	return strings.Join(parts, ", ")
 }
 
-func splitLabelsFlag(cmd *cli.Command) []string {
-	raw := cmd.StringSlice("label")
-	var out []string
-	for _, entry := range raw {
-		for _, part := range strings.Split(entry, ",") {
-			if p := strings.TrimSpace(part); p != "" {
-				out = append(out, p)
-			}
-		}
-	}
-	return out
-}
-
-func parseLabelsFlag(cmd *cli.Command) map[string]string {
-	raw := splitLabelsFlag(cmd)
-	if len(raw) == 0 {
-		return nil
-	}
-	if len(raw) > config.MaxUserLabels {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: too many labels (%d), max %d user labels allowed\n", len(raw), config.MaxUserLabels)
-		raw = raw[:config.MaxUserLabels]
-	}
-	labels := make(map[string]string, len(raw))
-	for _, pair := range raw {
-		k, v, _ := strings.Cut(pair, "=")
-		if slices.Contains(config.SoftReservedLabelKeys, k) {
-			_, _ = fmt.Fprintf(os.Stderr, "warning: label %q is reserved, skipping\n", k)
-			continue
-		}
-		labels[k] = v
-	}
-	return labels
-}
-
-func sortFlag() cli.Flag {
-	return &cli.StringFlag{Name: "sort", Aliases: []string{"s"}, Usage: "sort by: name, size, used, used%, created, clients"}
-}
-
-func ascFlag() cli.Flag {
-	return &cli.BoolFlag{Name: "asc", Usage: "ascending sort (default is descending)"}
-}
-
-func watchFlag() cli.Flag {
-	return &cli.DurationFlag{Name: "watch", Aliases: []string{"w"}, Value: 2 * time.Second, Usage: "watch mode with interval (default 2s)"}
-}
-
-func injectWatchDefault(args []string) []string {
-	for i, a := range args {
-		if a == "-w" || a == "--watch" {
-			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
-				out := make([]string, 0, len(args)+1)
-				out = append(out, args[:i+1]...)
-				out = append(out, "2s")
-				out = append(out, args[i+1:]...)
-				return out
-			}
-		}
-	}
-	return args
-}
-
 func runWatch(ctx context.Context, cmd *cli.Command, fn func() error) error {
 	if !cmd.IsSet("watch") || !term.IsTerminal(int(os.Stdout.Fd())) {
 		return fn()
@@ -205,10 +139,6 @@ func runWatch(ctx context.Context, cmd *cli.Command, fn func() error) error {
 	}
 }
 
-func columnsFlag() cli.Flag {
-	return &cli.StringFlag{Name: "columns", Aliases: []string{"c"}, Usage: "comma-separated columns to display (omits header if single column)"}
-}
-
 type tableWriter struct {
 	selected []string
 	w        *tabwriter.Writer
@@ -219,11 +149,13 @@ func newTableWriter(cmd *cli.Command, all []string) *tableWriter {
 	if raw := cmd.String("columns"); raw != "" {
 		avail := make(map[string]string, len(all))
 		for _, col := range all {
-			avail[strings.ToLower(col)] = col
+			key := strings.ToLower(strings.ReplaceAll(col, " ", ""))
+			avail[key] = col
 		}
 		var filtered []string
 		for _, r := range strings.Split(raw, ",") {
-			if col, ok := avail[strings.ToLower(strings.TrimSpace(r))]; ok {
+			key := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(r), " ", ""))
+			if col, ok := avail[key]; ok {
 				filtered = append(filtered, col)
 			}
 		}

--- a/ctl/volume.go
+++ b/ctl/volume.go
@@ -12,43 +12,45 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func listVolumes(ctx context.Context, cmd *cli.Command, sortBy string, rev bool, opts v1.ListOpts) error {
+func listVolumes(ctx context.Context, cmd *cli.Command, sortBy string, rev bool, opts cliListOpts) error {
 	if isWide(cmd) {
-		resp, err := apiClient.ListVolumesDetail(ctx, opts)
+		resp, err := apiClient.ListVolumesDetail(ctx, opts.ListOpts)
 		if err != nil {
 			return err
 		}
 		sortVolumesDetail(resp.Volumes, sortBy, rev)
 		return output(cmd, resp, func() {
-			tw := newTableWriter(cmd, []string{"NAME", "SIZE", "USED", "QUOTA", "COMPRESSION", "NOCOW", "UID", "GID", "MODE", "LABELS", "CLIENTS", "CREATED"})
+			tw := newTableWriter(cmd, []string{"NAME", "CREATED BY", "SIZE", "USED", "QUOTA", "COMPRESSION", "NOCOW", "UID", "GID", "MODE", "LABELS", "CLIENTS", "CREATED"})
 			tw.writeHeader()
 			for _, v := range resp.Volumes {
 				tw.writeRow(map[string]string{
-					"NAME": v.Name, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
+					"NAME": v.Name, "CREATED BY": v.CreatedBy, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
 					"QUOTA": utils.FormatBytes(v.QuotaBytes), "COMPRESSION": v.Compression, "NOCOW": fmt.Sprintf("%v", v.NoCOW),
 					"UID": fmt.Sprintf("%d", v.UID), "GID": fmt.Sprintf("%d", v.GID), "MODE": v.Mode,
 					"LABELS": formatLabelsShort(v.Labels), "CLIENTS": fmt.Sprintf("%d", len(v.Exports)), "CREATED": v.CreatedAt.Format(timeFmt),
 				})
 			}
 			tw.flush()
+			emptyHint("volumes", len(resp.Volumes), opts.allSet, opts.labelSet)
 		})
 	}
-	resp, err := apiClient.ListVolumes(ctx, opts)
+	resp, err := apiClient.ListVolumes(ctx, opts.ListOpts)
 	if err != nil {
 		return err
 	}
 	sortVolumes(resp.Volumes, sortBy, rev)
 	return output(cmd, resp, func() {
-		tw := newTableWriter(cmd, []string{"NAME", "SIZE", "USED", "USED%", "CLIENTS", "CREATED"})
+		tw := newTableWriter(cmd, []string{"NAME", "CREATED BY", "SIZE", "USED", "USED%", "CLIENTS", "CREATED"})
 		tw.writeHeader()
 		for _, v := range resp.Volumes {
 			tw.writeRow(map[string]string{
-				"NAME": v.Name, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
+				"NAME": v.Name, "CREATED BY": v.CreatedBy, "SIZE": utils.FormatBytes(v.SizeBytes), "USED": utils.FormatBytes(v.UsedBytes),
 				"USED%":   fmt.Sprintf("%.0f%%", usedPct(v.UsedBytes, v.SizeBytes)),
 				"CLIENTS": fmt.Sprintf("%d", v.Exports), "CREATED": v.CreatedAt.Format(timeFmt),
 			})
 		}
 		tw.flush()
+		emptyHint("volumes", len(resp.Volumes), opts.allSet, opts.labelSet)
 	})
 }
 
@@ -128,6 +130,11 @@ func volumeDelete(ctx context.Context, cmd *cli.Command) error {
 				return wrapErr(err, "volume", name)
 			}
 			if vol.Labels[config.LabelCreatedBy] != apiClient.Identity() {
+				owner := vol.Labels[config.LabelCreatedBy]
+				if owner == "" {
+					owner = "unknown"
+				}
+				_, _ = fmt.Fprintf(os.Stderr, "skipped %q (created-by: %s)\n", name, owner)
 				protected = append(protected, name)
 				continue
 			}
@@ -140,7 +147,7 @@ func volumeDelete(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 	if len(protected) > 0 {
-		_, _ = fmt.Fprintf(os.Stderr, "skipped %d protected volume(s) (created-by != cli):\n  btrfs-nfs-csi volume delete %s --confirm --yes\n", len(protected), strings.Join(protected, " "))
+		_, _ = fmt.Fprintf(os.Stderr, "to force:  btrfs-nfs-csi volume delete %s --confirm --yes\n", strings.Join(protected, " "))
 	}
 	return nil
 }

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -80,6 +80,7 @@ Example: `GET /v1/volumes?limit=10` returns the first 10 volumes. Use the `next`
 // Response 201
 {
   "name": "vol-1",
+  "created_by": "cli",
   "path": "/srv/csi/default/vol-1",
   "size_bytes": 1073741824,
   "nocow": false,
@@ -113,6 +114,7 @@ Returns a summary list. Supports pagination (`?after=&limit=`), label filtering 
   "volumes": [
     {
       "name": "vol-1",
+      "created_by": "cli",
       "size_bytes": 1073741824,
       "used_bytes": 16384,
       "clients": 1,
@@ -130,6 +132,7 @@ With `?detail=true`, each volume includes the full detail fields (same as `GET /
 ```json
 {
   "name": "vol-1",
+  "created_by": "cli",
   "path": "/srv/csi/default/vol-1",
   "size_bytes": 1073741824,
   "nocow": false,
@@ -273,6 +276,7 @@ With `?detail=true`, each export includes `labels`:
 // Response 201
 {
   "name": "snap-1",
+  "created_by": "cli",
   "volume": "vol-1",
   "path": "/srv/csi/default/snapshots/snap-1",
   "size_bytes": 1073741824,
@@ -294,6 +298,7 @@ Returns a summary list of all snapshots. Supports pagination (`?after=&limit=`),
   "snapshots": [
     {
       "name": "snap-1",
+      "created_by": "cli",
       "volume": "vol-1",
       "size_bytes": 1073741824,
       "used_bytes": 16384,
@@ -315,6 +320,7 @@ Returns a summary list of snapshots for a specific volume. Same response format 
 ```json
 {
   "name": "snap-1",
+  "created_by": "cli",
   "volume": "vol-1",
   "path": "/srv/csi/default/snapshots/snap-1",
   "size_bytes": 1073741824,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -308,6 +308,8 @@ btrfs-nfs-csi version
 
 **Sorting:** `--sort` / `-s` with `--asc` (default descending). Volume default: `used%`. Snapshot/task default: `created`.
 
+**Default filter:** List commands filter by `created-by=cli` by default (only show resources created by the CLI). Use `--all` / `-A` to show all resources regardless of creator.
+
 **Label filter:** `--label` / `-l`, repeatable (AND). Supports comma-separated values: `-l env=prod,team=be`.
 
 **Size values:** Supports `Ki`, `Mi`, `Gi` (binary) and `K`, `M`, `G` (decimal). `volume expand` accepts relative sizes with `+`/`-` prefix.


### PR DESCRIPTION
## Summary
- Default `created-by=cli` filter on all list commands, `-A` flag to show all
- `created_by` field in volume/snapshot API responses (from labels)
- `CREATED BY` column in volume/snapshot list output
- Empty list hint after table header (e.g. "no volumes found (use -A to show all)")
- Delete protection now shows per-item owner (e.g. `skipped "pvc-..." (created-by: controller)`)
- Enforce `created-by` label on task creation (400 if missing)
- Space-insensitive column filter (`-c createdby` matches `CREATED BY`)
- Extract flags and helpers into `flags.go`, rename `listOpts` to `cliListOpts`