### PR TITLE
Serialize concurrent same-name creates to prevent 500s and metadata loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Major feature release. The agent is now a multi-purpose storage backend with a s
 - Update release workflow to trigger on version tags (#120)
 
 ### Bug Fixes
+- Serialize concurrent same-name creates to prevent 500s and metadata loss
 - Harden driver defaults (#116)
 - Fixed CI workflows (#110)
 

--- a/agent/api/v1/handler_snapshot.go
+++ b/agent/api/v1/handler_snapshot.go
@@ -53,6 +53,7 @@ func snapshotDetailResponseFrom(meta *storage.SnapshotMetadata) models.SnapshotD
 // @Success      201 {object} models.SnapshotDetailResponse
 // @Failure      400 {object} models.ErrorResponse
 // @Failure      409 {object} models.SnapshotDetailResponse "Snapshot already exists"
+// @Failure      423 {object} models.ErrorResponse "Lock contention, retry"
 // @Router       /v1/snapshots [post]
 // @Security     BearerAuth
 func (h *Handler) CreateSnapshot(c *echo.Context) error {

--- a/agent/api/v1/handler_volume.go
+++ b/agent/api/v1/handler_volume.go
@@ -62,6 +62,7 @@ func volumeDetailResponseFrom(meta *storage.VolumeMetadata) models.VolumeDetailR
 // @Success      201 {object} models.VolumeDetailResponse
 // @Failure      400 {object} models.ErrorResponse
 // @Failure      409 {object} models.VolumeDetailResponse "Volume already exists"
+// @Failure      423 {object} models.ErrorResponse "Lock contention, retry"
 // @Router       /v1/volumes [post]
 // @Security     BearerAuth
 func (h *Handler) CreateVolume(c *echo.Context) error {
@@ -196,6 +197,7 @@ func (h *Handler) DeleteVolume(c *echo.Context) error {
 // @Success      201 {object} models.VolumeDetailResponse
 // @Failure      400 {object} models.ErrorResponse
 // @Failure      409 {object} models.VolumeDetailResponse "Volume already exists"
+// @Failure      423 {object} models.ErrorResponse "Lock contention, retry"
 // @Router       /v1/volumes/clone [post]
 // @Security     BearerAuth
 func (h *Handler) CloneVolume(c *echo.Context) error {
@@ -227,6 +229,7 @@ func (h *Handler) CloneVolume(c *echo.Context) error {
 // @Success      201 {object} models.VolumeDetailResponse
 // @Failure      400 {object} models.ErrorResponse
 // @Failure      409 {object} models.VolumeDetailResponse "Volume already exists"
+// @Failure      423 {object} models.ErrorResponse "Lock contention, retry"
 // @Router       /v1/clones [post]
 // @Security     BearerAuth
 func (h *Handler) CreateClone(c *echo.Context) error {

--- a/agent/api/v1/swagger/docs.go
+++ b/agent/api/v1/swagger/docs.go
@@ -82,6 +82,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse"
                         }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -246,6 +252,12 @@ const docTemplate = `{
                         "description": "Snapshot already exists",
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.SnapshotDetailResponse"
+                        }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
                         }
                     }
                 }
@@ -652,6 +664,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse"
                         }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -702,6 +720,12 @@ const docTemplate = `{
                         "description": "Volume already exists",
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse"
+                        }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
                         }
                     }
                 }

--- a/agent/api/v1/swagger/swagger.json
+++ b/agent/api/v1/swagger/swagger.json
@@ -71,6 +71,12 @@
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse"
                         }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -235,6 +241,12 @@
                         "description": "Snapshot already exists",
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.SnapshotDetailResponse"
+                        }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
                         }
                     }
                 }
@@ -641,6 +653,12 @@
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse"
                         }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -691,6 +709,12 @@
                         "description": "Volume already exists",
                         "schema": {
                             "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse"
+                        }
+                    },
+                    "423": {
+                        "description": "Lock contention, retry",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse"
                         }
                     }
                 }

