### PR TITLE
Harden tenant auth: constant-time compare, reserve internal names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.1 (unreleased)
+
+### Security
+- Constant-time token comparison in the agent auth middleware, replacing the map lookup
+- Reserve internal directory names (`tasks`, `snapshots`, `data`, `metadata`, case-insensitive) as invalid tenant names; `AGENT_TENANTS` is now validated at boot before any filesystem operations
+
 ## v0.10.0
 
 Major feature release. The agent is now a multi-purpose storage backend with a standalone CLI, REST API, task system, and label-based multi-tenancy. 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -37,7 +37,10 @@ func NewAgent(cfg *config.AgentConfig, version, commit string) (*Agent, error) {
 	}
 
 	// parse tenants
-	tenants := parseTenants(cfg.Tenants)
+	tenants, err := parseTenants(cfg.Tenants)
+	if err != nil {
+		return nil, err
+	}
 	if tenants == nil {
 		return nil, fmt.Errorf("AGENT_TENANTS must contain at least one valid name:token pair")
 	}
@@ -165,22 +168,28 @@ func (a *Agent) Start(ctx context.Context) {
 }
 
 // parseTenants parses "name:token,name:token" into map[token]name.
-// Returns nil if input is empty.
-func parseTenants(s string) map[string]string {
+// Returns nil map if input is empty. Returns an error if any tenant name
+// is invalid or reserved, so misconfiguration fails before any filesystem
+// operations are attempted.
+func parseTenants(s string) (map[string]string, error) {
 	if s == "" {
-		return nil
+		return nil, nil
 	}
 	m := make(map[string]string)
 	for entry := range strings.SplitSeq(s, ",") {
 		name, tok, ok := strings.Cut(strings.TrimSpace(entry), ":")
-		if ok {
-			name = strings.TrimSpace(name)
-			tok = strings.TrimSpace(tok)
-			m[tok] = name
+		if !ok {
+			continue
 		}
+		name = strings.TrimSpace(name)
+		tok = strings.TrimSpace(tok)
+		if err := config.ValidateTenantName(name); err != nil {
+			return nil, fmt.Errorf("AGENT_TENANTS: %w", err)
+		}
+		m[tok] = name
 	}
 	if len(m) == 0 {
-		return nil
+		return nil, nil
 	}
-	return m
+	return m, nil
 }

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
 	"net/http"
 	"strings"
@@ -43,7 +44,7 @@ func AuthMiddleware(tenants map[string]string) echo.MiddlewareFunc {
 				return authFailed(c, "unsupported auth scheme: "+scheme)
 			}
 
-			tenant, ok := tenants[providedToken]
+			tenant, ok := lookupTenant(tenants, providedToken)
 			if !ok {
 				return authFailed(c, "invalid token")
 			}
@@ -52,6 +53,23 @@ func AuthMiddleware(tenants map[string]string) echo.MiddlewareFunc {
 			return next(c)
 		}
 	}
+}
+
+// lookupTenant resolves a provided token to a tenant name using a constant-time
+// comparison. It always iterates over every configured tenant so that neither
+// the match position nor the presence of a match is observable via timing.
+func lookupTenant(tenants map[string]string, provided string) (string, bool) {
+	providedBytes := []byte(provided)
+	var matched string
+	var found int
+	for token, name := range tenants {
+		eq := subtle.ConstantTimeCompare([]byte(token), providedBytes)
+		if eq == 1 {
+			matched = name
+		}
+		found |= eq
+	}
+	return matched, found == 1
 }
 
 func authFailed(c *echo.Context, reason string) error {

--- a/agent/api/v1/middleware_test.go
+++ b/agent/api/v1/middleware_test.go
@@ -102,3 +102,75 @@ func TestAuthMiddleware_ValidToken(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "mytenant", gotTenant)
 }
