### PR TITLE
Backfill volume labels on ControllerPublishVolume, document upgrade path

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -168,24 +168,13 @@ features are additive, the Kubernetes integration is fully backwards compatible.
 
 There are a few things to be aware of after upgrading:
 
-- **Volume labels:** Volumes created before v0.10.0 have no labels. Labels are
-  backfilled automatically when pods are rescheduled (`ControllerPublishVolume`
-  sets `created-by`, `kubernetes.pvc.name`, `kubernetes.pvc.namespace`, and
-  `kubernetes.pvc.storageclassname`). No manual action required, labels appear
-  gradually as pods restart (rolling updates, node drains, pod evictions).
-- **Snapshot labels:** Snapshots created before v0.10.0 will not have labels.
-  This is purely cosmetic, they continue to work for restores and clones.
-- **Stale NFS exports:** The export model changed from a simple client IP list
-  to reference-counted exports with labels. Pre-0.10.0 exports are migrated
-  automatically but may leave orphaned entries. Volumes with stale exports
-  cannot be deleted by the controller (the agent returns "busy"). If this
-  happens, you will see it in the PVC events and controller logs. To clean up:
+- **Volume labels**, Volumes created before v0.10.0 have no labels. Labels are backfilled automatically when pods are rescheduled (`ControllerPublishVolume` sets `created-by`, `kubernetes.pvc.name`, `kubernetes.pvc.namespace`, and `kubernetes.pvc.storageclassname`). No manual action required, labels appear gradually as pods restart (rolling updates, node drains, pod evictions).
+- **Snapshot labels**, Snapshots created before v0.10.0 will not have labels. This is purely cosmetic, they continue to work for restores and clones.
+- **Stale NFS exports**, The export model changed from a simple client IP list to reference-counted exports with labels. Pre-0.10.0 exports are migrated automatically but may leave orphaned entries. Volumes with stale exports cannot be deleted by the controller (the agent returns "busy"). If this happens, you will see it in the PVC events and controller logs. To clean up:
   1. Scale down or delete the workloads using the affected volumes.
   2. Wait ~3 minutes until the VolumeAttachments are fully removed.
-  3. Remove the stale exports: `btrfs-nfs-csi export list`, then
-     `btrfs-nfs-csi export remove <volume> <client>` for each stale entry.
-  4. Scale your workloads back up. The controller will create fresh exports
-     with the new reference-counted model.
+  3. Remove the stale exports: `btrfs-nfs-csi export list`, then `btrfs-nfs-csi export remove <volume> <client>` for each stale entry.
+  4. Scale your workloads back up. The controller will create fresh exports with the new reference-counted model.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -158,22 +158,34 @@ so much we can build on top of this, this release is the new foundation for a mu
 
 ## Upgrade Guide
 
-### Setting `created-by` on pre-0.10.0 volumes
+### A note to existing Kubernetes users
 
-Volumes created before v0.10.0 have no `created-by` label. The v0.10.0 agent
-allows setting this label once via update if it was previously empty. After it
-is set, it becomes immutable like on any new volume.
+This release adds a lot of new surface area (CLI, REST API, task system, labels)
+and lays the groundwork for integrations beyond Kubernetes. If you are using
+btrfs-nfs-csi purely as a CSI driver, nothing changes for you. Your Helm values,
+StorageClasses, PVCs, and snapshots continue to work exactly as before. The new
+features are additive, the Kubernetes integration is fully backwards compatible.
 
-> **Note:** If you are using the Kubernetes CSI driver integration, set the
-> value to `k8s` to match the identity used by the controller. If you used
-> the agent without the CSI driver, set it to any value that identifies your
-> integration (e.g. `cli`, `nomad`, `custom`). In the future you can also use
-> the `AGENT_CSI_IDENTITY` env var to configure the identity for new resources.
+There are a few things to be aware of after upgrading:
 
-Placeholder for release...
-
-NFS exports are re-created on each publish and will already carry the correct
-`created-by` label after upgrading the controller, no manual action needed.
+- **Volume labels:** Volumes created before v0.10.0 have no labels. Labels are
+  backfilled automatically when pods are rescheduled (`ControllerPublishVolume`
+  sets `created-by`, `kubernetes.pvc.name`, `kubernetes.pvc.namespace`, and
+  `kubernetes.pvc.storageclassname`). No manual action required, labels appear
+  gradually as pods restart (rolling updates, node drains, pod evictions).
+- **Snapshot labels:** Snapshots created before v0.10.0 will not have labels.
+  This is purely cosmetic, they continue to work for restores and clones.
+- **Stale NFS exports:** The export model changed from a simple client IP list
+  to reference-counted exports with labels. Pre-0.10.0 exports are migrated
+  automatically but may leave orphaned entries. Volumes with stale exports
+  cannot be deleted by the controller (the agent returns "busy"). If this
+  happens, you will see it in the PVC events and controller logs. To clean up:
+  1. Scale down or delete the workloads using the affected volumes.
+  2. Wait ~3 minutes until the VolumeAttachments are fully removed.
+  3. Remove the stale exports: `btrfs-nfs-csi export list`, then
+     `btrfs-nfs-csi export remove <volume> <client>` for each stale entry.
+  4. Scale your workloads back up. The controller will create fresh exports
+     with the new reference-counted model.
 
 ---
 

--- a/integrations/kubernetes/controller/pvc.go
+++ b/integrations/kubernetes/controller/pvc.go
@@ -118,9 +118,10 @@ func (s *Server) resolveVolumeParams(ctx context.Context, params map[string]stri
 	scName := ptr.Deref(pvc.Spec.StorageClassName, "")
 	vp.StorageClass = scName
 	vp.Labels = map[string]string{
-		labelPVCName:         pvcName,
-		labelPVCNamespace:    pvcNamespace,
-		labelPVCStorageClass: scName,
+		labelPVCName:          pvcName,
+		labelPVCNamespace:     pvcNamespace,
+		labelPVCStorageClass:  scName,
+		config.LabelCreatedBy: config.IdentityK8sController,
 	}
 	for k, v := range envDefaultLabels {
 		if _, exists := vp.Labels[k]; !exists {


### PR DESCRIPTION
## Summary
- Include `created-by: k8s` in `resolveVolumeParams()` so that `ControllerPublishVolume` backfills labels (`created-by`, `kubernetes.pvc.*`) on pre-0.10.0 volumes when pods are rescheduled
- Rewrite the upgrade guide in RELEASE.md with a clear note to existing K8s users, covering volume labels, snapshot labels, and stale NFS export cleanup

## E2E Tested
- Deployed 0.9.11 on hcloud (agent + k3s), created volumes, snapshots, wrote data
- Upgraded to 0.10.0, verified volumes/snapshots/data intact
- Confirmed pre-upgrade volumes have no labels
- Deleted pod + VolumeAttachment, recreated pod, verified labels backfilled via ControllerPublishVolume
- Verified `protectImmutableLabels` migration exception allows initial `created-by` set
- Rollback 0.10.0 -> 0.9.11 -> 0.10.0 cycle, data survives
