### PR TITLE
Bulk qgroup query in usage updater to eliminate N+1 btrfs commands

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -171,12 +171,12 @@ func parseTenants(s string) map[string]string {
 		return nil
 	}
 	m := make(map[string]string)
-	for _, entry := range strings.Split(s, ",") {
-		parts := strings.SplitN(strings.TrimSpace(entry), ":", 2)
-		if len(parts) == 2 {
-			name := strings.TrimSpace(parts[0])
-			token := strings.TrimSpace(parts[1])
-			m[token] = name
+	for entry := range strings.SplitSeq(s, ",") {
+		name, tok, ok := strings.Cut(strings.TrimSpace(entry), ":")
+		if ok {
+			name = strings.TrimSpace(name)
+			tok = strings.TrimSpace(tok)
+			m[tok] = name
 		}
 	}
 	if len(m) == 0 {

--- a/agent/api/v1/handler_export.go
+++ b/agent/api/v1/handler_export.go
@@ -1,8 +1,9 @@
 package v1
 
 import (
+	"cmp"
 	"net/http"
-	"sort"
+	"slices"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
@@ -92,11 +93,11 @@ func (h *Handler) ListVolumeExports(c *echo.Context) error {
 	if err != nil {
 		return StorageError(c, err)
 	}
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].Name != items[j].Name {
-			return items[i].Name < items[j].Name
+	slices.SortFunc(items, func(a, b storage.ExportEntry) int {
+		if c := cmp.Compare(a.Name, b.Name); c != 0 {
+			return c
 		}
-		return items[i].Client < items[j].Client
+		return cmp.Compare(a.Client, b.Client)
 	})
 
 	if c.QueryParam("detail") == "true" {

--- a/agent/api/v1/handler_snapshot.go
+++ b/agent/api/v1/handler_snapshot.go
@@ -1,8 +1,9 @@
 package v1
 
 import (
+	"cmp"
 	"net/http"
-	"sort"
+	"slices"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
@@ -79,7 +80,7 @@ func (h *Handler) listSnapshotsPage(c *echo.Context, volume string) error {
 	if err != nil {
 		return StorageError(c, err)
 	}
-	sort.Slice(snaps, func(i, j int) bool { return snaps[i].Name < snaps[j].Name })
+	slices.SortFunc(snaps, func(a, b storage.SnapshotMetadata) int { return cmp.Compare(a.Name, b.Name) })
 
 	if c.QueryParam("detail") == "true" {
 		return paginatedList(h, c, snaps, snapshotDetailResponseFrom, func(r []models.SnapshotDetailResponse, total int, next string) any {

--- a/agent/api/v1/handler_task.go
+++ b/agent/api/v1/handler_task.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"net/http"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
@@ -119,7 +119,7 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 // @Security     BearerAuth
 func (h *Handler) ListTasks(c *echo.Context) error {
 	tasks := h.Store.Tasks().List(c.QueryParam("type"))
-	sort.Slice(tasks, func(i, j int) bool { return tasks[i].CreatedAt.After(tasks[j].CreatedAt) })
+	slices.SortFunc(tasks, func(a, b task.Task) int { return b.CreatedAt.Compare(a.CreatedAt) })
 
 	if c.QueryParam("detail") == "true" {
 		return paginatedList(h, c, tasks, taskDetailResponseFrom, func(r []models.TaskDetailResponse, total int, next string) any {

--- a/agent/api/v1/handler_volume.go
+++ b/agent/api/v1/handler_volume.go
@@ -1,8 +1,9 @@
 package v1
 
 import (
+	"cmp"
 	"net/http"
-	"sort"
+	"slices"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
@@ -100,7 +101,7 @@ func (h *Handler) ListVolumes(c *echo.Context) error {
 	if err != nil {
 		return StorageError(c, err)
 	}
-	sort.Slice(vols, func(i, j int) bool { return vols[i].Name < vols[j].Name })
+	slices.SortFunc(vols, func(a, b storage.VolumeMetadata) int { return cmp.Compare(a.Name, b.Name) })
 
 	if c.QueryParam("detail") == "true" {
 		return paginatedList(h, c, vols, volumeDetailResponseFrom, func(r []models.VolumeDetailResponse, total int, next string) any {

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -20,17 +20,17 @@ func AuthMiddleware(tenants map[string]string) echo.MiddlewareFunc {
 				return authFailed(c, "missing authorization header")
 			}
 
-			parts := strings.SplitN(auth, " ", 2)
-			if len(parts) != 2 {
+			scheme, token, ok := strings.Cut(auth, " ")
+			if !ok {
 				return authFailed(c, "malformed authorization header")
 			}
 
 			var providedToken string
-			switch parts[0] {
+			switch scheme {
 			case "Bearer":
-				providedToken = parts[1]
+				providedToken = token
 			case "Basic":
-				decoded, err := base64.StdEncoding.DecodeString(parts[1])
+				decoded, err := base64.StdEncoding.DecodeString(token)
 				if err != nil {
 					return authFailed(c, "invalid basic auth encoding")
 				}
@@ -40,7 +40,7 @@ func AuthMiddleware(tenants map[string]string) echo.MiddlewareFunc {
 				}
 				providedToken = pass
 			default:
-				return authFailed(c, "unsupported auth scheme: "+parts[0])
+				return authFailed(c, "unsupported auth scheme: "+scheme)
 			}
 
 			tenant, ok := tenants[providedToken]

--- a/agent/storage/btrfs/btrfs.go
+++ b/agent/storage/btrfs/btrfs.go
@@ -66,10 +66,10 @@ func (m *Manager) QgroupUsageEx(ctx context.Context, path string) (QgroupInfo, e
 		return QgroupInfo{}, err
 	}
 	var subvolID string
-	for _, line := range strings.Split(showOut, "\n") {
+	for line := range strings.SplitSeq(showOut, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "Subvolume ID:") {
-			subvolID = strings.TrimSpace(strings.TrimPrefix(trimmed, "Subvolume ID:"))
+		if v, ok := strings.CutPrefix(trimmed, "Subvolume ID:"); ok {
+			subvolID = strings.TrimSpace(v)
 			break
 		}
 	}
@@ -77,26 +77,20 @@ func (m *Manager) QgroupUsageEx(ctx context.Context, path string) (QgroupInfo, e
 		return QgroupInfo{}, fmt.Errorf("subvolume ID not found for %s", path)
 	}
 
-	qgroupID := "0/" + subvolID
-
 	out, err := m.cmd.Run(ctx, m.bin, "qgroup", "show", "-re", "--raw", path)
 	if err != nil {
 		return QgroupInfo{}, err
 	}
-	for _, line := range strings.Split(out, "\n") {
-		fields := strings.Fields(line)
-		if len(fields) >= 3 && fields[0] == qgroupID {
-			var info QgroupInfo
-			if _, err := fmt.Sscanf(fields[1], "%d", &info.Referenced); err != nil {
-				return QgroupInfo{}, fmt.Errorf("parse referenced bytes %q: %w", fields[1], err)
-			}
-			if _, err := fmt.Sscanf(fields[2], "%d", &info.Exclusive); err != nil {
-				return QgroupInfo{}, fmt.Errorf("parse exclusive bytes %q: %w", fields[2], err)
-			}
-			return info, nil
-		}
+	qgroups, err := parseQgroupMap(out)
+	if err != nil {
+		return QgroupInfo{}, err
 	}
-	return QgroupInfo{}, fmt.Errorf("qgroup %s not found for %s", qgroupID, path)
+	qgroupID := "0/" + subvolID
+	info, ok := qgroups[qgroupID]
+	if !ok {
+		return QgroupInfo{}, fmt.Errorf("qgroup %s not found for %s", qgroupID, path)
+	}
+	return info, nil
 }
 
 func (m *Manager) SetNoCOW(ctx context.Context, path string) error {
@@ -186,22 +180,43 @@ func (m *Manager) ScrubStatus(ctx context.Context, path string) (*ScrubStatus, e
 	return parseScrubStatus(out)
 }
 
+// QgroupUsageBulk returns qgroup usage for all subvolumes under path.
+// Runs `btrfs subvolume list -o` and `btrfs qgroup show -re --raw` once each,
+// joins by subvolume ID. Returns map keyed by relative subvolume path.
+func (m *Manager) QgroupUsageBulk(ctx context.Context, path string) (map[string]QgroupInfo, error) {
+	listOut, err := m.cmd.Run(ctx, m.bin, "subvolume", "list", "-o", path)
+	if err != nil {
+		return nil, fmt.Errorf("subvolume list: %w", err)
+	}
+	qgroupOut, err := m.cmd.Run(ctx, m.bin, "qgroup", "show", "-re", "--raw", path)
+	if err != nil {
+		return nil, fmt.Errorf("qgroup show: %w", err)
+	}
+
+	subvols := parseSubvolumeListFull(listOut)
+	qgroups, err := parseQgroupMap(qgroupOut)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]QgroupInfo, len(subvols))
+	for _, sv := range subvols {
+		if info, ok := qgroups["0/"+sv.ID]; ok {
+			result[sv.Path] = info
+		}
+	}
+	return result, nil
+}
+
 func (m *Manager) SubvolumeList(ctx context.Context, path string) ([]SubvolumeInfo, error) {
 	out, err := m.cmd.Run(ctx, m.bin, "subvolume", "list", "-o", path)
 	if err != nil {
 		return nil, err
 	}
-
-	var subs []SubvolumeInfo
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line == "" {
-			continue
-		}
-		// format: ID <id> gen <gen> top level <tl> path <path>
-		parts := strings.Fields(line)
-		if len(parts) >= 9 {
-			subs = append(subs, SubvolumeInfo{Path: parts[8]})
-		}
+	entries := parseSubvolumeListFull(out)
+	subs := make([]SubvolumeInfo, len(entries))
+	for i, e := range entries {
+		subs[i] = SubvolumeInfo{Path: e.Path}
 	}
 	return subs, nil
 }

--- a/agent/storage/btrfs/btrfs_test.go
+++ b/agent/storage/btrfs/btrfs_test.go
@@ -603,3 +603,155 @@ func TestScrubStatus(t *testing.T) {
 		assert.Equal(t, []string{"scrub", "start", "-B", "/mnt/data"}, m.Calls[0])
 	})
 }
+
+func TestParseSubvolumeListFull(t *testing.T) {
+	t.Run("multiple entries", func(t *testing.T) {
+		out := strings.Join([]string{
+			"ID 259 gen 12 top level 5 path tenant/vol1/data",
+			"ID 260 gen 13 top level 5 path tenant/vol2/data",
+			"ID 261 gen 14 top level 5 path tenant/snapshots/snap1/data",
+		}, "\n")
+
+		entries := parseSubvolumeListFull(out)
+		require.Len(t, entries, 3)
+		assert.Equal(t, "259", entries[0].ID)
+		assert.Equal(t, "tenant/vol1/data", entries[0].Path)
+		assert.Equal(t, "260", entries[1].ID)
+		assert.Equal(t, "tenant/vol2/data", entries[1].Path)
+		assert.Equal(t, "261", entries[2].ID)
+		assert.Equal(t, "tenant/snapshots/snap1/data", entries[2].Path)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		entries := parseSubvolumeListFull("")
+		assert.Empty(t, entries)
+	})
+
+	t.Run("skips non-ID lines", func(t *testing.T) {
+		out := "some header line\nID 259 gen 12 top level 5 path vol1\n"
+		entries := parseSubvolumeListFull(out)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "259", entries[0].ID)
+	})
+}
+
+func TestParseQgroupMap(t *testing.T) {
+	t.Run("multiple entries", func(t *testing.T) {
+		out := strings.Join([]string{
+			"qgroupid         rfer         excl",
+			"--------         ----         ----",
+			"0/259        16384         8192",
+			"0/260        32768         4096",
+		}, "\n")
+
+		m, err := parseQgroupMap(out)
+		require.NoError(t, err)
+		require.Len(t, m, 2)
+		assert.Equal(t, uint64(16384), m["0/259"].Referenced)
+		assert.Equal(t, uint64(8192), m["0/259"].Exclusive)
+		assert.Equal(t, uint64(32768), m["0/260"].Referenced)
+		assert.Equal(t, uint64(4096), m["0/260"].Exclusive)
+	})
+
+	t.Run("skips headers", func(t *testing.T) {
+		out := "qgroupid         rfer         excl\n--------         ----         ----\n"
+		m, err := parseQgroupMap(out)
+		require.NoError(t, err)
+		assert.Empty(t, m)
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		out := "0/259        abc         8192\n"
+		_, err := parseQgroupMap(out)
+		assert.Error(t, err)
+	})
+}
+
+func TestQgroupUsageBulk(t *testing.T) {
+	listOutput := strings.Join([]string{
+		"ID 259 gen 12 top level 5 path tenant/vol1/data",
+		"ID 260 gen 13 top level 5 path tenant/vol2/data",
+		"ID 261 gen 14 top level 5 path tenant/snapshots/snap1/data",
+	}, "\n")
+
+	qgroupOutput := strings.Join([]string{
+		"qgroupid         rfer         excl",
+		"--------         ----         ----",
+		"0/5          16384        16384",
+		"0/259        10000         5000",
+		"0/260        20000         8000",
+		"0/261         3000         1000",
+	}, "\n")
+
+	t.Run("success", func(t *testing.T) {
+		m := &utils.MockRunner{
+			RunFn: func(args []string) (string, error) {
+				if slices.Contains(args, "list") {
+					return listOutput, nil
+				}
+				return qgroupOutput, nil
+			},
+		}
+		mgr := newTestManager(m)
+
+		result, err := mgr.QgroupUsageBulk(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+
+		assert.Equal(t, uint64(10000), result["tenant/vol1/data"].Referenced)
+		assert.Equal(t, uint64(5000), result["tenant/vol1/data"].Exclusive)
+		assert.Equal(t, uint64(20000), result["tenant/vol2/data"].Referenced)
+		assert.Equal(t, uint64(3000), result["tenant/snapshots/snap1/data"].Referenced)
+
+		require.Len(t, m.Calls, 2, "should make exactly 2 btrfs calls")
+	})
+
+	t.Run("subvol without qgroup is skipped", func(t *testing.T) {
+		// qgroup output missing 0/260
+		partialQgroup := strings.Join([]string{
+			"0/259        10000         5000",
+			"0/261         3000         1000",
+		}, "\n")
+
+		m := &utils.MockRunner{
+			RunFn: func(args []string) (string, error) {
+				if slices.Contains(args, "list") {
+					return listOutput, nil
+				}
+				return partialQgroup, nil
+			},
+		}
+		mgr := newTestManager(m)
+
+		result, err := mgr.QgroupUsageBulk(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		_, hasVol2 := result["tenant/vol2/data"]
+		assert.False(t, hasVol2)
+	})
+
+	t.Run("subvolume list error", func(t *testing.T) {
+		m := &utils.MockRunner{Err: fmt.Errorf("list failed")}
+		mgr := newTestManager(m)
+
+		_, err := mgr.QgroupUsageBulk(context.Background(), "/mnt/data")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subvolume list")
+	})
+
+	t.Run("qgroup show error", func(t *testing.T) {
+		m := &utils.MockRunner{
+			RunFn: func(args []string) (string, error) {
+				if slices.Contains(args, "list") {
+					return listOutput, nil
+				}
+				return "", fmt.Errorf("qgroup show failed")
+			},
+		}
+		mgr := newTestManager(m)
+
+		_, err := mgr.QgroupUsageBulk(context.Background(), "/mnt/data")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "qgroup show")
+	})
+}

--- a/agent/storage/btrfs/utils.go
+++ b/agent/storage/btrfs/utils.go
@@ -13,7 +13,7 @@ import (
 // Missing (empty path): devid    2 size 0 used 0 path  MISSING
 func parseDevices(out string) ([]BTRFSDevice, error) {
 	var devices []BTRFSDevice
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "devid") {
 			continue
@@ -63,22 +63,21 @@ func parseDevices(out string) ([]BTRFSDevice, error) {
 func parseDeviceErrors(out string) ([]DeviceErrors, error) {
 	var all []DeviceErrors
 	var cur *DeviceErrors
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
 		// format: [/dev/sda].write_io_errs    0
-		bracket := strings.Index(line, "].")
-		if bracket < 0 {
+		devicePart, rest, ok := strings.Cut(line, "].")
+		if !ok {
 			continue
 		}
-		device := line[1:bracket]
+		device := strings.TrimPrefix(devicePart, "[")
 		if cur == nil || cur.Device != device {
 			all = append(all, DeviceErrors{Device: device})
 			cur = &all[len(all)-1]
 		}
-		rest := line[bracket+2:]
 		parts := strings.Fields(rest)
 		if len(parts) != 2 {
 			continue
@@ -110,7 +109,7 @@ func parseFilesystemUsage(out string) (FilesystemUsage, error) {
 	var fu FilesystemUsage
 	var inOverall bool
 
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		trimmed := strings.TrimSpace(line)
 
 		if strings.HasPrefix(trimmed, "Overall:") {
@@ -125,8 +124,8 @@ func parseFilesystemUsage(out string) (FilesystemUsage, error) {
 			}
 			// "Data ratio:" is a float, not a uint - handle separately
 			if strings.HasPrefix(trimmed, "Data ratio:") {
-				if parts := strings.SplitN(trimmed, ":", 2); len(parts) == 2 {
-					if v, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64); err == nil {
+				if _, val, ok := strings.Cut(trimmed, ":"); ok {
+					if v, err := strconv.ParseFloat(strings.TrimSpace(val), 64); err == nil {
 						fu.DataRatio = v
 					}
 				}
@@ -162,12 +161,12 @@ func parseFilesystemUsage(out string) (FilesystemUsage, error) {
 // Uses the first ":" as the separator to handle keys like "Free (estimated)"
 // and values like "(min: 12345)".
 func parseKVBytes(line string) (key string, val uint64, ok bool) {
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) != 2 {
+	k, rawVal, found := strings.Cut(line, ":")
+	if !found {
 		return "", 0, false
 	}
-	key = strings.TrimSpace(parts[0])
-	raw := strings.TrimSpace(parts[1])
+	key = strings.TrimSpace(k)
+	raw := strings.TrimSpace(rawVal)
 	// strip parenthetical like "(min: 12345)"
 	if p := strings.Index(raw, "("); p > 0 {
 		raw = strings.TrimSpace(raw[:p])
@@ -184,17 +183,17 @@ func parseKVBytes(line string) (key string, val uint64, ok bool) {
 // and "key: value" pairs for counters.
 func parseScrubStatus(out string) (*ScrubStatus, error) {
 	s := &ScrubStatus{}
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
 		}
-		parts := strings.SplitN(trimmed, ":", 2)
-		if len(parts) != 2 {
+		k, v, ok := strings.Cut(trimmed, ":")
+		if !ok {
 			continue
 		}
-		key := strings.TrimSpace(parts[0])
-		val := strings.TrimSpace(parts[1])
+		key := strings.TrimSpace(k)
+		val := strings.TrimSpace(v)
 
 		switch key {
 		case "Status":
@@ -220,10 +219,66 @@ func parseScrubStatus(out string) (*ScrubStatus, error) {
 	return s, nil
 }
 
+// subvolEntry holds a parsed line from `btrfs subvolume list -o`.
+type subvolEntry struct {
+	ID   string
+	Path string
+}
+
+// parseSubvolumeListFull parses `btrfs subvolume list -o` output into ID + path pairs.
+// Format: ID 259 gen 12 top level 5 path tenant/vol1/data
+func parseSubvolumeListFull(out string) []subvolEntry {
+	var entries []subvolEntry
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 9 || fields[0] != "ID" {
+			continue
+		}
+		_, path, ok := strings.Cut(line, " path ")
+		if !ok {
+			continue
+		}
+		entries = append(entries, subvolEntry{
+			ID:   fields[1],
+			Path: path,
+		})
+	}
+	return entries
+}
+
+// parseQgroupMap parses `btrfs qgroup show -re --raw` output into a map keyed by qgroup ID.
+// Format:
+//
+//	qgroupid         rfer         excl
+//	--------         ----         ----
+//	0/259        16384         8192
+func parseQgroupMap(out string) (map[string]QgroupInfo, error) {
+	result := make(map[string]QgroupInfo)
+	for line := range strings.SplitSeq(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || !strings.Contains(fields[0], "/") {
+			continue
+		}
+		var info QgroupInfo
+		var err error
+		if info.Referenced, err = strconv.ParseUint(fields[1], 10, 64); err != nil {
+			return nil, fmt.Errorf("parse referenced bytes %q: %w", fields[1], err)
+		}
+		if info.Exclusive, err = strconv.ParseUint(fields[2], 10, 64); err != nil {
+			return nil, fmt.Errorf("parse exclusive bytes %q: %w", fields[2], err)
+		}
+		result[fields[0]] = info
+	}
+	return result, nil
+}
+
 // parseProfileSizeUsed parses "Metadata,DUP: Size:1073741824, Used:536870912".
 func parseProfileSizeUsed(line string) (size, used uint64) {
-	if idx := strings.Index(line, "Size:"); idx >= 0 {
-		raw := line[idx+len("Size:"):]
+	if _, after, ok := strings.Cut(line, "Size:"); ok {
+		raw := after
 		if end := strings.IndexAny(raw, ", \t"); end > 0 {
 			raw = raw[:end]
 		}
@@ -232,8 +287,8 @@ func parseProfileSizeUsed(line string) (size, used uint64) {
 			size = v
 		}
 	}
-	if idx := strings.Index(line, "Used:"); idx >= 0 {
-		raw := line[idx+len("Used:"):]
+	if _, after, ok := strings.Cut(line, "Used:"); ok {
+		raw := after
 		if end := strings.IndexAny(raw, ", \t"); end > 0 {
 			raw = raw[:end]
 		}

--- a/agent/storage/model.go
+++ b/agent/storage/model.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"encoding/json"
 	"maps"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
@@ -117,7 +117,7 @@ func uniqueExportIPs(clients []ExportMetadata) []string {
 	for ip := range seen {
 		ips = append(ips, ip)
 	}
-	sort.Strings(ips)
+	slices.Sort(ips)
 	return ips
 }
 

--- a/agent/storage/nfs/kernel.go
+++ b/agent/storage/nfs/kernel.go
@@ -39,8 +39,8 @@ func exportfsClient(client string) string {
 
 // unwrapBrackets removes bracket wrapping from an IPv6 address returned by exportfs -v.
 func unwrapBrackets(client string) string {
-	if strings.HasPrefix(client, "[") && strings.Contains(client, "]") {
-		return strings.TrimPrefix(strings.SplitN(client, "]", 2)[0], "[")
+	if addr, _, ok := strings.Cut(client, "]"); ok && strings.HasPrefix(addr, "[") {
+		return strings.TrimPrefix(addr, "[")
 	}
 	return client
 }
@@ -92,7 +92,7 @@ func (e *kernelExporter) ListExports(ctx context.Context) ([]ExportInfo, error) 
 func parseExports(output string) []ExportInfo {
 	var exports []ExportInfo
 	var currentPath string
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
 			continue
@@ -101,7 +101,8 @@ func parseExports(output string) []ExportInfo {
 		switch {
 		case !indented && len(fields) >= 2:
 			// path and client on same line
-			client := unwrapBrackets(strings.SplitN(fields[1], "(", 2)[0])
+			raw, _, _ := strings.Cut(fields[1], "(")
+			client := unwrapBrackets(raw)
 			exports = append(exports, ExportInfo{Path: fields[0], Client: client})
 			currentPath = ""
 		case !indented:
@@ -109,7 +110,8 @@ func parseExports(output string) []ExportInfo {
 			currentPath = fields[0]
 		case currentPath != "":
 			// indented client line
-			client := unwrapBrackets(strings.SplitN(fields[0], "(", 2)[0])
+			raw, _, _ := strings.Cut(fields[0], "(")
+			client := unwrapBrackets(raw)
 			exports = append(exports, ExportInfo{Path: currentPath, Client: client})
 			currentPath = ""
 		}

--- a/agent/storage/usage.go
+++ b/agent/storage/usage.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -32,7 +33,18 @@ func (s *Storage) startUsageUpdater(ctx context.Context, mgr *btrfs.Manager, int
 }
 
 func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant string) {
+	start := time.Now()
 	log.Debug().Str("tenant", tenant).Msg("usage updater: starting scan")
+
+	// bulk-fetch qgroup usage: 2 btrfs commands total instead of 2*N
+	var usageMap map[string]btrfs.QgroupInfo
+	if s.quotaEnabled {
+		var err error
+		usageMap, err = mgr.QgroupUsageBulk(ctx, s.mountPoint)
+		if err != nil {
+			log.Warn().Err(err).Str("tenant", tenant).Msg("usage updater: bulk qgroup query failed, skipping usage updates")
+		}
+	}
 
 	var updated, failed, count int
 	s.volumes.Range(func(t, name string, cached *VolumeMetadata) bool {
@@ -67,14 +79,15 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 
 		// detect usage drift
 		var used uint64
-		if meta.QuotaBytes > 0 {
-			u, err := mgr.QgroupUsage(ctx, dataDir)
-			if err != nil {
-				log.Warn().Err(err).Str("volume", name).Msg("usage updater: qgroup query failed, skipping volume - if issue persists check your quotas")
+		if meta.QuotaBytes > 0 && usageMap != nil {
+			relPath, _ := filepath.Rel(s.mountPoint, dataDir)
+			if qi, ok := usageMap[relPath]; ok {
+				used = qi.Referenced
+			} else {
+				log.Warn().Str("volume", name).Str("path", relPath).Msg("usage updater: volume not found in bulk qgroup data")
 				failed++
 				return true
 			}
-			used = u
 			if used != meta.UsedBytes {
 				changed = true
 			}
@@ -115,7 +128,7 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 	})
 
 	VolumesGauge.WithLabelValues(tenant).Set(float64(count))
-	log.Info().Str("tenant", tenant).Int("volumes", count).Int("updated", updated).Int("failed", failed).Msg("usage updater: volume scan complete")
+	log.Info().Str("tenant", tenant).Int("volumes", count).Int("updated", updated).Int("failed", failed).Str("took", time.Since(start).String()).Msg("usage updater: scan complete")
 
 	// update snapshot usage
 	var snapUpdated, snapFailed, snapCount int
@@ -126,20 +139,25 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 		snapCount++
 
 		dataDir := s.snapshots.DataPath(tenant, name)
-		info, err := mgr.QgroupUsageEx(ctx, dataDir)
-		if err != nil {
-			log.Warn().Err(err).Str("snapshot", name).Msg("usage updater: snapshot qgroup query failed")
+
+		if usageMap == nil {
+			return true
+		}
+		relPath, _ := filepath.Rel(s.mountPoint, dataDir)
+		qi, ok := usageMap[relPath]
+		if !ok {
+			log.Warn().Str("snapshot", name).Str("path", relPath).Msg("usage updater: snapshot not found in bulk qgroup data")
 			snapFailed++
 			return true
 		}
 
-		if info.Referenced == cached.UsedBytes && info.Exclusive == cached.ExclusiveBytes {
+		if qi.Referenced == cached.UsedBytes && qi.Exclusive == cached.ExclusiveBytes {
 			return true
 		}
 
 		if _, err := s.snapshots.Update(tenant, name, func(m *SnapshotMetadata) {
-			m.UsedBytes = info.Referenced
-			m.ExclusiveBytes = info.Exclusive
+			m.UsedBytes = qi.Referenced
+			m.ExclusiveBytes = qi.Exclusive
 			m.UpdatedAt = time.Now().UTC()
 		}); err != nil {
 			log.Error().Err(err).Str("snapshot", name).Msg("usage updater: failed to write snapshot metadata")

--- a/agent/storage/usage_test.go
+++ b/agent/storage/usage_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -20,16 +21,32 @@ import (
 
 // --- utils ---
 
-// qgroupRunFn returns a RunFn that responds to btrfs subvolume show + qgroup show.
-func qgroupRunFn(referenced, exclusive uint64) func([]string) (string, error) {
+// bulkRunFn builds a mock RunFn for QgroupUsageBulk. entries maps relative
+// subvolume paths (e.g. "tenant/vol1/data") to [referenced, exclusive] pairs.
+// The generated output is deterministic (sorted by path).
+func bulkRunFn(entries map[string][2]uint64) func([]string) (string, error) {
+	paths := make([]string, 0, len(entries))
+	for p := range entries {
+		paths = append(paths, p)
+	}
+	slices.Sort(paths)
+
+	var listLines, qgroupLines []string
+	id := 256
+	for _, path := range paths {
+		usage := entries[path]
+		listLines = append(listLines, fmt.Sprintf("ID %d gen 10 top level 5 path %s", id, path))
+		qgroupLines = append(qgroupLines, fmt.Sprintf("0/%d\t%d\t%d", id, usage[0], usage[1]))
+		id++
+	}
+	listOut := strings.Join(listLines, "\n")
+	qgroupOut := strings.Join(qgroupLines, "\n")
+
 	return func(args []string) (string, error) {
-		if len(args) >= 1 && args[0] == "subvolume" {
-			return "Subvolume ID:\t\t\t256\n", nil
+		if slices.Contains(args, "list") {
+			return listOut, nil
 		}
-		if len(args) >= 1 && args[0] == "qgroup" {
-			return fmt.Sprintf("0/256\t%d\t%d\n", referenced, exclusive), nil
-		}
-		return "", fmt.Errorf("unexpected command: %v", args)
+		return qgroupOut, nil
 	}
 }
 
@@ -49,9 +66,10 @@ func usageTestStorage(t *testing.T, tenant string) (*Storage, string) {
 	require.NoError(t, os.MkdirAll(tenantPath, 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(tenantPath, config.SnapshotsDir), 0o755))
 	s := &Storage{
-		basePath:  base,
-		volumes:   meta.NewStore[VolumeMetadata](base),
-		snapshots: meta.NewStore[SnapshotMetadata](base, config.SnapshotsDir),
+		basePath:   base,
+		mountPoint: base,
+		volumes:    meta.NewStore[VolumeMetadata](base),
+		snapshots:  meta.NewStore[SnapshotMetadata](base, config.SnapshotsDir),
 	}
 	return s, tenantPath
 }
@@ -112,10 +130,13 @@ func TestUpdateAllEmpty(t *testing.T) {
 func TestUpdateAllNoChanges(t *testing.T) {
 	tenant := "nochange"
 	uid, gid := os.Getuid(), os.Getgid()
-	runner := &utils.MockRunner{RunFn: qgroupRunFn(1024, 512)}
+	runner := &utils.MockRunner{RunFn: bulkRunFn(map[string][2]uint64{
+		tenant + "/vol1/data": {1024, 512},
+	})}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 	initialTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	volDir := setupUsageVol(t, s, tp, tenant, "vol1", VolumeMetadata{
 		Name:       "vol1",
@@ -135,7 +156,7 @@ func TestUpdateAllNoChanges(t *testing.T) {
 	assert.Equal(t, gid, meta.GID)
 	assert.Equal(t, "755", meta.Mode)
 	assert.Equal(t, uint64(1024), meta.UsedBytes)
-	assert.Len(t, runner.Calls, 2, "QgroupUsage should still be called (subvolume show + qgroup show)")
+	assert.Len(t, runner.Calls, 2, "QgroupUsageBulk should make exactly 2 calls (subvolume list + qgroup show)")
 	cleanupMetrics(t, tenant, "vol1")
 }
 
@@ -189,10 +210,13 @@ func TestUpdateAllModeDrift(t *testing.T) {
 func TestUpdateAllUsageDrift(t *testing.T) {
 	tenant := "usagedrift"
 	uid, gid := os.Getuid(), os.Getgid()
-	runner := &utils.MockRunner{RunFn: qgroupRunFn(2048, 1024)}
+	runner := &utils.MockRunner{RunFn: bulkRunFn(map[string][2]uint64{
+		tenant + "/vol1/data": {2048, 1024},
+	})}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 	volDir := setupUsageVol(t, s, tp, tenant, "vol1", VolumeMetadata{
 		Name:       "vol1",
 		UID:        uid,
@@ -230,28 +254,18 @@ func TestUpdateAllNoQuota(t *testing.T) {
 	cleanupMetrics(t, tenant, "vol1")
 }
 
-func TestUpdateAllQgroupError(t *testing.T) {
+func TestUpdateAllQgroupMissing(t *testing.T) {
 	tenant := "qgerr"
 	uid, gid := os.Getuid(), os.Getgid()
 
-	runFn := func(args []string) (string, error) {
-		path := args[len(args)-1]
-		if strings.Contains(path, "/vol1/") {
-			return "", fmt.Errorf("qgroup error")
-		}
-		if args[0] == "subvolume" {
-			return "Subvolume ID:\t\t\t256\n", nil
-		}
-		if args[0] == "qgroup" {
-			return "0/256\t2048\t1024\n", nil
-		}
-		return "", fmt.Errorf("unexpected: %v", args)
-	}
-
-	runner := &utils.MockRunner{RunFn: runFn}
+	// vol1 is missing from qgroup results, vol2 is present
+	runner := &utils.MockRunner{RunFn: bulkRunFn(map[string][2]uint64{
+		tenant + "/vol2/data": {2048, 1024},
+	})}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 	setupUsageVol(t, s, tp, tenant, "vol1", VolumeMetadata{
 		Name:       "vol1",
 		UID:        uid,
@@ -272,16 +286,44 @@ func TestUpdateAllQgroupError(t *testing.T) {
 	s.updateAll(context.Background(), mgr, tenant)
 
 	meta2 := readVolumeMeta(t, volDir2)
-	assert.Equal(t, uint64(2048), meta2.UsedBytes, "vol2 should be updated despite vol1 qgroup error")
+	assert.Equal(t, uint64(2048), meta2.UsedBytes, "vol2 should be updated despite vol1 missing from qgroup data")
 	cleanupMetrics(t, tenant, "vol1", "vol2")
+}
+
+func TestUpdateAllBulkError(t *testing.T) {
+	tenant := "bulkerr"
+	uid, gid := os.Getuid(), os.Getgid()
+
+	runner := &utils.MockRunner{Err: fmt.Errorf("bulk qgroup failed")}
+	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
+
+	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
+	volDir := setupUsageVol(t, s, tp, tenant, "vol1", VolumeMetadata{
+		Name:       "vol1",
+		UID:        uid,
+		GID:        gid,
+		Mode:       "755",
+		QuotaBytes: 4096,
+		UsedBytes:  100,
+	})
+
+	s.updateAll(context.Background(), mgr, tenant)
+
+	meta := readVolumeMeta(t, volDir)
+	assert.Equal(t, uint64(100), meta.UsedBytes, "UsedBytes should be unchanged when bulk query fails")
+	cleanupMetrics(t, tenant, "vol1")
 }
 
 func TestUpdateAllSnapshots(t *testing.T) {
 	tenant := "snaps"
-	runner := &utils.MockRunner{RunFn: qgroupRunFn(2048, 512)}
+	runner := &utils.MockRunner{RunFn: bulkRunFn(map[string][2]uint64{
+		tenant + "/snapshots/snap1/data": {2048, 512},
+	})}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 	snapDir := setupUsageSnap(t, s, tp, tenant, "snap1", SnapshotMetadata{
 		Name:           "snap1",
 		Volume:         "vol1",
@@ -300,10 +342,13 @@ func TestUpdateAllSnapshots(t *testing.T) {
 
 func TestUpdateAllSnapshotNoChanges(t *testing.T) {
 	tenant := "snapnoch"
-	runner := &utils.MockRunner{RunFn: qgroupRunFn(1024, 512)}
+	runner := &utils.MockRunner{RunFn: bulkRunFn(map[string][2]uint64{
+		tenant + "/snapshots/snap1/data": {1024, 512},
+	})}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 	initialTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	snapDir := setupUsageSnap(t, s, tp, tenant, "snap1", SnapshotMetadata{
 		Name:           "snap1",
@@ -322,10 +367,11 @@ func TestUpdateAllSnapshotNoChanges(t *testing.T) {
 
 func TestUpdateAllSnapshotQgroupError(t *testing.T) {
 	tenant := "snaperr"
-	runner := &utils.MockRunner{Err: fmt.Errorf("qgroup error")}
+	runner := &utils.MockRunner{Err: fmt.Errorf("bulk qgroup failed")}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 	snapDir := setupUsageSnap(t, s, tp, tenant, "snap1", SnapshotMetadata{
 		Name:           "snap1",
 		Volume:         "vol1",
@@ -365,10 +411,14 @@ func TestUpdateAllNoSnapshotsDir(t *testing.T) {
 func TestUpdateAllMetrics(t *testing.T) {
 	tenant := "metrics"
 	uid, gid := os.Getuid(), os.Getgid()
-	runner := &utils.MockRunner{RunFn: qgroupRunFn(500, 200)}
+	runner := &utils.MockRunner{RunFn: bulkRunFn(map[string][2]uint64{
+		tenant + "/vol1/data": {500, 200},
+		tenant + "/vol2/data": {500, 200},
+	})}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 	setupUsageVol(t, s, tp, tenant, "vol1", VolumeMetadata{
 		Name:       "vol1",
 		UID:        uid,
@@ -393,16 +443,21 @@ func TestUpdateAllMetrics(t *testing.T) {
 	assert.Equal(t, float64(8192), testutil.ToFloat64(VolumeSizeBytes.WithLabelValues(tenant, "vol2")))
 	assert.Equal(t, float64(500), testutil.ToFloat64(VolumeUsedBytes.WithLabelValues(tenant, "vol1")))
 	assert.Equal(t, float64(500), testutil.ToFloat64(VolumeUsedBytes.WithLabelValues(tenant, "vol2")))
+	assert.Len(t, runner.Calls, 2, "should make exactly 2 btrfs calls regardless of volume count")
 	cleanupMetrics(t, tenant, "vol1", "vol2")
 }
 
 func TestUpdateAllStatError(t *testing.T) {
 	tenant := "staterr"
 	uid, gid := os.Getuid(), os.Getgid()
-	runner := &utils.MockRunner{RunFn: qgroupRunFn(2048, 1024)}
+	runner := &utils.MockRunner{RunFn: bulkRunFn(map[string][2]uint64{
+		tenant + "/vol1/data": {2048, 1024},
+		tenant + "/vol2/data": {2048, 1024},
+	})}
 	mgr := btrfs.NewManagerWithRunner("btrfs", runner)
 
 	s, tp := usageTestStorage(t, tenant)
+	s.quotaEnabled = true
 
 	// vol1: no data/ dir, os.Stat fails -- but must be in cache
 	seedVolume(t, s, tenant, tp, VolumeMetadata{Name: "vol1", QuotaBytes: 4096})

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -119,7 +119,7 @@ func ImmutableLabelKeys(extra string) []string {
 			seen[k] = true
 		}
 	}
-	for _, k := range strings.Split(extra, ",") {
+	for k := range strings.SplitSeq(extra, ",") {
 		k = strings.TrimSpace(k)
 		if k != "" && !seen[k] {
 			keys = append(keys, k)

--- a/cmd/btrfs-nfs-csi/flags.go
+++ b/cmd/btrfs-nfs-csi/flags.go
@@ -40,7 +40,7 @@ func splitLabelsFlag(cmd *cli.Command) []string {
 	raw := cmd.StringSlice("label")
 	var out []string
 	for _, entry := range raw {
-		for _, part := range strings.Split(entry, ",") {
+		for part := range strings.SplitSeq(entry, ",") {
 			if p := strings.TrimSpace(part); p != "" {
 				out = append(out, p)
 			}

--- a/cmd/btrfs-nfs-csi/task.go
+++ b/cmd/btrfs-nfs-csi/task.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -77,7 +77,7 @@ func genericResultSummary(result json.RawMessage) string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
 		parts = append(parts, fmt.Sprintf("%s: %v", k, m[k]))

--- a/cmd/btrfs-nfs-csi/utils.go
+++ b/cmd/btrfs-nfs-csi/utils.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -44,7 +45,7 @@ func formatLabels(labels map[string]string) string {
 	for k, v := range labels {
 		parts = append(parts, k+"="+v)
 	}
-	sort.Strings(parts)
+	slices.Sort(parts)
 	return strings.Join(parts, ", ")
 }
 
@@ -57,7 +58,7 @@ func printLabels(header string, labels map[string]string, indent int) {
 	for k := range labels {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	for i, k := range keys {
 		if i == 0 {
 			fmt.Printf("%-*s%s=%s\n", indent, header, k, labels[k])
@@ -82,7 +83,7 @@ func formatLabelsShort(labels map[string]string) string {
 		}
 		rest = append(rest, k+"="+v)
 	}
-	sort.Strings(rest)
+	slices.Sort(rest)
 	parts = append(parts, rest...)
 	s := strings.Join(parts, ", ")
 	if len(s) > 48 {
@@ -154,7 +155,7 @@ func newTableWriter(cmd *cli.Command, all []string) *tableWriter {
 			avail[key] = col
 		}
 		var filtered []string
-		for _, r := range strings.Split(raw, ",") {
+		for r := range strings.SplitSeq(raw, ",") {
 			key := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(r), " ", ""))
 			if col, ok := avail[key]; ok {
 				filtered = append(filtered, col)
@@ -197,166 +198,166 @@ func (tw *tableWriter) flush() {
 }
 
 func sortVolumes(vols []models.VolumeResponse, field string, reverse bool) {
-	sort.Slice(vols, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(vols, func(a, b models.VolumeResponse) int {
+		var c int
 		switch field {
 		case sortSize:
-			less = vols[i].SizeBytes < vols[j].SizeBytes
+			c = cmp.Compare(a.SizeBytes, b.SizeBytes)
 		case sortUsed:
-			less = vols[i].UsedBytes < vols[j].UsedBytes
+			c = cmp.Compare(a.UsedBytes, b.UsedBytes)
 		case sortUsedPct:
-			less = usedPct(vols[i].UsedBytes, vols[i].SizeBytes) < usedPct(vols[j].UsedBytes, vols[j].SizeBytes)
+			c = cmp.Compare(usedPct(a.UsedBytes, a.SizeBytes), usedPct(b.UsedBytes, b.SizeBytes))
 		case sortCreated:
-			less = vols[i].CreatedAt.Before(vols[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		case sortExports:
-			less = vols[i].Exports < vols[j].Exports
+			c = cmp.Compare(a.Exports, b.Exports)
 		default:
-			less = vols[i].Name < vols[j].Name
+			c = cmp.Compare(a.Name, b.Name)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 
 func sortVolumesDetail(vols []models.VolumeDetailResponse, field string, reverse bool) {
-	sort.Slice(vols, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(vols, func(a, b models.VolumeDetailResponse) int {
+		var c int
 		switch field {
 		case sortSize:
-			less = vols[i].SizeBytes < vols[j].SizeBytes
+			c = cmp.Compare(a.SizeBytes, b.SizeBytes)
 		case sortUsed:
-			less = vols[i].UsedBytes < vols[j].UsedBytes
+			c = cmp.Compare(a.UsedBytes, b.UsedBytes)
 		case sortUsedPct:
-			less = usedPct(vols[i].UsedBytes, vols[i].SizeBytes) < usedPct(vols[j].UsedBytes, vols[j].SizeBytes)
+			c = cmp.Compare(usedPct(a.UsedBytes, a.SizeBytes), usedPct(b.UsedBytes, b.SizeBytes))
 		case sortCreated:
-			less = vols[i].CreatedAt.Before(vols[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		case sortExports:
-			less = len(vols[i].Exports) < len(vols[j].Exports)
+			c = cmp.Compare(len(a.Exports), len(b.Exports))
 		default:
-			less = vols[i].Name < vols[j].Name
+			c = cmp.Compare(a.Name, b.Name)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 
 func sortSnapshots(snaps []models.SnapshotResponse, field string, reverse bool) {
-	sort.Slice(snaps, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(snaps, func(a, b models.SnapshotResponse) int {
+		var c int
 		switch field {
 		case sortSize:
-			less = snaps[i].SizeBytes < snaps[j].SizeBytes
+			c = cmp.Compare(a.SizeBytes, b.SizeBytes)
 		case sortUsed:
-			less = snaps[i].UsedBytes < snaps[j].UsedBytes
+			c = cmp.Compare(a.UsedBytes, b.UsedBytes)
 		case sortCreated:
-			less = snaps[i].CreatedAt.Before(snaps[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		case sortVolume:
-			less = snaps[i].Volume < snaps[j].Volume
+			c = cmp.Compare(a.Volume, b.Volume)
 		default:
-			less = snaps[i].Name < snaps[j].Name
+			c = cmp.Compare(a.Name, b.Name)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 
 func sortSnapshotsDetail(snaps []models.SnapshotDetailResponse, field string, reverse bool) {
-	sort.Slice(snaps, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(snaps, func(a, b models.SnapshotDetailResponse) int {
+		var c int
 		switch field {
 		case sortSize:
-			less = snaps[i].SizeBytes < snaps[j].SizeBytes
+			c = cmp.Compare(a.SizeBytes, b.SizeBytes)
 		case sortUsed:
-			less = snaps[i].UsedBytes < snaps[j].UsedBytes
+			c = cmp.Compare(a.UsedBytes, b.UsedBytes)
 		case sortCreated:
-			less = snaps[i].CreatedAt.Before(snaps[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		case sortVolume:
-			less = snaps[i].Volume < snaps[j].Volume
+			c = cmp.Compare(a.Volume, b.Volume)
 		default:
-			less = snaps[i].Name < snaps[j].Name
+			c = cmp.Compare(a.Name, b.Name)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 
 func sortExportsList(exports []models.ExportResponse, field string, reverse bool) {
-	sort.Slice(exports, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(exports, func(a, b models.ExportResponse) int {
+		var c int
 		switch field {
 		case "client":
-			less = exports[i].Client < exports[j].Client
+			c = cmp.Compare(a.Client, b.Client)
 		case sortCreated:
-			less = exports[i].CreatedAt.Before(exports[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		default:
-			less = exports[i].Name < exports[j].Name
+			c = cmp.Compare(a.Name, b.Name)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 
 func sortExportsDetailList(exports []models.ExportDetailResponse, field string, reverse bool) {
-	sort.Slice(exports, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(exports, func(a, b models.ExportDetailResponse) int {
+		var c int
 		switch field {
 		case "client":
-			less = exports[i].Client < exports[j].Client
+			c = cmp.Compare(a.Client, b.Client)
 		case sortCreated:
-			less = exports[i].CreatedAt.Before(exports[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		default:
-			less = exports[i].Name < exports[j].Name
+			c = cmp.Compare(a.Name, b.Name)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 
 func sortTasks(tasks []models.TaskResponse, field string, reverse bool) {
-	sort.Slice(tasks, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(tasks, func(a, b models.TaskResponse) int {
+		var c int
 		switch field {
 		case sortType:
-			less = tasks[i].Type < tasks[j].Type
+			c = cmp.Compare(a.Type, b.Type)
 		case sortStatus:
-			less = tasks[i].Status < tasks[j].Status
+			c = cmp.Compare(a.Status, b.Status)
 		default:
-			less = tasks[i].CreatedAt.Before(tasks[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 
 func sortTasksDetail(tasks []models.TaskDetailResponse, field string, reverse bool) {
-	sort.Slice(tasks, func(i, j int) bool {
-		var less bool
+	slices.SortFunc(tasks, func(a, b models.TaskDetailResponse) int {
+		var c int
 		switch field {
 		case sortType:
-			less = tasks[i].Type < tasks[j].Type
+			c = cmp.Compare(a.Type, b.Type)
 		case sortStatus:
-			less = tasks[i].Status < tasks[j].Status
+			c = cmp.Compare(a.Status, b.Status)
 		default:
-			less = tasks[i].CreatedAt.Before(tasks[j].CreatedAt)
+			c = a.CreatedAt.Compare(b.CreatedAt)
 		}
 		if reverse {
-			return !less
+			return -c
 		}
-		return less
+		return c
 	})
 }
 

--- a/cmd/btrfs-nfs-csi/utils.go
+++ b/cmd/btrfs-nfs-csi/utils.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
-	"cmp"
 	"slices"
 	"strings"
 	"text/tabwriter"

--- a/integrations/kubernetes/controller/pvc.go
+++ b/integrations/kubernetes/controller/pvc.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -178,7 +178,7 @@ func mergeUserLabels(dst, user map[string]string, maxUser int) (skippedKeys []st
 	for k := range user {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	merged := 0
 	truncated := false
@@ -209,7 +209,7 @@ func mergeUserLabels(dst, user map[string]string, maxUser int) (skippedKeys []st
 
 func parseLabels(raw string) map[string]string {
 	labels := make(map[string]string)
-	for _, pair := range strings.Split(raw, ",") {
+	for pair := range strings.SplitSeq(raw, ",") {
 		pair = strings.TrimSpace(pair)
 		if pair == "" {
 			continue

--- a/integrations/kubernetes/controller/volumes.go
+++ b/integrations/kubernetes/controller/volumes.go
@@ -1,8 +1,8 @@
 package controller
 
 import (
-	"context"
 	"cmp"
+	"context"
 	"slices"
 	"time"
 

--- a/integrations/kubernetes/controller/volumes.go
+++ b/integrations/kubernetes/controller/volumes.go
@@ -2,7 +2,8 @@ package controller
 
 import (
 	"context"
-	"sort"
+	"cmp"
+	"slices"
 	"time"
 
 	agentclient "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/client"
@@ -26,7 +27,7 @@ func sortedAgents(agents map[string]*agentclient.Client) []agentEntry {
 	for sc, c := range agents {
 		entries = append(entries, agentEntry{sc: sc, client: c})
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].sc < entries[j].sc })
+	slices.SortFunc(entries, func(a, b agentEntry) int { return cmp.Compare(a.sc, b.sc) })
 	return entries
 }
 

--- a/integrations/kubernetes/csiserver/utils.go
+++ b/integrations/kubernetes/csiserver/utils.go
@@ -10,11 +10,11 @@ func MakeVolumeID(storageClass, name string) string {
 }
 
 func ParseVolumeID(id string) (storageClass, name string, err error) {
-	parts := strings.SplitN(id, VolumeIDSep, 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	sc, n, ok := strings.Cut(id, VolumeIDSep)
+	if !ok || sc == "" || n == "" {
 		return "", "", fmt.Errorf("invalid volume ID: %s", id)
 	}
-	return parts[0], parts[1], nil
+	return sc, n, nil
 }
 
 func MakeNodeID(hostname, ip string) string {
@@ -22,9 +22,9 @@ func MakeNodeID(hostname, ip string) string {
 }
 
 func ParseNodeID(nodeID string) (hostname, ip string, err error) {
-	parts := strings.SplitN(nodeID, NodeIDSep, 2)
-	if len(parts) != 2 || parts[1] == "" {
+	h, i, ok := strings.Cut(nodeID, NodeIDSep)
+	if !ok || i == "" {
 		return "", "", fmt.Errorf("invalid node ID %q (expected hostname%sip)", nodeID, NodeIDSep)
 	}
-	return parts[0], parts[1], nil
+	return h, i, nil
 }

--- a/utils/mount.go
+++ b/utils/mount.go
@@ -21,7 +21,7 @@ func FindMountPoint(path string) (string, error) {
 	}
 
 	var bestMount string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 5 {
 			continue

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -44,16 +44,16 @@ func IsValidCompression(s string) bool {
 	if s == "" || s == "none" {
 		return true
 	}
-	parts := strings.SplitN(s, ":", 2)
-	maxLevel, ok := compressionMaxLevel[parts[0]]
+	algo, levelStr, hasLevel := strings.Cut(s, ":")
+	maxLevel, ok := compressionMaxLevel[algo]
 	if !ok {
 		return false
 	}
-	if len(parts) == 2 {
+	if hasLevel {
 		if maxLevel == 0 {
 			return false
 		}
-		level, err := strconv.Atoi(parts[1])
+		level, err := strconv.Atoi(levelStr)
 		if err != nil || level < 1 || level > maxLevel {
 			return false
 		}


### PR DESCRIPTION
## Summary
- Replace per-volume `QgroupUsage`/`QgroupUsageEx` calls in the usage updater with a single `QgroupUsageBulk` that runs `btrfs subvolume list -o` and `btrfs qgroup show -re --raw` once, joins by subvolume ID, and returns a map keyed by relative path. Reduces 2*(N+M) btrfs shell-outs per interval to 2.
- Refactor `QgroupUsageEx` and `SubvolumeList` to reuse the new `parseQgroupMap` and `parseSubvolumeListFull` parsers instead of duplicating parsing logic. Also fixes a latent bug in `SubvolumeList` where `parts[8]` would break on paths containing spaces.
- Add `took` duration to the usage updater scan log message.
- Modernize string/sort APIs across the codebase: `strings.Split` -> `strings.SplitSeq`, `strings.SplitN`/`strings.Index` -> `strings.Cut`/`strings.CutPrefix`, `sort.Slice` -> `slices.SortFunc`, `sort.Strings` -> `slices.Sort`, `fmt.Sscanf` -> `strconv.ParseUint`.