+
+func TestAuthMiddleware_ValidToken_MultipleTenants(t *testing.T) {
+	tenants := map[string]string{
+		"token-a": "alpha",
+		"token-b": "bravo",
+		"token-c": "charlie",
+	}
+	mw := AuthMiddleware(tenants)
+
+	cases := []struct {
+		token      string
+		wantTenant string
+	}{
+		{"token-a", "alpha"},
+		{"token-b", "bravo"},
+		{"token-c", "charlie"},
+	}
+
+	for _, tc := range cases {
+		e := echo.New()
+		var gotTenant string
+		handler := mw(func(c *echo.Context) error {
+			gotTenant = c.Get("tenant").(string)
+			return c.NoContent(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/volumes", nil)
+		req.Header.Set("Authorization", "Bearer "+tc.token)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		require.NoError(t, handler(c))
+		assert.Equal(t, http.StatusOK, rec.Code, "token %q", tc.token)
+		assert.Equal(t, tc.wantTenant, gotTenant, "token %q", tc.token)
+	}
+}
+
+func TestAuthMiddleware_EmptyTenants(t *testing.T) {
+	mw := AuthMiddleware(nil)
+
+	e := echo.New()
+	handler := mw(func(c *echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/volumes", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestLookupTenant_NoMatchWithSimilarLengthToken(t *testing.T) {
+	tenants := map[string]string{
+		"token-a": "alpha",
+		"token-b": "bravo",
+	}
+
+	matched, ok := lookupTenant(tenants, "token-x")
+	assert.False(t, ok)
+	assert.Empty(t, matched)
+
+	matched, ok = lookupTenant(tenants, "")
+	assert.False(t, ok)
+	assert.Empty(t, matched)
+
+	matched, ok = lookupTenant(tenants, "token-a")
+	assert.True(t, ok)
+	assert.Equal(t, "alpha", matched)
+}

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -90,8 +90,8 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 	}
 
 	for _, name := range tenants {
-		if err := config.ValidateName(name); err != nil {
-			log.Fatal().Str("tenant", name).Msg("invalid tenant name")
+		if err := config.ValidateTenantName(name); err != nil {
+			log.Fatal().Err(err).Str("tenant", name).Msg("invalid tenant name")
 		}
 		td := filepath.Join(basePath, name)
 		if err := os.MkdirAll(td, os.FileMode(parsedDirMode)); err != nil {

--- a/agent/storage/utils_test.go
+++ b/agent/storage/utils_test.go
@@ -186,6 +186,39 @@ func TestValidateName(t *testing.T) {
 	}
 }
 
+func TestValidateTenantName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple", "mytenant", false},
+		{"with_hyphen", "tenant-a", false},
+		{"default", "default", false},
+		{"reserved_tasks", "tasks", true},
+		{"reserved_snapshots", "snapshots", true},
+		{"reserved_data", "data", true},
+		{"reserved_metadata", "metadata", true},
+		{"reserved_uppercase", "TASKS", true},
+		{"reserved_mixedcase", "Snapshots", true},
+		{"invalid_regex_dot", "has.dot", true},
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := config.ValidateTenantName(tt.input)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var ve *config.ValidationError
+			require.ErrorAs(t, err, &ve)
+		})
+	}
+}
+
 func TestValidateClientIP(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"regexp"
+	"slices"
+	"strings"
 	"time"
 )
 
@@ -26,6 +28,24 @@ const (
 	LabelCloneSourceName = "clone.source.name"
 )
 
+const (
+	DataDir      = "data"
+	MetadataFile = "metadata.json"
+	SnapshotsDir = "snapshots"
+	TasksDir     = "tasks"
+)
+
+// ReservedTenantNames collide with directory names the agent creates or may
+// create directly under AGENT_BASE_PATH. Tenant names are compared
+// case-insensitively because btrfs on Linux is case-sensitive but users
+// would otherwise be surprised by a mixed-case bypass.
+var ReservedTenantNames = []string{TasksDir, SnapshotsDir, DataDir, "metadata"}
+
+// SoftReservedLabelKeys are managed automatically (identity, clone source tracking).
+// Cannot be set via K8s annotations or CLI flags. Agent API consumers should use v1.Client
+// which handles these automatically.
+var SoftReservedLabelKeys = []string{LabelCreatedBy, LabelCloneSourceType, LabelCloneSourceName}
+
 // ValidationError is returned by ValidateName and ValidateLabels.
 // Consumers can type-assert to distinguish validation errors from other errors.
 type ValidationError struct {
@@ -37,6 +57,16 @@ func (e *ValidationError) Error() string { return e.Message }
 func ValidateName(name string) error {
 	if !ValidName.MatchString(name) {
 		return &ValidationError{Message: fmt.Sprintf("invalid name: %q (must be 1-128 chars, only a-z A-Z 0-9 _ -)", name)}
+	}
+	return nil
+}
+
+func ValidateTenantName(name string) error {
+	if err := ValidateName(name); err != nil {
+		return err
+	}
+	if slices.Contains(ReservedTenantNames, strings.ToLower(name)) {
+		return &ValidationError{Message: fmt.Sprintf("tenant name %q is reserved", name)}
 	}
 	return nil
 }
@@ -55,18 +85,6 @@ func ValidateLabels(labels map[string]string) error {
 	}
 	return nil
 }
-
-// SoftReservedLabelKeys are managed automatically (identity, clone source tracking).
-// Cannot be set via K8s annotations or CLI flags. Agent API consumers should use v1.Client
-// which handles these automatically.
-var SoftReservedLabelKeys = []string{LabelCreatedBy, LabelCloneSourceType, LabelCloneSourceName}
-
-const (
-	DataDir      = "data"
-	MetadataFile = "metadata.json"
-	SnapshotsDir = "snapshots"
-	TasksDir     = "tasks"
-)
 
 type AgentConfig struct {
 	BasePath               string        `env:"AGENT_BASE_PATH" envDefault:"./storage"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 | Variable | Default | Description |
 |---|---|---|
 | `AGENT_BASE_PATH` | `./storage` | btrfs mount point (quickstart sets `/export/data`) |
-| `AGENT_TENANTS` | **required** | `name:token,name:token` |
+| `AGENT_TENANTS` | **required** | `name:token,name:token`. Reserved names: `tasks`, `snapshots`, `data`, `metadata`. |
 | `AGENT_LISTEN_ADDR` | `:8080` | HTTP listen address |
 | `AGENT_METRICS_ADDR` | `127.0.0.1:9090` | Metrics server address |
 | `AGENT_TLS_CERT` | - | TLS certificate path |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -171,7 +171,7 @@ For multiple tenants on one agent:
 AGENT_TENANTS=cluster-a:token-aaa,cluster-b:token-bbb
 ```
 
-Each tenant is isolated (separate directory, separate token). See [multi-tenancy](architecture.md#multi-tenancy) for details.
+Each tenant is isolated (separate directory, separate token). Reserved names that cannot be used as tenants: `tasks`, `snapshots`, `data`, `metadata`. See [multi-tenancy](architecture.md#multi-tenancy) for details.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Constant-time token comparison (`crypto/subtle`) in `AuthMiddleware`, replacing the map lookup. Low practical risk, removes the class.
- Reserved tenant names `{tasks, snapshots, data, metadata}` (case-insensitive) via new `ValidateTenantName`. Prevents `AGENT_TENANTS="tasks:..."` from colliding with `{basePath}/tasks/`.
- Validated in `parseTenants` so bad `AGENT_TENANTS` fails at boot before the btrfs check.