### PR TITLE
Fix health checker auto-heal, harden driver defaults

### DIFF
--- a/agent/api/v1/client/client.go
+++ b/agent/api/v1/client/client.go
@@ -73,7 +73,7 @@ type ClientConfig struct {
 	Timeout       time.Duration `env:"AGENT_HTTP_CLIENT_TIMEOUT" envDefault:"30s"`
 	TLSSkipVerify bool          `env:"AGENT_HTTP_CLIENT_TLS_SKIP_VERIFY"`
 	Identity      string        `env:"AGENT_CSI_IDENTITY"`
-	PageLimit     int           `env:"AGENT_HTTP_CLIENT_PAGE_LIMIT" envDefault:"100"`
+	PageLimit     int           `env:"AGENT_HTTP_CLIENT_PAGE_LIMIT" envDefault:"0"`
 	Prefetch      int           `env:"AGENT_HTTP_CLIENT_PREFETCH" envDefault:"8"`
 	PrefetchMB    int           `env:"AGENT_HTTP_CLIENT_PREFETCH_MB" envDefault:"4"`
 	HTTPClient    *http.Client  `env:"-"`
@@ -91,7 +91,7 @@ func DefaultClientConfig() ClientConfig {
 	if err != nil {
 		return ClientConfig{
 			Timeout:    DefaultTimeout,
-			PageLimit:  100,
+			PageLimit:  0,
 			Prefetch:   8,
 			PrefetchMB: 4,
 		}

--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) deleteSnapshot(id string) {
 func paginatedList[T labeled, R any](h *Handler, c *echo.Context, items []T, mapFn func(*T) R, wrapFn func([]R, int, string) any) error {
 	after := c.QueryParam("after")
 	limit, _ := strconv.Atoi(c.QueryParam("limit"))
-	if limit <= 0 {
+	if limit < 0 {
 		limit = h.DefaultPageLimit
 	}
 

--- a/agent/api/v1/handler_export.go
+++ b/agent/api/v1/handler_export.go
@@ -80,7 +80,7 @@ func (h *Handler) DeleteVolumeExport(c *echo.Context) error {
 // @Tags         exports
 // @Produce      json
 // @Param        detail query string false "Return full detail" Enums(true)
-// @Param        limit  query int    false "Items per page"
+// @Param        limit  query int    false "Items per page (0 = pagination disabled)"
 // @Param        after  query string false "Pagination cursor"
 // @Param        label  query []string false "Label filter (key=value), repeatable"
 // @Success      200 {object} models.ExportListResponse

--- a/agent/api/v1/handler_snapshot.go
+++ b/agent/api/v1/handler_snapshot.go
@@ -97,7 +97,7 @@ func (h *Handler) listSnapshotsPage(c *echo.Context, volume string) error {
 // @Tags         snapshots
 // @Produce      json
 // @Param        detail query string false "Return full detail" Enums(true)
-// @Param        limit  query int    false "Items per page"
+// @Param        limit  query int    false "Items per page (0 = pagination disabled)"
 // @Param        after  query string false "Pagination cursor"
 // @Param        label  query []string false "Label filter (key=value), repeatable"
 // @Success      200 {object} models.SnapshotListResponse

--- a/agent/api/v1/handler_task.go
+++ b/agent/api/v1/handler_task.go
@@ -111,7 +111,7 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 // @Produce      json
 // @Param        type   query string false "Filter by task type" Enums(scrub, test)
 // @Param        detail query string false "Return full detail" Enums(true)
-// @Param        limit  query int    false "Items per page"
+// @Param        limit  query int    false "Items per page (0 = pagination disabled)"
 // @Param        after  query string false "Pagination cursor"
 // @Param        label  query []string false "Label filter (key=value), repeatable"
 // @Success      200 {object} models.TaskListResponse

--- a/agent/api/v1/handler_volume.go
+++ b/agent/api/v1/handler_volume.go
@@ -88,7 +88,7 @@ func (h *Handler) CreateVolume(c *echo.Context) error {
 // @Tags         volumes
 // @Produce      json
 // @Param        detail query string false "Return full detail" Enums(true)
-// @Param        limit  query int    false "Items per page"
+// @Param        limit  query int    false "Items per page (0 = pagination disabled)"
 // @Param        after  query string false "Pagination cursor from previous response"
 // @Param        label  query []string false "Label filter (key=value), repeatable"
 // @Success      200 {object} models.VolumeListResponse

--- a/agent/api/v1/models/models.go
+++ b/agent/api/v1/models/models.go
@@ -403,18 +403,18 @@ const (
 // ListOpts configures list endpoint queries (pagination + label filtering).
 type ListOpts struct {
 	After  string   // opaque cursor from a previous response's Next field
-	Limit  int      // items per page (0 = use client/server default)
+	Limit  int      // items per page (0 = pagination disabled, negative = use client default)
 	Labels []string // label filters in "key=value" format
 }
 
-// Query builds url.Values for a list request. defaultLimit is used when Limit is 0.
+// Query builds url.Values for a list request. defaultLimit is used when Limit is negative.
 func (o ListOpts) Query(defaultLimit int) url.Values {
 	q := GenerateLabelQuery(o.Labels)
 	if o.After != "" {
 		q.Set("after", o.After)
 	}
 	limit := o.Limit
-	if limit <= 0 {
+	if limit < 0 {
 		limit = defaultLimit
 	}
 	if limit > 0 {

--- a/agent/api/v1/swagger/docs.go
+++ b/agent/api/v1/swagger/docs.go
@@ -113,7 +113,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },
@@ -171,7 +171,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },
@@ -391,7 +391,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },
@@ -576,7 +576,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },

--- a/agent/api/v1/swagger/swagger.json
+++ b/agent/api/v1/swagger/swagger.json
@@ -102,7 +102,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },
@@ -160,7 +160,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },
@@ -380,7 +380,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },
@@ -565,7 +565,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page",
+                        "description": "Items per page (0 = pagination disabled)",
                         "name": "limit",
                         "in": "query"
                     },

--- a/agent/api/v1/swagger/swagger.yaml
+++ b/agent/api/v1/swagger/swagger.yaml
@@ -678,7 +678,7 @@ paths:
         in: query
         name: detail
         type: string
-      - description: Items per page
+      - description: Items per page (0 = pagination disabled)
         in: query
         name: limit
         type: integer
@@ -716,7 +716,7 @@ paths:
         in: query
         name: detail
         type: string
-      - description: Items per page
+      - description: Items per page (0 = pagination disabled)
         in: query
         name: limit
         type: integer
@@ -857,7 +857,7 @@ paths:
         in: query
         name: detail
         type: string
-      - description: Items per page
+      - description: Items per page (0 = pagination disabled)
         in: query
         name: limit
         type: integer
@@ -976,7 +976,7 @@ paths:
         in: query
         name: detail
         type: string
-      - description: Items per page
+      - description: Items per page (0 = pagination disabled)
         in: query
         name: limit
         type: integer

--- a/agent/storage/meta/store.go
+++ b/agent/storage/meta/store.go
@@ -216,7 +216,7 @@ func writeJSONAtomic(path string, v any) error {
 		return err
 	}
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return err
 	}
 

--- a/agent/storage/meta/store_test.go
+++ b/agent/storage/meta/store_test.go
@@ -45,7 +45,7 @@ func TestStore_GetCacheMiss_DiskFallback(t *testing.T) {
 	s, dir := testStore(t)
 	entryDir := filepath.Join(dir, "t", "k1")
 	require.NoError(t, os.MkdirAll(entryDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(entryDir, "metadata.json"), []byte(`{"name":"disk","value":99}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(entryDir, "metadata.json"), []byte(`{"name":"disk","value":99}`), 0o644))
 
 	got, err := s.Get("t", "k1")
 	require.NoError(t, err)

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -37,7 +37,7 @@ func writeTestJSONFile(t *testing.T, path string, v any) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -253,7 +253,7 @@ func (tm *Manager) persist(t *Task) {
 	}
 	path := tm.taskFile(t.ID)
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		log.Error().Err(err).Str("task", t.ID).Msg("failed to persist task")
 		return
 	}

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -39,7 +39,17 @@ func requireImmutableLabels(keys []string, labels map[string]string) error {
 }
 
 func protectImmutableLabels(keys []string, cur, updated map[string]string) error {
+	// Protect explicitly configured immutable keys and soft-reserved keys
+	// (clone.source.*, created-by). Soft-reserved labels are set automatically
+	// on create and must not be changed or added via update.
+	allKeys := make(map[string]struct{}, len(keys)+len(config.SoftReservedLabelKeys))
 	for _, k := range keys {
+		allKeys[k] = struct{}{}
+	}
+	for _, k := range config.SoftReservedLabelKeys {
+		allKeys[k] = struct{}{}
+	}
+	for k := range allKeys {
 		if v, ok := updated[k]; ok && v != cur[k] {
 			return &StorageError{Code: ErrInvalid, Message: fmt.Sprintf("label %q cannot be changed", k)}
 		}

--- a/agent/storage/utils_test.go
+++ b/agent/storage/utils_test.go
@@ -292,6 +292,29 @@ func TestProtectImmutableLabels(t *testing.T) {
 		updated := map[string]string{"created-by": "csi", "env": "prod"}
 		require.NoError(t, protectImmutableLabels(keys, map[string]string{"created-by": "csi"}, updated))
 	})
+
+	t.Run("rejects_clone_source_change", func(t *testing.T) {
+		cur := map[string]string{"created-by": "k8s", "clone.source.type": "snapshot", "clone.source.name": "snap-1"}
+		updated := map[string]string{"clone.source.type": "volume"}
+		err := protectImmutableLabels(keys, cur, updated)
+		requireStorageError(t, err, ErrInvalid)
+	})
+
+	t.Run("preserves_clone_source_on_omit", func(t *testing.T) {
+		cur := map[string]string{"created-by": "k8s", "clone.source.type": "snapshot", "clone.source.name": "snap-1"}
+		updated := map[string]string{"env": "prod"}
+		require.NoError(t, protectImmutableLabels(keys, cur, updated))
+		assert.Equal(t, "snapshot", updated["clone.source.type"])
+		assert.Equal(t, "snap-1", updated["clone.source.name"])
+		assert.Equal(t, "k8s", updated["created-by"])
+	})
+
+	t.Run("rejects_adding_clone_source_to_non_clone", func(t *testing.T) {
+		cur := map[string]string{"created-by": "k8s"}
+		updated := map[string]string{"clone.source.type": "snapshot"}
+		err := protectImmutableLabels(keys, cur, updated)
+		requireStorageError(t, err, ErrInvalid)
+	})
 }
 
 func TestFileMode(t *testing.T) {

--- a/charts/btrfs-nfs-csi/README.md
+++ b/charts/btrfs-nfs-csi/README.md
@@ -54,7 +54,7 @@ driver:
   storageInterface: "eth1"    # or storageCIDR: "10.10.0.0/24"
 ```
 
-`hostNetwork` is auto-enabled when either is set.
+`hostNetwork` is enabled by default so NFS4 sessions survive driver pod restarts (e.g. during `helm upgrade`). It is also required when `storageInterface` or `storageCIDR` is set.
 
 ## Values
 
@@ -139,7 +139,7 @@ Sidecars: `provisioner`, `attacher`, `snapshotter`, `resizer`, `livenessProbe`
 | `driver.priorityClassName` | `system-node-critical` | Priority class |
 | `driver.storageInterface` | `""` | Dedicated storage NIC |
 | `driver.storageCIDR` | `""` | Storage subnet CIDR |
-| `driver.hostNetwork` | `false` | Host networking (auto-enabled for storage NIC/CIDR) |
+| `driver.hostNetwork` | `true` | Host networking; required for NFS4 session stability across pod restarts |
 | `driver.updateStrategy` | RollingUpdate, maxUnavailable 1 | DaemonSet update strategy |
 | `driver.podSecurityContext` | `{}` | Pod security context |
 | `driver.resources` | 10m CPU, 32Mi/128Mi memory | Resource requests/limits |

--- a/charts/btrfs-nfs-csi/values.yaml
+++ b/charts/btrfs-nfs-csi/values.yaml
@@ -182,7 +182,7 @@ driver:
   # Set one of these for dedicated storage networks (both require hostNetwork):
   storageInterface: "" # NIC name, e.g. "eth1"
   storageCIDR: "" # subnet CIDR, e.g. "10.10.0.0/24"
-  hostNetwork: false # auto-enabled when storageInterface or storageCIDR is set
+  hostNetwork: true # NFS4 sessions must survive driver pod restarts; also required for storageInterface/storageCIDR
   healthCheckInterval: "30s" # NFS mount health check interval, set to "0" to disable
 
   updateStrategy:

--- a/cmd/btrfs-nfs-csi/main.go
+++ b/cmd/btrfs-nfs-csi/main.go
@@ -44,16 +44,18 @@ func main() {
 	}).With().Timestamp().Logger()
 
 	app := &cli.Command{
-		Name:  "btrfs-nfs-csi",
-		Usage: "btrfs-nfs-csi storage driver",
+		Name:        "btrfs-nfs-csi",
+		Usage:       "btrfs-nfs-csi storage driver",
+		Description: `Turns any btrfs filesystem into a full-featured NFS storage backend with
+instant snapshots, clones, and quotas. Includes a standalone REST agent,
+a CLI, and several CSI integrations.
+
+Docs:   https://github.com/erikmagkekse/btrfs-nfs-csi#readme
+Issues: https://github.com/erikmagkekse/btrfs-nfs-csi/issues`,
 		OnUsageError: func(_ context.Context, _ *cli.Command, err error, _ bool) error {
 			return err
 		},
-		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "agent-url", Sources: cli.EnvVars("AGENT_URL"), Usage: "agent API URL"},
-			&cli.StringFlag{Name: "agent-token", Sources: cli.EnvVars("AGENT_TOKEN"), Usage: "tenant token"},
-			&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Value: outputTable, Usage: "output format: table, wide, json, json,wide"},
-		},
+		Flags: []cli.Flag{},
 		Commands: append(
 			withCLIHooks(
 				volumeCmd(),
@@ -128,10 +130,10 @@ func driverBackwardsCompatibilityWillBeRemovedInTheFuture() *cli.Command {
 func integrationCmd() *cli.Command {
 	return &cli.Command{
 		Name:        "integration",
-		Aliases:     []string{"integrations"},
+		Aliases:     []string{"integrations", "int"},
 		Usage:       "Platform integrations (kubernetes, ...)",
 		Category:    "Server",
-		Description: "Start platform-specific server components for Integrations",
+		Description: "Start platform-specific server components for integrations.",
 		Commands: []*cli.Command{
 			kubernetesCmd(),
 		},
@@ -140,9 +142,15 @@ func integrationCmd() *cli.Command {
 
 func kubernetesCmd() *cli.Command {
 	return &cli.Command{
-		Name:    "kubernetes",
-		Aliases: []string{"k8s"},
-		Usage:   "Kubernetes CSI driver",
+		Name:        "kubernetes",
+		Aliases:     []string{"k8s"},
+		Usage:       "Kubernetes integration",
+		Description: `Dynamic provisioning of btrfs volumes and snapshots via PVCs.
+Supports volume expansion, cloning, snapshots, NFS exports,
+health monitoring with auto-heal, and multi-node access.
+
+https://github.com/erikmagkekse/btrfs-nfs-csi
+Author: Erik Groh <me@eriks.life>`,
 		Commands: []*cli.Command{
 			{
 				Name:  "controller",

--- a/cmd/btrfs-nfs-csi/main.go
+++ b/cmd/btrfs-nfs-csi/main.go
@@ -44,8 +44,8 @@ func main() {
 	}).With().Timestamp().Logger()
 
 	app := &cli.Command{
-		Name:        "btrfs-nfs-csi",
-		Usage:       "btrfs-nfs-csi storage driver",
+		Name:  "btrfs-nfs-csi",
+		Usage: "btrfs-nfs-csi storage driver",
 		Description: `Turns any btrfs filesystem into a full-featured NFS storage backend with
 instant snapshots, clones, and quotas. Includes a standalone REST agent,
 a CLI, and several CSI integrations.
@@ -142,9 +142,9 @@ func integrationCmd() *cli.Command {
 
 func kubernetesCmd() *cli.Command {
 	return &cli.Command{
-		Name:        "kubernetes",
-		Aliases:     []string{"k8s"},
-		Usage:       "Kubernetes integration",
+		Name:    "kubernetes",
+		Aliases: []string{"k8s"},
+		Usage:   "Kubernetes integration",
 		Description: `Dynamic provisioning of btrfs volumes and snapshots via PVCs.
 Supports volume expansion, cloning, snapshots, NFS exports,
 health monitoring with auto-heal, and multi-node access.

--- a/cmd/btrfs-nfs-csi/model.go
+++ b/cmd/btrfs-nfs-csi/model.go
@@ -15,7 +15,7 @@ func versionCmd() *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			fmt.Printf("Local:\n")
 			fmt.Printf("  btrfs-nfs-csi %s (%s)\n", version, commit)
-			if cmd.Root().String("agent-url") != "" && cmd.Root().String("agent-token") != "" {
+			if cmd.String("agent-url") != "" && cmd.String("agent-token") != "" {
 				fmt.Printf("Agent:\n")
 				if h, err := apiClient.Healthz(ctx); err == nil {
 					fmt.Printf("  btrfs-nfs-csi %s (%s)\n", h.Version, h.Commit)
@@ -49,12 +49,12 @@ func healthCmd() *cli.Command {
 func volumeCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "volume",
-		Aliases: []string{"volumes", "vol"},
+		Aliases: []string{"volumes", "vol", "v"},
 		Usage:   "manage volumes",
 		Commands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls"},
+				Aliases: []string{"ls", "l"},
 				Usage:   "list all volumes",
 				Flags:   []cli.Flag{allFlag(), sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -71,6 +71,7 @@ func volumeCmd() *cli.Command {
 			},
 			{
 				Name:      "get",
+				Aliases:   []string{"g"},
 				Usage:     "get volume details",
 				ArgsUsage: "<name>",
 				Flags:     []cli.Flag{watchFlag()},
@@ -78,6 +79,7 @@ func volumeCmd() *cli.Command {
 			},
 			{
 				Name:      "create",
+				Aliases:   []string{"c"},
 				Usage:     "create a volume",
 				ArgsUsage: "<name> <size>",
 				Flags: []cli.Flag{
@@ -92,7 +94,7 @@ func volumeCmd() *cli.Command {
 			},
 			{
 				Name:      "delete",
-				Aliases:   []string{"rm"},
+				Aliases:   []string{"rm", "d"},
 				Usage:     "delete volumes",
 				ArgsUsage: "<name> [name...]",
 				Flags: []cli.Flag{
@@ -121,12 +123,12 @@ func volumeCmd() *cli.Command {
 func snapshotCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "snapshot",
-		Aliases: []string{"snapshots", "snap"},
+		Aliases: []string{"snapshots", "snap", "s"},
 		Usage:   "manage snapshots",
 		Commands: []*cli.Command{
 			{
 				Name:      "list",
-				Aliases:   []string{"ls"},
+				Aliases:   []string{"ls", "l"},
 				Usage:     "list snapshots (optionally filter by volume)",
 				ArgsUsage: "[volume]",
 				Flags:     []cli.Flag{allFlag(), sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
@@ -145,6 +147,7 @@ func snapshotCmd() *cli.Command {
 			},
 			{
 				Name:      "get",
+				Aliases:   []string{"g"},
 				Usage:     "get snapshot details",
 				ArgsUsage: "<name>",
 				Flags:     []cli.Flag{watchFlag()},
@@ -152,6 +155,7 @@ func snapshotCmd() *cli.Command {
 			},
 			{
 				Name:      "create",
+				Aliases:   []string{"c"},
 				Usage:     "create a snapshot",
 				ArgsUsage: "<volume> <name>",
 				Flags:     []cli.Flag{labelFlag()},
@@ -159,7 +163,7 @@ func snapshotCmd() *cli.Command {
 			},
 			{
 				Name:      "delete",
-				Aliases:   []string{"rm"},
+				Aliases:   []string{"rm", "d"},
 				Usage:     "delete snapshots",
 				ArgsUsage: "<name> [name...]",
 				Flags: []cli.Flag{
@@ -182,11 +186,12 @@ func snapshotCmd() *cli.Command {
 func exportCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "export",
-		Aliases: []string{"exports"},
+		Aliases: []string{"exports", "e"},
 		Usage:   "manage NFS exports",
 		Commands: []*cli.Command{
 			{
 				Name:      "add",
+				Aliases:   []string{"a"},
 				Usage:     "add NFS export",
 				ArgsUsage: "<volume> <client-ip>",
 				Flags:     []cli.Flag{labelFlag()},
@@ -194,7 +199,7 @@ func exportCmd() *cli.Command {
 			},
 			{
 				Name:      "remove",
-				Aliases:   []string{"rm"},
+				Aliases:   []string{"rm", "r"},
 				Usage:     "remove NFS export",
 				ArgsUsage: "<volume> <client-ip>",
 				Flags:     []cli.Flag{labelFlag()},
@@ -202,7 +207,7 @@ func exportCmd() *cli.Command {
 			},
 			{
 				Name:    "list",
-				Aliases: []string{"ls"},
+				Aliases: []string{"ls", "l"},
 				Usage:   "list active NFS exports",
 				Flags:   []cli.Flag{allFlag(), sortFlag(), ascFlag(), labelFlag(), columnsFlag(), watchFlag()},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -221,12 +226,12 @@ func exportCmd() *cli.Command {
 func taskCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "task",
-		Aliases: []string{"tasks"},
+		Aliases: []string{"tasks", "t"},
 		Usage:   "manage background tasks",
 		Commands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls"},
+				Aliases: []string{"ls", "l"},
 				Usage:   "list tasks",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "type", Aliases: []string{"t"}, Usage: "filter by type (e.g. scrub)"},
@@ -252,6 +257,7 @@ func taskCmd() *cli.Command {
 			},
 			{
 				Name:      "get",
+				Aliases:   []string{"g"},
 				Usage:     "get task details",
 				ArgsUsage: "<id>",
 				Flags:     []cli.Flag{watchFlag()},
@@ -264,8 +270,9 @@ func taskCmd() *cli.Command {
 				Action:    taskCancel,
 			},
 			{
-				Name:  "create",
-				Usage: "create a background task",
+				Name:    "create",
+				Aliases: []string{"c"},
+				Usage:   "create a background task",
 				Commands: []*cli.Command{
 					{
 						Name:  models.TaskTypeScrub,

--- a/cmd/btrfs-nfs-csi/utils.go
+++ b/cmd/btrfs-nfs-csi/utils.go
@@ -369,12 +369,17 @@ var (
 
 func initClient(cmd *cli.Command) error {
 	var err error
-	apiClient, err = agentclient.NewClient(cmd.Root().String("agent-url"), cmd.Root().String("agent-token"), config.IdentityCLI)
+	apiClient, err = agentclient.NewClient(cmd.String("agent-url"), cmd.String("agent-token"), config.IdentityCLI)
 	return err
 }
 
 func withCLIHooks(cmds ...*cli.Command) []*cli.Command {
 	for _, cmd := range cmds {
+		cmd.Flags = append(cmd.Flags,
+			&cli.StringFlag{Name: "agent-url", Sources: cli.EnvVars("AGENT_URL"), Usage: "agent API URL"},
+			&cli.StringFlag{Name: "agent-token", Sources: cli.EnvVars("AGENT_TOKEN"), Usage: "tenant token"},
+			&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Value: outputTable, Usage: "output format: table, wide, json, json,wide"},
+		)
 		cmd.Before = func(ctx context.Context, c *cli.Command) (context.Context, error) {
 			if err := initClient(c); err != nil {
 				return ctx, err
@@ -408,7 +413,7 @@ func watchAction(fn cli.ActionFunc) cli.ActionFunc {
 }
 
 func outputFormat(cmd *cli.Command) string {
-	return cmd.Root().String("output")
+	return cmd.String("output")
 }
 
 func isWide(cmd *cli.Command) bool {

--- a/config/config.go
+++ b/config/config.go
@@ -92,7 +92,7 @@ type AgentConfig struct {
 	TaskDefaultTimeout     time.Duration `env:"AGENT_TASK_DEFAULT_TIMEOUT" envDefault:"6h"`
 	TaskScrubTimeout       time.Duration `env:"AGENT_TASK_SCRUB_TIMEOUT" envDefault:"24h"`
 	TaskPollInterval       time.Duration `env:"AGENT_TASK_POLL_INTERVAL" envDefault:"5s"`
-	DefaultPageLimit       int           `env:"AGENT_DEFAULT_PAGE_LIMIT" envDefault:"100"`
+	DefaultPageLimit       int           `env:"AGENT_DEFAULT_PAGE_LIMIT" envDefault:"0"`
 	PaginationSnapshotTTL  time.Duration `env:"AGENT_API_PAGINATION_SNAPSHOT_TTL" envDefault:"30s"`
 	PaginationMaxSnapshots int           `env:"AGENT_API_PAGINATION_MAX_SNAPSHOTS" envDefault:"100"`
 	SwaggerEnabled         bool          `env:"AGENT_API_SWAGGER_ENABLED"`

--- a/deploy/driver/setup.yaml
+++ b/deploy/driver/setup.yaml
@@ -291,8 +291,9 @@ spec:
           effect: NoExecute
         - operator: Exists
           effect: NoSchedule
-      # Uncomment if using DRIVER_STORAGE_INTERFACE or DRIVER_STORAGE_CIDR
-      #hostNetwork: true
+      # hostNetwork is recommended: NFS4 sessions survive driver pod restarts.
+      # Required when using DRIVER_STORAGE_INTERFACE or DRIVER_STORAGE_CIDR.
+      hostNetwork: true
       containers:
         - name: csi-driver
           image: ghcr.io/erikmagkekse/btrfs-nfs-csi:0.10.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@
 | `AGENT_TASK_SCRUB_TIMEOUT` | `24h` | Timeout for btrfs scrub tasks. `0` = no timeout |
 | `AGENT_TASK_POLL_INTERVAL` | `5s` | Progress update interval for background tasks |
 | `AGENT_IMMUTABLE_LABELS` | - | Comma-separated label keys that cannot be changed after creation |
-| `AGENT_DEFAULT_PAGE_LIMIT` | `100` | Default page size for list API responses |
+| `AGENT_DEFAULT_PAGE_LIMIT` | `0` | Default page size for list API responses (0 = pagination disabled) |
 | `AGENT_API_PAGINATION_SNAPSHOT_TTL` | `30s` | TTL for cursor-based pagination snapshots |
 | `AGENT_API_PAGINATION_MAX_SNAPSHOTS` | `100` | Max concurrent pagination snapshots |
 | `AGENT_API_SWAGGER_ENABLED` | `false` | Enable `GET /swagger.json` endpoint |
@@ -42,7 +42,7 @@ Shared by CLI and controller (any `v1.Client` user).
 | `AGENT_CSI_IDENTITY` | `cli` (CLI), `k8s` (controller) | Caller identity for `created-by` label, injected automatically on every create |
 | `AGENT_HTTP_CLIENT_TIMEOUT` | `30s` | API request timeout (Go duration) |
 | `AGENT_HTTP_CLIENT_TLS_SKIP_VERIFY` | `false` | Skip TLS certificate verification |
-| `AGENT_HTTP_CLIENT_PAGE_LIMIT` | `100` | Items per page for auto-pagination |
+| `AGENT_HTTP_CLIENT_PAGE_LIMIT` | `0` | Items per page for auto-pagination (0 = pagination disabled) |
 | `AGENT_HTTP_CLIENT_PREFETCH` | `8` | Max pages to prefetch concurrently (`0` = sequential) |
 | `AGENT_HTTP_CLIENT_PREFETCH_MB` | `4` | Prefetch byte budget in MB (`0` = unlimited) |
 
@@ -78,7 +78,7 @@ Also configurable via `--agent-url` and `--agent-token` flags.
 
 **IP resolution order:** `DRIVER_STORAGE_INTERFACE` > `DRIVER_STORAGE_CIDR` > `DRIVER_NODE_IP`. At least one required.
 
-**Note:** `DRIVER_STORAGE_INTERFACE` and `DRIVER_STORAGE_CIDR` resolve IPs from the host's network interfaces. The node DaemonSet must have `hostNetwork: true` for this to work.
+**Note:** `hostNetwork: true` is the default and recommended setting. NFS4 client sessions are tied to the pod's hostname; without host networking, every DaemonSet rolling update (e.g. `helm upgrade`) orphans all active NFS4 sessions, causing stale mounts. `DRIVER_STORAGE_INTERFACE` and `DRIVER_STORAGE_CIDR` also require `hostNetwork: true` to resolve IPs from the host's network interfaces.
 
 ## StorageClass Parameters
 

--- a/integrations/kubernetes/driver/health.go
+++ b/integrations/kubernetes/driver/health.go
@@ -11,6 +11,7 @@ import (
 	"github.com/erikmagkekse/btrfs-nfs-csi/integrations/kubernetes/csiserver"
 
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/mount-utils"
@@ -141,9 +142,11 @@ func (s *NodeServer) healMount(ctx context.Context, mp mount.MountPoint, vi *vol
 		return
 	}
 
-	// No forceUnmount needed: mounting over a stale NFS mount works and is faster
-	// than waiting for the unmount timeout (which fails with "Resource busy" anyway
-	// because bind mounts are still active).
+	// Mount over the stale NFS mount. The kernel stacks the fresh mount on top;
+	// the stale one becomes hidden but stays as a fallback if remount fails on
+	// the next health check cycle. We intentionally do NOT lazy-unmount the
+	// globalmount first -- if the fresh mount fails, the stale entry is still
+	// present so the health checker can retry.
 	log.Info().Str("source", mp.Device).Str("mountpoint", mp.Path).Str("fstype", mp.Type).Strs("opts", mp.Opts).Msg("health check: remounting")
 	start := time.Now()
 	if err := s.mounter.Mount(mp.Device, mp.Path, mp.Type, mp.Opts); err != nil {
@@ -157,9 +160,44 @@ func (s *NodeServer) healMount(ctx context.Context, mp mount.MountPoint, vi *vol
 
 	mountOpsTotal.WithLabelValues("health_remount", "success").Inc()
 	mountDuration.WithLabelValues("health_remount").Observe(time.Since(start).Seconds())
-	log.Info().Str("mountpoint", mp.Path).Msg("health check: remount succeeded, bind mounts healed")
 	healthChecksTotal.WithLabelValues("remounted").Inc()
+
+	// Pod bind mounts still reference the old (stale) globalmount. Lazy-unmount
+	// each and re-bind from the fresh globalmount so pods get working I/O.
+	healed := s.healBindMounts(mp.Device, mp.Path)
+	log.Info().Str("mountpoint", mp.Path).Int("bind_mounts_healed", healed).Msg("health check: remount succeeded")
 	s.reportVolumeEvent(ctx, vi, eventMountRemounted, "NFS mount was stale, auto-healed by driver")
+}
+
+// healBindMounts lazy-unmounts and re-binds pod bind mounts that reference the
+// given NFS globalmount device. Returns the number of healed bind mounts.
+func (s *NodeServer) healBindMounts(globalDevice, globalMountPath string) int {
+	dataDir := globalMountPath + "/" + config.DataDir
+	mounts, err := s.mounter.List()
+	if err != nil {
+		log.Warn().Err(err).Msg("health check: failed to list mounts for bind healing")
+		return 0
+	}
+	healed := 0
+	for _, m := range mounts {
+		// In /proc/mounts, bind mounts from an NFS subpath show the parent NFS
+		// device (e.g. "10.0.0.5:/exports/vol"), not the subpath. Match on the
+		// device and filter to pod volume paths.
+		if m.Device != globalDevice || !strings.Contains(m.Path, "/pods/") {
+			continue
+		}
+		if err := unix.Unmount(m.Path, unix.MNT_DETACH); err != nil {
+			log.Warn().Err(err).Str("path", m.Path).Msg("health check: lazy unmount bind failed")
+			continue
+		}
+		if err := s.mounter.Mount(dataDir, m.Path, "", []string{"bind"}); err != nil {
+			log.Error().Err(err).Str("path", m.Path).Msg("health check: re-bind failed")
+			continue
+		}
+		log.Info().Str("path", m.Path).Msg("health check: bind mount healed")
+		healed++
+	}
+	return healed
 }
 
 func (s *NodeServer) reportVolumeEvent(ctx context.Context, vi *volumeInfo, reason, message string) {

--- a/integrations/kubernetes/driver/health_test.go
+++ b/integrations/kubernetes/driver/health_test.go
@@ -68,7 +68,7 @@ func TestCheckMountHealth_SkipsNonGlobalmount(t *testing.T) {
 
 func TestCheckMountHealth_HealthyMount(t *testing.T) {
 	globalmountDir := filepath.Join(t.TempDir(), "globalmount", "vol")
-	require.NoError(t, os.MkdirAll(filepath.Join(globalmountDir, "data"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(globalmountDir, "data"), 0o755))
 
 	ns := newTestNodeServer([]mount.MountPoint{
 		{Device: "10.0.0.5:/exports/vol", Path: globalmountDir, Type: "nfs4"},
@@ -87,7 +87,7 @@ func TestCheckMountHealth_SkipsInFlightStat(t *testing.T) {
 	// statWithTimeout would fail and trigger healing. But because we
 	// pre-mark the path as in-flight, the health check should skip it.
 	globalmountDir := filepath.Join(t.TempDir(), "globalmount", "vol")
-	require.NoError(t, os.MkdirAll(globalmountDir, 0755))
+	require.NoError(t, os.MkdirAll(globalmountDir, 0o755))
 
 	ns := newTestNodeServer([]mount.MountPoint{
 		{Device: "10.0.0.5:/exports/vol", Path: globalmountDir, Type: "nfs4"},
@@ -178,6 +178,40 @@ func TestHealMount_SetsHealthStateAbnormalOnFailure(t *testing.T) {
 	vh := h.(*volumeHealth)
 	assert.True(t, vh.abnormal)
 	assert.Contains(t, vh.message, "remount failed")
+}
+
+// --- healBindMounts tests ---
+
+func TestHealBindMounts_HealsMatchingPodMounts(t *testing.T) {
+	podPath := "/var/lib/kubelet/pods/uid-123/volumes/kubernetes.io~csi/pv-1/mount"
+	ns := newTestNodeServer([]mount.MountPoint{
+		// In /proc/mounts, bind mounts show parent NFS device (without /data suffix)
+		{Device: "10.0.0.5:/exports/vol", Path: podPath, Type: "nfs4"},
+	})
+
+	healed := ns.healBindMounts("10.0.0.5:/exports/vol", "/var/lib/kubelet/plugins/csi/globalmount")
+
+	// unix.Unmount fails in tests (not a real mount), so re-bind is skipped.
+	// In production, lazy unmount succeeds and the bind is re-created.
+	assert.Equal(t, 0, healed, "unix.Unmount fails in test env, so no binds healed")
+}
+
+func TestHealBindMounts_SkipsNonPodMounts(t *testing.T) {
+	ns := newTestNodeServer([]mount.MountPoint{
+		{Device: "10.0.0.5:/exports/vol", Path: "/var/lib/kubelet/plugins/csi/globalmount", Type: "nfs4"},
+		{Device: "10.0.0.5:/other", Path: "/var/lib/kubelet/pods/uid/vol/mount", Type: "nfs4"},
+		{Device: "/dev/sda1", Path: "/var/lib/kubelet/pods/uid/vol", Type: "ext4"},
+	})
+
+	healed := ns.healBindMounts("10.0.0.5:/exports/vol", "/var/lib/kubelet/plugins/csi/globalmount")
+
+	assert.Equal(t, 0, healed, "none should match: globalmount not under /pods/, other has wrong device, ext4 has wrong device")
+}
+
+func TestHealBindMounts_NoMounts(t *testing.T) {
+	ns := newTestNodeServer(nil)
+	healed := ns.healBindMounts("10.0.0.5:/exports/vol", "/var/lib/kubelet/plugins/csi/globalmount")
+	assert.Equal(t, 0, healed)
 }
 
 // --- Event tests (with fake kubeClient) ---

--- a/integrations/kubernetes/driver/node.go
+++ b/integrations/kubernetes/driver/node.go
@@ -44,7 +44,7 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
-	if err := os.MkdirAll(stagingPath, 0755); err != nil {
+	if err := os.MkdirAll(stagingPath, 0o755); err != nil {
 		return nil, status.Errorf(codes.Internal, "mkdir staging for volume %s: %v", vol, err)
 	}
 
@@ -118,7 +118,7 @@ func (s *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		log.Warn().Err(err).Str("volume", vol).Str("sc", sc).Str("path", req.TargetPath).Msg("stale bind mount detected, remounting over it")
 	}
 
-	if err := os.MkdirAll(req.TargetPath, 0755); err != nil {
+	if err := os.MkdirAll(req.TargetPath, 0o755); err != nil {
 		return nil, status.Errorf(codes.Internal, "mkdir target for volume %s: %v", vol, err)
 	}
 


### PR DESCRIPTION
## Summary

- Health checker: fix bind mount healing, `healMount()` now heals pod bind mounts after remounting the globalmount. Previously, mount-over-stale left bind mounts referencing the dead NFS session. New `healBindMounts()` lazy-unmounts and re-binds each affected pod mount. Fixed device matching (`/proc/mounts` shows parent NFS device, not subpath).
- hostNetwork default to true -- NFS4 client sessions are tied to the pod hostname. Without host networking, every DaemonSet rolling update orphans all active sessions, causing stale mounts. Now enabled by default; docs updated.
- Clone label protection -- `clone.source.type` and `clone.source.name` labels are now protected by `protectImmutableLabels()`. Previously they could be changed or deleted via the update API.
- Pagination: limit=0 disables -- `limit=0` now means "return all" instead of falling back to default 100. Default changed to 0 (pagination disabled). Affects server, client, and swagger docs.
- Improved CTL
- Disabled pagination per default