--- a/agent/api/v1/swagger/swagger.yaml
+++ b/agent/api/v1/swagger/swagger.yaml
@@ -662,6 +662,10 @@ paths:
           description: Volume already exists
           schema:
             $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse'
+        "423":
+          description: Lock contention, retry
+          schema:
+            $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Create a clone from snapshot
@@ -770,6 +774,10 @@ paths:
           description: Snapshot already exists
           schema:
             $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.SnapshotDetailResponse'
+        "423":
+          description: Lock contention, retry
+          schema:
+            $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Create a snapshot
@@ -1029,6 +1037,10 @@ paths:
           description: Volume already exists
           schema:
             $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse'
+        "423":
+          description: Lock contention, retry
+          schema:
+            $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Create a volume
@@ -1255,6 +1267,10 @@ paths:
           description: Volume already exists
           schema:
             $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.VolumeDetailResponse'
+        "423":
+          description: Lock contention, retry
+          schema:
+            $ref: '#/definitions/github_com_erikmagkekse_btrfs-nfs-csi_agent_api_v1_models.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Clone a volume

--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -53,6 +53,11 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 		}
 	}
 	cloneDir := s.volumes.Dir(tenant, req.Name)
+
+	// Serialize concurrent creators of the same name (see CreateVolume).
+	unlock := s.volumes.Lock(tenant, req.Name)
+	defer unlock()
+
 	if existing, err := s.volumes.Get(tenant, req.Name); err == nil {
 		return existing, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("clone %q already exists", req.Name)}
 	}
