### PR TITLE
Fix Kubernetes docs: labels, metrics, timeouts, NixOS kubeletDir

### DIFF
--- a/docs/integrations/kubernetes/README.md
+++ b/docs/integrations/kubernetes/README.md
@@ -72,6 +72,22 @@ spec:
 
 ReadWriteMany is the default. Every volume is an NFS export.
 
+## NixOS
+
+NixOS kubelet uses `/var/lib/kubernetes` as its root directory instead of `/var/lib/kubelet`. Set `kubeletDir` in your Helm values:
+
+```yaml
+kubeletDir: /var/lib/kubernetes
+```
+
+Or via `--set`:
+
+```bash
+helm install btrfs-nfs-csi --set kubeletDir=/var/lib/kubernetes ...
+```
+
+For static manifests, replace `/var/lib/kubelet` with `/var/lib/kubernetes` in all hostPath volumes.
+
 ## Dedicated Storage Network
 
 If your nodes have a separate storage NIC, add to `values.yaml`:

--- a/docs/integrations/kubernetes/configuration.md
+++ b/docs/integrations/kubernetes/configuration.md
@@ -67,8 +67,11 @@ On snapshots:
 
 | Label | Value |
 |---|---|
+| `kubernetes.pv.name` | PV name |
+| `kubernetes.pv.storageclassname` | StorageClass name |
 | `kubernetes.source.pvc.name` | Source PVC name |
 | `kubernetes.source.pvc.namespace` | Source PVC namespace |
+| `kubernetes.source.pvc.storageclassname` | Source StorageClass name |
 | `kubernetes.snapshot.name` | VolumeSnapshot name |
 | `kubernetes.snapshot.namespace` | VolumeSnapshot namespace |
 | `created-by` | `k8s` |
@@ -78,9 +81,11 @@ On NFS exports:
 | Label | Value |
 |---|---|
 | `kubernetes.pv.name` | PV name |
-| `kubernetes.pvc.name` | PVC name |
+| `kubernetes.pv.storageclassname` | StorageClass name |
 | `kubernetes.node.name` | Node hostname |
 | `kubernetes.volumeattachment.name` | VolumeAttachment name |
+| `kubernetes.pvc.name` | PVC name (if available) |
+| `kubernetes.pvc.namespace` | PVC namespace (if available) |
 | `created-by` | `k8s` |
 
 Clones always receive `clone.source.type` and `clone.source.name` automatically. All `kubernetes.*` and `clone.*` keys are reserved and cannot be overridden via annotations. Max 8 user labels, max 32 total.

--- a/docs/integrations/kubernetes/metrics.md
+++ b/docs/integrations/kubernetes/metrics.md
@@ -17,7 +17,7 @@ See also: [Agent metrics](../../metrics.md) for agent Prometheus metrics and Pro
 | Operation | Status |
 |---|---|
 | `create_volume` | `success`, `error`, `conflict` |
-| `delete_volume` | `success`, `error`, `not_found` |
+| `delete_volume` | `success`, `error`, `not_found`, `busy` |
 | `create_snapshot` | `success`, `error`, `conflict` |
 | `delete_snapshot` | `success`, `error`, `not_found` |
 | `create_clone` | `success`, `error`, `conflict` |
@@ -31,7 +31,7 @@ See also: [Agent metrics](../../metrics.md) for agent Prometheus metrics and Pro
 
 **Buckets (agent_duration):** `[0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]`
 
-## Node (7) - port 9090
+## Node (5) - port 9090
 
 | Metric | Type | Labels |
 |---|---|---|
@@ -41,7 +41,7 @@ See also: [Agent metrics](../../metrics.md) for agent Prometheus metrics and Pro
 | `btrfs_nfs_csi_node_mount_duration_seconds` | Histogram | `operation` |
 | `btrfs_nfs_csi_node_volume_stats_ops_total` | Counter | `status` |
 
-**Mount operations:** `nfs_mount`, `bind_mount`, `umount`, `force_umount`, `remount_ro`
+**Mount operations:** `nfs_mount`, `bind_mount`, `umount`, `remount_ro`
 
 **Buckets (grpc_request_duration):** `[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]`
 
@@ -55,9 +55,6 @@ sum(rate(btrfs_nfs_csi_controller_agent_ops_total{status="error"}[5m]))
 
 # NFS mount failures
 rate(btrfs_nfs_csi_node_mount_ops_total{operation="nfs_mount",status="error"}[5m])
-
-# Force unmounts (stuck mounts)
-increase(btrfs_nfs_csi_node_mount_ops_total{operation="force_umount"}[1h])
 
 # Agent health check errors
 rate(btrfs_nfs_csi_controller_agent_ops_total{operation="health_check",status="error"}[5m])

--- a/docs/integrations/kubernetes/operations.md
+++ b/docs/integrations/kubernetes/operations.md
@@ -106,6 +106,6 @@ ControllerPublish creates an export with K8s metadata labels, NodeStage mounts v
 
 Exports are [reference-counted per client IP](../../operations.md#nfs-exports).
 
-**Retries:** Controller retries export/unexport 3x with 3s timeout each.
+**Timeouts:** Export/unexport calls have a 10s context timeout. On failure, Kubernetes retries the operation.
 
-**Mount timeouts:** NFS/bind mount 2min, unmount falls back to `umount -f`.
+**Mounts:** Uses `k8s.io/mount-utils` for all mount/unmount operations, including stale NFS mount detection (ESTALE, EACCES, EIO) and force unmount fallback (30s timeout).


### PR DESCRIPTION
## Summary
- Fix incorrect retry/timeout claims in operations.md (no retries, 10s timeout, k8s.io/mount-utils)
- Fix node metrics count (5, not 7) and remove phantom `force_umount` operation
- Add missing `busy` status for `delete_volume` metric
- Document missing export labels (`kubernetes.pv.storageclassname`, conditional `pvc.name`/`pvc.namespace`)
- Document missing snapshot labels (`kubernetes.pv.name`, `kubernetes.pv.storageclassname`, `kubernetes.source.pvc.storageclassname`)
- Add NixOS `kubeletDir` section for `/var/lib/kubernetes` (#130)