@@ -60,14 +65,18 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 	// operations
 	if err := os.MkdirAll(cloneDir, s.defaultDirMode); err != nil {
 		log.Error().Err(err).Msg("failed to create clone directory")
-		return nil, fmt.Errorf("failed to create clone directory: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("failed to create clone directory: %v", err)}
 	}
 
 	dstData := s.volumes.DataPath(tenant, req.Name)
 	if err := s.btrfs.SubvolumeSnapshot(ctx, srcData, dstData, false); err != nil {
+		if isSubvolumeAlreadyExistsError(err) {
+			log.Warn().Err(err).Str("path", dstData).Msg("clone target already exists on disk")
+			return nil, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("clone %q already exists on disk", req.Name)}
+		}
 		_ = os.RemoveAll(cloneDir)
 		log.Error().Err(err).Msg("failed to create clone")
-		return nil, fmt.Errorf("btrfs snapshot failed: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("btrfs snapshot failed: %v", err)}
 	}
 
 	if s.quotaEnabled && srcVol.QuotaBytes > 0 {

--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -55,7 +55,10 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 	cloneDir := s.volumes.Dir(tenant, req.Name)
 
 	// Serialize concurrent creators of the same name (see CreateVolume).
-	unlock := s.volumes.Lock(tenant, req.Name)
+	unlock, err := s.volumes.Lock(ctx, tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrBusy, Message: fmt.Sprintf("lock contention for clone %q: %v", req.Name, err)}
+	}
 	defer unlock()
 
 	if existing, err := s.volumes.Get(tenant, req.Name); err == nil {

--- a/agent/storage/meta/store.go
+++ b/agent/storage/meta/store.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -124,18 +125,21 @@ func (s *Store[T]) Store(tenant, name string, val *T) error {
 // name are serialized and the losers observe the winner's cache entry
 // on their second Get. Uses the same refcounted path mutex pool as
 // Update, so Create and Update on the same entry are mutually exclusive.
-func (s *Store[T]) Lock(tenant, name string) func() {
-	diskPath := s.MetaPath(tenant, name)
-	rm := pathLock(diskPath)
-	return func() { pathUnlock(diskPath, rm) }
+//
+// Lock respects ctx: if the caller's context is canceled or times out
+// while waiting for a stuck predecessor, Lock returns ctx.Err() instead
+// of blocking indefinitely. Callers should translate this to a
+// user-visible BUSY error.
+func (s *Store[T]) Lock(ctx context.Context, tenant, name string) (func(), error) {
+	return pathLockCtx(ctx, s.MetaPath(tenant, name))
 }
 
 // Update performs a read-modify-write with per-path locking.
 // Reads from cache (disk fallback), applies fn, writes to disk, updates cache.
 func (s *Store[T]) Update(tenant, name string, fn func(*T)) (*T, error) {
 	diskPath := s.MetaPath(tenant, name)
-	rm := pathLock(diskPath)
-	defer pathUnlock(diskPath, rm)
+	release := pathLock(diskPath)
+	defer release()
 
 	val, err := s.Get(tenant, name)
 	if err != nil {
@@ -182,32 +186,71 @@ func (s *Store[T]) Exists(tenant, name string) bool {
 	return ok
 }
 
-// per-path mutex pool for serializing read-modify-write operations
+// per-path mutex pool for serializing read-modify-write operations.
+//
+// refMutex uses a buffered channel of size 1 as a semaphore instead of
+// sync.Mutex, so waiters can select on context cancellation. A non-nil
+// token in the channel means "unlocked"; Lock drains, Unlock refills.
 var (
 	locksMu  sync.Mutex
 	locksMap = map[string]*refMutex{}
 )
 
 type refMutex struct {
-	mu   sync.Mutex
+	ch   chan struct{}
 	refs int
 }
 
-func pathLock(path string) *refMutex {
+// pathLockShared bumps refcount and returns (or creates) the refMutex for path.
+func pathLockShared(path string) *refMutex {
 	locksMu.Lock()
 	rm, ok := locksMap[path]
 	if !ok {
-		rm = &refMutex{}
+		rm = &refMutex{ch: make(chan struct{}, 1)}
+		rm.ch <- struct{}{} // start in the unlocked state
 		locksMap[path] = rm
 	}
 	rm.refs++
 	locksMu.Unlock()
-	rm.mu.Lock()
 	return rm
 }
 
-func pathUnlock(path string, rm *refMutex) {
-	rm.mu.Unlock()
+// makeRelease returns the unlock closure that refills the semaphore and
+// drops the refcount. Order matters: the chan refill must happen before
+// releaseRef so any waiter observes the free state before the entry can
+// be garbage-collected from locksMap.
+func makeRelease(path string, rm *refMutex) func() {
+	return func() {
+		rm.ch <- struct{}{}
+		releaseRef(path, rm)
+	}
+}
+
+// pathLock blocks until the per-path semaphore is acquired. Used by Update
+// and other callers that do not have a cancellable context.
+func pathLock(path string) func() {
+	rm := pathLockShared(path)
+	<-rm.ch
+	return makeRelease(path, rm)
+}
+
+// pathLockCtx blocks until the per-path semaphore is acquired or ctx is
+// done, whichever happens first. On ctx cancellation the refcount is
+// decremented so the map does not leak, and the caller receives ctx.Err().
+func pathLockCtx(ctx context.Context, path string) (func(), error) {
+	rm := pathLockShared(path)
+	select {
+	case <-rm.ch:
+		return makeRelease(path, rm), nil
+	case <-ctx.Done():
+		releaseRef(path, rm)
+		return nil, ctx.Err()
+	}
+}
+
+// releaseRef drops one reference to rm and removes it from locksMap when
+// the last waiter is gone. Caller must NOT hold locksMu.
+func releaseRef(path string, rm *refMutex) {
 	locksMu.Lock()
 	rm.refs--
 	if rm.refs == 0 {

--- a/agent/storage/meta/store.go
+++ b/agent/storage/meta/store.go
@@ -116,6 +116,20 @@ func (s *Store[T]) Store(tenant, name string, val *T) error {
 	return nil
 }
 
+// Lock acquires the exclusive per-entry lock used by Update, and returns
+// an unlock function the caller must invoke (typically via defer).
+//
+// Create-style callers should hold this lock across their cache check,
+// filesystem operations, and Store, so concurrent creators of the same
+// name are serialized and the losers observe the winner's cache entry
+// on their second Get. Uses the same refcounted path mutex pool as
+// Update, so Create and Update on the same entry are mutually exclusive.
+func (s *Store[T]) Lock(tenant, name string) func() {
+	diskPath := s.MetaPath(tenant, name)
+	rm := pathLock(diskPath)
+	return func() { pathUnlock(diskPath, rm) }
+}
+
 // Update performs a read-modify-write with per-path locking.
 // Reads from cache (disk fallback), applies fn, writes to disk, updates cache.
 func (s *Store[T]) Update(tenant, name string, fn func(*T)) (*T, error) {

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -34,6 +34,10 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	}
 	srcData := s.volumes.DataPath(tenant, req.Volume)
 
+	// Serialize concurrent creators of the same snapshot name (see CreateVolume).
+	unlock := s.snapshots.Lock(tenant, req.Name)
+	defer unlock()
+
 	if existing, err := s.snapshots.Get(tenant, req.Name); err == nil {
 		return existing, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("snapshot %q already exists", req.Name)}
 	}
@@ -42,14 +46,18 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	// operations
 	if err := os.MkdirAll(snapDir, s.defaultDirMode); err != nil {
 		log.Error().Err(err).Msg("failed to create snapshot directory")
-		return nil, fmt.Errorf("failed to create snapshot directory: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("failed to create snapshot directory: %v", err)}
 	}
 
 	dstData := s.snapshots.DataPath(tenant, req.Name)
 	if err := s.btrfs.SubvolumeSnapshot(ctx, srcData, dstData, true); err != nil {
+		if isSubvolumeAlreadyExistsError(err) {
+			log.Warn().Err(err).Str("path", dstData).Msg("snapshot target already exists on disk")
+			return nil, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("snapshot %q already exists on disk", req.Name)}
+		}
 		_ = os.RemoveAll(snapDir)
 		log.Error().Err(err).Msg("failed to create snapshot")
-		return nil, fmt.Errorf("btrfs snapshot failed: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("btrfs snapshot failed: %v", err)}
 	}
 
 	now := time.Now().UTC()

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -35,7 +35,10 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	srcData := s.volumes.DataPath(tenant, req.Volume)
 
 	// Serialize concurrent creators of the same snapshot name (see CreateVolume).
-	unlock := s.snapshots.Lock(tenant, req.Name)
+	unlock, err := s.snapshots.Lock(ctx, tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrBusy, Message: fmt.Sprintf("lock contention for snapshot %q: %v", req.Name, err)}
+	}
 	defer unlock()
 
 	if existing, err := s.snapshots.Get(tenant, req.Name); err == nil {

--- a/agent/storage/utils.go
+++ b/agent/storage/utils.go
@@ -29,6 +29,17 @@ type StorageError struct {
 
 func (e *StorageError) Error() string { return e.Message }
 
+// isSubvolumeAlreadyExistsError reports whether a btrfs subvolume create or
+// snapshot error indicates that the target path already exists. The btrfs CLI
+// does not expose a stable error code, so we match on its stderr string.
+// Used by Create paths as defense-in-depth: the per-name lock should prevent
+// concurrent creators from racing here, but stale on-disk state left over
+// from a crashed previous run can still cause EEXIST, and we want to return
+// 409 ALREADY_EXISTS in that case, not 500 INTERNAL_ERROR.
+func isSubvolumeAlreadyExistsError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "target path already exists")
+}
+
 func requireImmutableLabels(keys []string, labels map[string]string) error {
 	for _, k := range keys {
 		if labels[k] == "" {

--- a/agent/storage/utils_test.go
+++ b/agent/storage/utils_test.go
@@ -21,9 +21,10 @@ import (
 
 // --- test utils for storage operations ---
 
-// testStorageWithRunner creates a Storage with a configurable MockRunner and MockExporter.
+// testStorageWithRunner creates a Storage with a configurable Runner and MockExporter.
 // Sets defaultDataMode to "2770" (matching the default agent config).
-func testStorageWithRunner(t *testing.T, runner *utils.MockRunner, exporter *nfs.MockExporter) (*Storage, string) {
+// Accepts any utils.Runner so concurrent tests can supply a thread-safe runner.
+func testStorageWithRunner(t *testing.T, runner utils.Runner, exporter *nfs.MockExporter) (*Storage, string) {
 	t.Helper()
 	base := t.TempDir()
 	t.Cleanup(func() {

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -60,7 +60,11 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 	// Serialize concurrent creators of the same name. Losers block here and
 	// then observe the winner's cache entry on the Get below, returning a
 	// clean ALREADY_EXISTS instead of racing into btrfs.SubvolumeCreate.
-	unlock := s.volumes.Lock(tenant, req.Name)
+	// Lock honours ctx so a stuck predecessor cannot pin a caller forever.
+	unlock, err := s.volumes.Lock(ctx, tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrBusy, Message: fmt.Sprintf("lock contention for volume %q: %v", req.Name, err)}
+	}
 	defer unlock()
 
 	if existing, err := s.volumes.Get(tenant, req.Name); err == nil {
@@ -353,7 +357,10 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 	cloneDir := s.volumes.Dir(tenant, req.Name)
 
 	// Serialize concurrent creators of the same name (see CreateVolume).
-	unlock := s.volumes.Lock(tenant, req.Name)
+	unlock, err := s.volumes.Lock(ctx, tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrBusy, Message: fmt.Sprintf("lock contention for volume %q: %v", req.Name, err)}
+	}
 	defer unlock()
 
 	if existing, err := s.volumes.Get(tenant, req.Name); err == nil {

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -57,13 +57,19 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 	volDir := s.volumes.Dir(tenant, req.Name)
 	dataDir := s.volumes.DataPath(tenant, req.Name)
 
+	// Serialize concurrent creators of the same name. Losers block here and
+	// then observe the winner's cache entry on the Get below, returning a
+	// clean ALREADY_EXISTS instead of racing into btrfs.SubvolumeCreate.
+	unlock := s.volumes.Lock(tenant, req.Name)
+	defer unlock()
+
 	if existing, err := s.volumes.Get(tenant, req.Name); err == nil {
 		return existing, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("volume %q already exists", req.Name)}
 	}
 
 	if err := os.MkdirAll(volDir, s.defaultDirMode); err != nil {
 		log.Error().Err(err).Str("path", volDir).Msg("failed to create volume directory")
-		return nil, fmt.Errorf("create volume directory: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("create volume directory: %v", err)}
 	}
 
 	cleanup := func() {
@@ -76,9 +82,17 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 	}
 
 	if err := s.btrfs.SubvolumeCreate(ctx, dataDir); err != nil {
+		if isSubvolumeAlreadyExistsError(err) {
+			// Stale on-disk state from a prior crash that never made it into
+			// the cache. Do NOT touch volDir - it may belong to a concurrent
+			// creator that we do not know about (should not happen under the
+			// per-name lock, but be defensive).
+			log.Warn().Err(err).Str("path", dataDir).Msg("subvolume already exists on disk")
+			return nil, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("volume %q already exists on disk", req.Name)}
+		}
 		_ = os.RemoveAll(volDir)
 		log.Error().Err(err).Str("path", dataDir).Msg("failed to create subvolume")
-		return nil, fmt.Errorf("btrfs subvolume create failed: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("btrfs subvolume create failed: %v", err)}
 	}
 
 	if req.NoCOW {
@@ -337,12 +351,17 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 	}
 
 	cloneDir := s.volumes.Dir(tenant, req.Name)
+
+	// Serialize concurrent creators of the same name (see CreateVolume).
+	unlock := s.volumes.Lock(tenant, req.Name)
+	defer unlock()
+
 	if existing, err := s.volumes.Get(tenant, req.Name); err == nil {
 		return existing, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("volume %q already exists", req.Name)}
 	}
 
 	if err := os.MkdirAll(cloneDir, s.defaultDirMode); err != nil {
-		return nil, fmt.Errorf("create clone directory: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("create clone directory: %v", err)}
 	}
 
 	srcData := s.volumes.DataPath(tenant, req.Source)
@@ -358,8 +377,12 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 	}
 
 	if err := s.btrfs.SubvolumeSnapshot(ctx, srcData, cloneData, false); err != nil {
+		if isSubvolumeAlreadyExistsError(err) {
+			log.Warn().Err(err).Str("path", cloneData).Msg("clone target already exists on disk")
+			return nil, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("volume %q already exists on disk", req.Name)}
+		}
 		cleanup()
-		return nil, fmt.Errorf("btrfs snapshot failed: %w", err)
+		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("btrfs snapshot failed: %v", err)}
 	}
 
 	if s.quotaEnabled {

--- a/agent/storage/volume_test.go
+++ b/agent/storage/volume_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/nfs"
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
@@ -267,6 +268,34 @@ func TestCreateVolume(t *testing.T) {
 		// On-disk metadata must not have been destroyed by a loser's RemoveAll.
 		ondisk := readVolumeMeta(t, filepath.Join(bp, "racevol"))
 		assert.Equal(t, "racevol", ondisk.Name)
+	})
+
+	t.Run("ctx_cancel_while_locked", func(t *testing.T) {
+		// A stuck predecessor must not pin the caller forever: ctx fires,
+		// CreateVolume returns ErrBusy (HTTP 423), no hung goroutine.
+		runner := &btrfsSimRunner{}
+		exporter := &nfs.MockExporter{}
+		s, _ := testStorageWithRunner(t, runner, exporter)
+
+		unlock, err := s.volumes.Lock(context.Background(), "test", "stuckvol")
+		require.NoError(t, err)
+		defer unlock()
+
+		callCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err = s.CreateVolume(callCtx, "test", VolumeCreateRequest{
+			Name:      "stuckvol",
+			SizeBytes: 1 << 20,
+		})
+		elapsed := time.Since(start)
+
+		require.Error(t, err, "must not block forever")
+		assert.True(t, isStorageCode(err, ErrBusy),
+			"expected ErrBusy, got: %v", err)
+		assert.Less(t, elapsed, 500*time.Millisecond,
+			"caller must return promptly after ctx deadline, took %s", elapsed)
 	})
 
 	t.Run("cleanup_on_nocow_failure", func(t *testing.T) {

--- a/agent/storage/volume_test.go
+++ b/agent/storage/volume_test.go
@@ -2,10 +2,13 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/nfs"
@@ -210,6 +213,60 @@ func TestCreateVolume(t *testing.T) {
 
 		_, statErr := os.Stat(filepath.Join(bp, "failvol"))
 		assert.True(t, os.IsNotExist(statErr), "volDir should be cleaned up after failure")
+	})
+
+	t.Run("concurrent_same_name", func(t *testing.T) {
+		// Reproduces the TOCTOU race in CreateVolume: the cache check at
+		// the top cannot prevent concurrent goroutines from racing into
+		// btrfs.SubvolumeCreate. On broken code the losers come back with
+		// INTERNAL_ERROR (wrapped fmt.Errorf) instead of ALREADY_EXISTS,
+		// and the loser's destructive os.RemoveAll(volDir) may clobber the
+		// winner's metadata. After the fix, exactly one creator wins and
+		// all others return ALREADY_EXISTS with the winner state intact.
+		runner := &btrfsSimRunner{}
+		exporter := &nfs.MockExporter{}
+		s, bp := testStorageWithRunner(t, runner, exporter)
+
+		const N = 50
+		req := VolumeCreateRequest{
+			Name:      "racevol",
+			SizeBytes: 1 << 20,
+		}
+
+		var (
+			wg                             sync.WaitGroup
+			successes, conflicts, internal atomic.Int64
+		)
+		for range N {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := s.CreateVolume(ctx, "test", req)
+				switch {
+				case err == nil:
+					successes.Add(1)
+				case isStorageCode(err, ErrAlreadyExists):
+					conflicts.Add(1)
+				default:
+					internal.Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(t, int64(1), successes.Load(), "exactly one creator must win")
+		assert.Equal(t, int64(N-1), conflicts.Load(), "all losers must return ALREADY_EXISTS")
+		assert.Equal(t, int64(0), internal.Load(), "no INTERNAL_ERROR allowed")
+
+		// Winner's state must be intact and readable via the cache.
+		meta, err := s.GetVolume("test", "racevol")
+		require.NoError(t, err, "winner's volume must be readable")
+		assert.Equal(t, "racevol", meta.Name)
+		assert.EqualValues(t, 1<<20, meta.SizeBytes)
+
+		// On-disk metadata must not have been destroyed by a loser's RemoveAll.
+		ondisk := readVolumeMeta(t, filepath.Join(bp, "racevol"))
+		assert.Equal(t, "racevol", ondisk.Name)
 	})
 
 	t.Run("cleanup_on_nocow_failure", func(t *testing.T) {
@@ -658,4 +715,39 @@ func TestDeleteVolume(t *testing.T) {
 		require.Error(t, err, "delete should fail for corrupt metadata")
 		assert.Contains(t, err.Error(), "failed to read volume metadata")
 	})
+}
+
+// --- concurrent test helpers ---
+
+// isStorageCode reports whether err unwraps to a *StorageError with the given code.
+func isStorageCode(err error, code string) bool {
+	var se *StorageError
+	if !errors.As(err, &se) {
+		return false
+	}
+	return se.Code == code
+}
+
+// btrfsSimRunner is a thread-safe fake btrfs runner for concurrent tests.
+// It uses os.Mkdir for "subvolume create", which is atomic at the filesystem
+// level and faithfully reproduces real btrfs EEXIST semantics on race.
+// Unlike MockRunner it records no call history, so it is safe under -race.
+type btrfsSimRunner struct{}
+
+func (r *btrfsSimRunner) Run(_ context.Context, _ string, args ...string) (string, error) {
+	if len(args) >= 3 && args[0] == "subvolume" && args[1] == "create" {
+		path := args[2]
+		if err := os.Mkdir(path, 0o755); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				return "", fmt.Errorf("exit status 1: ERROR: target path already exists: %s", path)
+			}
+			return "", err
+		}
+		return "", nil
+	}
+	if len(args) >= 3 && args[0] == "subvolume" && args[1] == "delete" {
+		_ = os.RemoveAll(args[2])
+		return "", nil
+	}
+	return "", nil
 }


### PR DESCRIPTION
## Summary
- Fix TOCTOU race in `CreateVolume`, `CreateSnapshot`, `CreateClone`, and `CloneVolume`: the initial cache check did not prevent two concurrent requests for the same name from both reaching `btrfs subvolume create`. Losers destroyed the winner's `metadata.json` via `os.RemoveAll` and returned bare errors that the API layer mapped to HTTP 500 instead of 409.
- Expose `Store.Lock(tenant, name)` in `agent/storage/meta/store.go`, reusing the existing `pathLock` refcounted mutex pool, and hold it across the cache check, filesystem ops, and metadata write in all four Create paths. Losers now see the winner's entry on their second Get and return `ALREADY_EXISTS` cleanly.
- Add `isSubvolumeAlreadyExistsError` defense-in-depth in `agent/storage/utils.go`: if stale on-disk state survives a crashed previous run and `btrfs subvolume create`/`snapshot` returns "target path already exists", translate to `StorageError{Code: ErrAlreadyExists}` (HTTP 409) instead of clobbering on-disk state and returning 500.
- Replace remaining bare `fmt.Errorf` returns on Create error paths with structured `StorageError` values so the HTTP mapping in `agent/api/v1/utils.go` returns the correct status code.
