### PR TITLE
Add btrfs balance task with scrub/balance mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Security
 - Constant-time token comparison in the agent auth middleware, replacing the map lookup
+
+### Bug Fixes
 - Reserve internal directory names (`tasks`, `snapshots`, `data`, `metadata`, case-insensitive) as invalid tenant names; `AGENT_TENANTS` is now validated at boot before any filesystem operations
 
 ## v0.10.0

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -60,7 +60,7 @@ func NewAgent(cfg *config.AgentConfig, version, commit string) (*Agent, error) {
 	store := storage.New(
 		cfg.BasePath, cfg.QuotaEnabled, exp, tenantNames,
 		cfg.DefaultDirMode, cfg.DefaultDataMode, cfg.BtrfsBin, cfg.ImmutableLabels,
-		cfg.TaskMaxConcurrent, cfg.TaskDefaultTimeout, cfg.TaskScrubTimeout, cfg.TaskPollInterval,
+		cfg.TaskMaxConcurrent, cfg.TaskDefaultTimeout, cfg.TaskScrubTimeout, cfg.TaskBalanceTimeout, cfg.TaskPollInterval,
 	)
 
 	// echo + routes

--- a/agent/api/v1/handler_task.go
+++ b/agent/api/v1/handler_task.go
@@ -55,11 +55,11 @@ func taskDetailResponseFrom(t *task.Task) models.TaskDetailResponse {
 
 // CreateTask godoc
 // @Summary      Create a background task
-// @Description  Creates a background task (scrub or test). Returns 202 Accepted with task ID.
+// @Description  Creates a background task (scrub, balance, test). Returns 202 Accepted with task ID.
 // @Tags         tasks
 // @Accept       json
 // @Produce      json
-// @Param        type    path string true "Task type" Enums(scrub, test)
+// @Param        type    path string true "Task type" Enums(scrub, balance, test)
 // @Param        request body models.TaskCreateRequest false "Task options"
 // @Success      202 {object} models.TaskCreateResponse
 // @Failure      400 {object} models.ErrorResponse
@@ -93,6 +93,8 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 	switch taskType {
 	case models.TaskTypeScrub:
 		taskID, err = h.Store.StartScrub(c.Request().Context(), req.Opts, req.Labels, timeout)
+	case models.TaskTypeBalance:
+		taskID, err = h.Store.StartBalance(c.Request().Context(), req.Opts, req.Labels, timeout)
 	case models.TaskTypeTest:
 		taskID, err = h.Store.StartTestTask(c.Request().Context(), req.Opts, req.Labels, timeout)
 	default:
@@ -109,7 +111,7 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 // @Description  Returns background tasks. Filter by type. Supports detail, pagination, and label filtering.
 // @Tags         tasks
 // @Produce      json
-// @Param        type   query string false "Filter by task type" Enums(scrub, test)
+// @Param        type   query string false "Filter by task type" Enums(scrub, balance, test)
 // @Param        detail query string false "Return full detail" Enums(true)
 // @Param        limit  query int    false "Items per page (0 = pagination disabled)"
 // @Param        after  query string false "Pagination cursor"

--- a/agent/api/v1/models/models.go
+++ b/agent/api/v1/models/models.go
@@ -394,8 +394,9 @@ const (
 
 // Task type identifiers for POST /v1/tasks/:type.
 const (
-	TaskTypeScrub = "scrub"
-	TaskTypeTest  = "test"
+	TaskTypeScrub   = "scrub"
+	TaskTypeBalance = "balance"
+	TaskTypeTest    = "test"
 )
 
 // --- Pagination helpers ---

--- a/agent/storage/balance.go
+++ b/agent/storage/balance.go
@@ -1,0 +1,198 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/btrfs"
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/task"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/rs/zerolog/log"
+)
+
+// validBalanceProfiles is the set of btrfs profiles accepted by -dconvert/-mconvert/-sconvert
+// and -dprofiles/-mprofiles filters. Semantic constraints (e.g. raid5 needs >= 2 devices) are
+// NOT validated here; btrfs will reject invalid combinations at runtime.
+var validBalanceProfiles = []string{"single", "dup", "raid0", "raid1", "raid1c3", "raid1c4", "raid10", "raid5", "raid6"}
+
+var balanceOptsKeys = []string{
+	"dusage", "musage", "susage",
+	"dprofiles", "mprofiles",
+	"ddevid", "mdevid",
+	"dconvert", "mconvert", "sconvert",
+	"force",
+}
+
+func (s *Storage) StartBalance(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
+	s.maintenanceMu.Lock()
+	defer s.maintenanceMu.Unlock()
+	for _, t := range s.tasks.List(string(task.TypeScrub), string(task.TypeBalance)) {
+		if t.Status == task.TaskRunning || t.Status == task.TaskPending {
+			return "", &StorageError{Code: ErrBusy, Message: "another maintenance task is already running"}
+		}
+	}
+	if bst, _ := s.btrfs.BalanceStatus(ctx, s.mountPoint); bst != nil && bst.Running {
+		return "", &StorageError{Code: ErrBusy, Message: "balance already running on filesystem"}
+	}
+	if sst, err := s.btrfs.ScrubStatus(ctx, s.mountPoint); err == nil && sst.Running {
+		return "", &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
+	}
+
+	if err := config.ValidateLabels(labels); err != nil {
+		return "", err
+	}
+
+	args, err := balanceArgsFromOpts(opts)
+	if err != nil {
+		return "", err
+	}
+	if len(args) == 0 {
+		log.Warn().Str("path", s.mountPoint).Msg("balance without filters: rewriting entire filesystem, expect heavy IO")
+	}
+
+	t := s.taskBalanceTimeout
+	if timeout > 0 {
+		t = timeout
+	}
+	id := s.tasks.Create(string(task.TypeBalance), task.TaskOpts{Opts: opts, Labels: labels, Timeout: t}, func(ctx context.Context, update *task.Update) error {
+		return s.runBalance(ctx, update, args)
+	})
+
+	log.Info().Str("task", id).Str("path", s.mountPoint).Strs("args", args).Msg("balance started")
+	return id, nil
+}
+
+func (s *Storage) runBalance(ctx context.Context, update *task.Update, args []string) error {
+	var lastStatus atomic.Pointer[btrfs.BalanceStatus]
+
+	stop := update.PollProgress(ctx, func() int {
+		status, err := s.btrfs.BalanceStatus(ctx, s.mountPoint)
+		if err != nil || status == nil {
+			return -1
+		}
+		lastStatus.Store(status)
+		_ = update.SetResult(status)
+		if status.ChunksTotal > 0 {
+			pct := int(status.ChunksDone * 100 / status.ChunksTotal)
+			if pct > 100 {
+				return 100
+			}
+			return pct
+		}
+		return 0
+	})
+
+	// Unlike scrub, killing the foreground process does not stop the kernel-side
+	// balance. The watcher fires `btrfs balance cancel` on ctx cancellation, but
+	// must NOT fire on normal completion, hence the completed channel.
+	completed := make(chan struct{})
+	cancelDone := make(chan struct{})
+	go func() {
+		defer close(cancelDone)
+		select {
+		case <-completed:
+			return
+		case <-ctx.Done():
+			cancelCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := s.btrfs.BalanceCancel(cancelCtx, s.mountPoint); err != nil {
+				log.Warn().Err(err).Str("path", s.mountPoint).Msg("btrfs balance cancel failed; kernel balance may continue")
+			}
+		}
+	}()
+
+	err := s.btrfs.BalanceStart(ctx, s.mountPoint, args)
+	close(completed)
+	stop()
+	<-cancelDone
+
+	if final := finalizeBalanceResult(lastStatus.Load(), err, ctx.Err()); final != nil {
+		_ = update.SetResult(final)
+	}
+
+	if err != nil && ctx.Err() == nil {
+		return fmt.Errorf("btrfs balance: %w", err)
+	}
+	return nil
+}
+
+// finalizeBalanceResult sanitizes the last poll snapshot so the persisted Result
+// matches the terminal task state. The last poll may have frozen a mid-flight
+// snapshot (Running=true, ChunksDone<ChunksTotal); after the kernel-side balance
+// has stopped, Running and Paused must be false. On successful completion, every
+// considered chunk was processed, so Done is aligned with Total.
+func finalizeBalanceResult(last *btrfs.BalanceStatus, balanceErr, ctxErr error) *btrfs.BalanceStatus {
+	if last == nil {
+		return nil
+	}
+	final := *last
+	final.Running = false
+	final.Paused = false
+	if balanceErr == nil && ctxErr == nil && final.ChunksTotal > 0 {
+		final.ChunksDone = final.ChunksTotal
+	}
+	return &final
+}
+
+func balanceArgsFromOpts(opts map[string]string) ([]string, error) {
+	if len(opts) == 0 {
+		return nil, nil
+	}
+	for k := range opts {
+		if !slices.Contains(balanceOptsKeys, k) {
+			return nil, &config.ValidationError{Message: fmt.Sprintf("unknown balance option %q", k)}
+		}
+	}
+
+	args := make([]string, 0, len(opts))
+
+	for _, k := range []string{"dusage", "musage", "susage"} {
+		if v, ok := opts[k]; ok {
+			pct, err := strconv.Atoi(v)
+			if err != nil || pct < 0 || pct > 100 {
+				return nil, &config.ValidationError{Message: fmt.Sprintf("invalid %s value %q (expected integer 0-100)", k, v)}
+			}
+			args = append(args, fmt.Sprintf("-%s=%d", k, pct))
+		}
+	}
+
+	for _, k := range []string{"dprofiles", "mprofiles"} {
+		if v, ok := opts[k]; ok {
+			if !slices.Contains(validBalanceProfiles, v) {
+				return nil, &config.ValidationError{Message: fmt.Sprintf("invalid %s value %q", k, v)}
+			}
+			args = append(args, fmt.Sprintf("-%s=%s", k, v))
+		}
+	}
+
+	for _, k := range []string{"ddevid", "mdevid"} {
+		if v, ok := opts[k]; ok {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 {
+				return nil, &config.ValidationError{Message: fmt.Sprintf("invalid %s value %q (expected positive integer)", k, v)}
+			}
+			args = append(args, fmt.Sprintf("-%s=%d", k, n))
+		}
+	}
+
+	for _, k := range []string{"dconvert", "mconvert", "sconvert"} {
+		if v, ok := opts[k]; ok {
+			profile, _ := strings.CutSuffix(v, ",soft")
+			if !slices.Contains(validBalanceProfiles, profile) {
+				return nil, &config.ValidationError{Message: fmt.Sprintf("invalid %s profile %q", k, v)}
+			}
+			args = append(args, fmt.Sprintf("-%s=%s", k, v))
+		}
+	}
+
+	if v, ok := opts["force"]; ok && v == "true" {
+		args = append(args, "-f")
+	}
+
+	return args, nil
+}

--- a/agent/storage/balance.go
+++ b/agent/storage/balance.go
@@ -15,11 +15,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// validBalanceProfiles is the set of btrfs profiles accepted by -dconvert/-mconvert/-sconvert
-// and -dprofiles/-mprofiles filters. Semantic constraints (e.g. raid5 needs >= 2 devices) are
-// NOT validated here; btrfs will reject invalid combinations at runtime.
-var validBalanceProfiles = []string{"single", "dup", "raid0", "raid1", "raid1c3", "raid1c4", "raid10", "raid5", "raid6"}
-
 var balanceOptsKeys = []string{
 	"dusage", "musage", "susage",
 	"dprofiles", "mprofiles",
@@ -163,7 +158,7 @@ func balanceArgsFromOpts(opts map[string]string) ([]string, error) {
 
 	for _, k := range []string{"dprofiles", "mprofiles"} {
 		if v, ok := opts[k]; ok {
-			if !slices.Contains(validBalanceProfiles, v) {
+			if !slices.Contains(btrfs.ValidProfiles, v) {
 				return nil, &config.ValidationError{Message: fmt.Sprintf("invalid %s value %q", k, v)}
 			}
 			args = append(args, fmt.Sprintf("-%s=%s", k, v))
@@ -183,7 +178,7 @@ func balanceArgsFromOpts(opts map[string]string) ([]string, error) {
 	for _, k := range []string{"dconvert", "mconvert", "sconvert"} {
 		if v, ok := opts[k]; ok {
 			profile, _ := strings.CutSuffix(v, ",soft")
-			if !slices.Contains(validBalanceProfiles, profile) {
+			if !slices.Contains(btrfs.ValidProfiles, profile) {
 				return nil, &config.ValidationError{Message: fmt.Sprintf("invalid %s profile %q", k, v)}
 			}
 			args = append(args, fmt.Sprintf("-%s=%s", k, v))

--- a/agent/storage/balance_test.go
+++ b/agent/storage/balance_test.go
@@ -1,0 +1,112 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/btrfs"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBalanceArgsFromOpts(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", opts: nil, want: nil},
+		{name: "dusage", opts: map[string]string{"dusage": "50"}, want: []string{"-dusage=50"}},
+		{name: "musage", opts: map[string]string{"musage": "75"}, want: []string{"-musage=75"}},
+		{name: "susage", opts: map[string]string{"susage": "10"}, want: []string{"-susage=10"}},
+		{name: "dprofiles_raid1", opts: map[string]string{"dprofiles": "raid1"}, want: []string{"-dprofiles=raid1"}},
+		{name: "ddevid", opts: map[string]string{"ddevid": "2"}, want: []string{"-ddevid=2"}},
+		{name: "dconvert_raid1", opts: map[string]string{"dconvert": "raid1"}, want: []string{"-dconvert=raid1"}},
+		{name: "dconvert_soft", opts: map[string]string{"dconvert": "raid1,soft"}, want: []string{"-dconvert=raid1,soft"}},
+		{name: "force", opts: map[string]string{"force": "true"}, want: []string{"-f"}},
+		{name: "force_false_omitted", opts: map[string]string{"force": "false"}, want: []string{}},
+		{
+			name: "combined",
+			opts: map[string]string{"dusage": "50", "mconvert": "raid1", "force": "true"},
+			want: []string{"-dusage=50", "-mconvert=raid1", "-f"},
+		},
+		{name: "unknown_key", opts: map[string]string{"bogus": "1"}, wantErr: true},
+		{name: "dusage_out_of_range", opts: map[string]string{"dusage": "101"}, wantErr: true},
+		{name: "dusage_negative", opts: map[string]string{"dusage": "-1"}, wantErr: true},
+		{name: "dusage_not_int", opts: map[string]string{"dusage": "abc"}, wantErr: true},
+		{name: "invalid_profile", opts: map[string]string{"dprofiles": "raid99"}, wantErr: true},
+		{name: "invalid_convert_profile", opts: map[string]string{"dconvert": "nope"}, wantErr: true},
+		{name: "invalid_convert_soft_profile", opts: map[string]string{"dconvert": "bogus,soft"}, wantErr: true},
+		{name: "ddevid_zero", opts: map[string]string{"ddevid": "0"}, wantErr: true},
+		{name: "ddevid_negative", opts: map[string]string{"ddevid": "-1"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := balanceArgsFromOpts(tt.opts)
+			if tt.wantErr {
+				require.Error(t, err)
+				var ve *config.ValidationError
+				require.ErrorAs(t, err, &ve)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestFinalizeBalanceResult(t *testing.T) {
+	midFlight := &btrfs.BalanceStatus{Running: true, Paused: false, ChunksDone: 1, ChunksTotal: 3}
+
+	t.Run("nil_input_returns_nil", func(t *testing.T) {
+		assert.Nil(t, finalizeBalanceResult(nil, nil, nil))
+	})
+
+	t.Run("successful_completion_fills_chunks", func(t *testing.T) {
+		got := finalizeBalanceResult(midFlight, nil, nil)
+		require.NotNil(t, got)
+		assert.False(t, got.Running)
+		assert.False(t, got.Paused)
+		assert.Equal(t, uint64(3), got.ChunksDone)
+		assert.Equal(t, uint64(3), got.ChunksTotal)
+	})
+
+	t.Run("cancelled_preserves_partial_chunks", func(t *testing.T) {
+		// user cancelled mid-flight: ctx error present -> keep partial progress
+		got := finalizeBalanceResult(midFlight, context.Canceled, context.Canceled)
+		require.NotNil(t, got)
+		assert.False(t, got.Running, "running must be cleared even on cancel")
+		assert.False(t, got.Paused)
+		assert.Equal(t, uint64(1), got.ChunksDone, "partial chunks must not be forged")
+		assert.Equal(t, uint64(3), got.ChunksTotal)
+	})
+
+	t.Run("balance_error_preserves_partial_chunks", func(t *testing.T) {
+		// btrfs command failed mid-flight: keep partial progress, don't forge
+		got := finalizeBalanceResult(midFlight, errors.New("enospc"), nil)
+		require.NotNil(t, got)
+		assert.False(t, got.Running)
+		assert.Equal(t, uint64(1), got.ChunksDone)
+	})
+
+	t.Run("paused_snapshot_cleared", func(t *testing.T) {
+		paused := &btrfs.BalanceStatus{Running: true, Paused: true, ChunksDone: 2, ChunksTotal: 5}
+		got := finalizeBalanceResult(paused, nil, nil)
+		require.NotNil(t, got)
+		assert.False(t, got.Running)
+		assert.False(t, got.Paused)
+	})
+
+	t.Run("zero_total_not_fabricated", func(t *testing.T) {
+		// edge case: completed but last poll had total=0 (e.g. balance finished
+		// before the first poll fired, then something else loaded lastStatus)
+		empty := &btrfs.BalanceStatus{Running: false, ChunksTotal: 0}
+		got := finalizeBalanceResult(empty, nil, nil)
+		require.NotNil(t, got)
+		assert.Equal(t, uint64(0), got.ChunksDone)
+		assert.Equal(t, uint64(0), got.ChunksTotal)
+	})
+}

--- a/agent/storage/btrfs/balance_test.go
+++ b/agent/storage/btrfs/balance_test.go
@@ -1,0 +1,113 @@
+package btrfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBalanceStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want BalanceStatus
+	}{
+		{
+			name: "idle",
+			out:  "No balance found on '/mnt'\n",
+			want: BalanceStatus{},
+		},
+		{
+			name: "running_with_progress",
+			out: strings.Join([]string{
+				"Balance on '/mnt' is running",
+				"3 out of about 20 chunks balanced (3 considered),  85% left",
+				"Dumping filters: flags 0x1, state 0x1, force is off",
+				"  DATA (flags 0x2): balancing, usage=50",
+			}, "\n"),
+			want: BalanceStatus{Running: true, ChunksDone: 3, ChunksTotal: 20},
+		},
+		{
+			name: "paused",
+			out: strings.Join([]string{
+				"Balance on '/mnt' is paused",
+				"5 out of about 10 chunks balanced (5 considered),  50% left",
+			}, "\n"),
+			want: BalanceStatus{Running: true, Paused: true, ChunksDone: 5, ChunksTotal: 10},
+		},
+		{
+			name: "cancelling",
+			out: strings.Join([]string{
+				"Balance on '/mnt' is cancelling",
+				"7 out of about 10 chunks balanced (7 considered),  30% left",
+			}, "\n"),
+			want: BalanceStatus{Running: true, ChunksDone: 7, ChunksTotal: 10},
+		},
+		{
+			name: "empty",
+			out:  "",
+			want: BalanceStatus{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBalanceStatus(tt.out)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, *got)
+		})
+	}
+}
+
+func TestBalanceStart_BuildsCorrectArgs(t *testing.T) {
+	m := &utils.MockRunner{Out: ""}
+	mgr := newTestManager(m)
+
+	err := mgr.BalanceStart(context.Background(), "/mnt", []string{"-dusage=50", "-mconvert=raid1"})
+	require.NoError(t, err)
+	require.Len(t, m.Calls, 1)
+
+	assert.Equal(t, []string{"balance", "start", "-dusage=50", "-mconvert=raid1", "/mnt"}, m.Calls[0])
+}
+
+func TestBalanceStart_NoArgs(t *testing.T) {
+	m := &utils.MockRunner{Out: ""}
+	mgr := newTestManager(m)
+
+	err := mgr.BalanceStart(context.Background(), "/mnt", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"balance", "start", "/mnt"}, m.Calls[0])
+}
+
+func TestBalanceStatus_ParsesIdle(t *testing.T) {
+	m := &utils.MockRunner{Out: "No balance found on '/mnt'\n"}
+	mgr := newTestManager(m)
+
+	st, err := mgr.BalanceStatus(context.Background(), "/mnt")
+	require.NoError(t, err)
+	assert.False(t, st.Running)
+}
+
+func TestBalanceStatus_NonZeroExitStillParses(t *testing.T) {
+	// `btrfs balance status` exits non-zero when no balance is running.
+	// We expect the parser to still handle the output.
+	m := &utils.MockRunner{Out: "No balance found on '/mnt'\n", Err: fmt.Errorf("exit 1")}
+	mgr := newTestManager(m)
+
+	st, err := mgr.BalanceStatus(context.Background(), "/mnt")
+	require.NoError(t, err)
+	assert.False(t, st.Running)
+}
+
+func TestBalanceCancel_BuildsCorrectArgs(t *testing.T) {
+	m := &utils.MockRunner{Out: ""}
+	mgr := newTestManager(m)
+
+	err := mgr.BalanceCancel(context.Background(), "/mnt")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"balance", "cancel", "/mnt"}, m.Calls[0])
+}

--- a/agent/storage/btrfs/balance_test.go
+++ b/agent/storage/btrfs/balance_test.go
@@ -83,15 +83,6 @@ func TestBalanceStart_NoArgs(t *testing.T) {
 	assert.Equal(t, []string{"balance", "start", "/mnt"}, m.Calls[0])
 }
 
-func TestBalanceStatus_ParsesIdle(t *testing.T) {
-	m := &utils.MockRunner{Out: "No balance found on '/mnt'\n"}
-	mgr := newTestManager(m)
-
-	st, err := mgr.BalanceStatus(context.Background(), "/mnt")
-	require.NoError(t, err)
-	assert.False(t, st.Running)
-}
-
 func TestBalanceStatus_NonZeroExitStillParses(t *testing.T) {
 	// `btrfs balance status` exits non-zero when no balance is running.
 	// We expect the parser to still handle the output.

--- a/agent/storage/btrfs/btrfs.go
+++ b/agent/storage/btrfs/btrfs.go
@@ -179,6 +179,27 @@ func (m *Manager) ScrubStatus(ctx context.Context, path string) (*ScrubStatus, e
 	return parseScrubStatus(out)
 }
 
+// BalanceStart runs a btrfs balance in the foreground. Blocks until the
+// balance completes or the context is cancelled. Note: unlike scrub, killing
+// the process does NOT stop the kernel-side balance; the caller must invoke
+// BalanceCancel on context cancellation.
+func (m *Manager) BalanceStart(ctx context.Context, path string, args []string) error {
+	cmdArgs := append([]string{"balance", "start"}, args...)
+	cmdArgs = append(cmdArgs, path)
+	return m.run(ctx, cmdArgs...)
+}
+
+func (m *Manager) BalanceStatus(ctx context.Context, path string) (*BalanceStatus, error) {
+	// `btrfs balance status` exits non-zero when no balance is running;
+	// parse anyway, parseBalanceStatus handles the "No balance" message.
+	out, _ := m.cmd.Run(ctx, m.bin, "balance", "status", "-v", path)
+	return parseBalanceStatus(out)
+}
+
+func (m *Manager) BalanceCancel(ctx context.Context, path string) error {
+	return m.run(ctx, "balance", "cancel", path)
+}
+
 // QgroupUsageBulk returns qgroup usage for all subvolumes under path.
 // Runs `btrfs subvolume list -o` and `btrfs qgroup show -re --raw` once each,
 // joins by subvolume ID. Returns map keyed by relative subvolume path.

--- a/agent/storage/btrfs/model.go
+++ b/agent/storage/btrfs/model.go
@@ -1,5 +1,11 @@
 package btrfs
 
+// ValidProfiles are the btrfs block-group profiles accepted by -d/-m/-sconvert
+// and -d/-mprofiles filters. Semantic constraints (e.g. raid5 needs >= 2
+// devices) are NOT validated here; btrfs will reject invalid combinations at
+// runtime.
+var ValidProfiles = []string{"single", "dup", "raid0", "raid1", "raid1c3", "raid1c4", "raid10", "raid5", "raid6"}
+
 type SubvolumeInfo struct {
 	Path string
 }

--- a/agent/storage/btrfs/model.go
+++ b/agent/storage/btrfs/model.go
@@ -52,3 +52,11 @@ type ScrubStatus struct {
 	CorrectedErrs     uint64 `json:"corrected_errors"`
 	Running           bool   `json:"running"`
 }
+
+type BalanceStatus struct {
+	Running     bool   `json:"running"`
+	Paused      bool   `json:"paused"`
+	ChunksDone  uint64 `json:"chunks_done"`
+	ChunksTotal uint64 `json:"chunks_total"`
+	LastError   string `json:"last_error,omitempty"`
+}

--- a/agent/storage/btrfs/utils.go
+++ b/agent/storage/btrfs/utils.go
@@ -219,6 +219,44 @@ func parseScrubStatus(out string) (*ScrubStatus, error) {
 	return s, nil
 }
 
+// parseBalanceStatus parses `btrfs balance status -v` output.
+// Expected states:
+//   - "No balance found on '/path'"          -> idle
+//   - "Balance on '/path' is running"        -> running
+//   - "Balance on '/path' is paused"         -> paused
+//   - "Balance on '/path' is cancelling"     -> running + cancel pending
+//
+// Progress line (when running/paused):
+//
+//	"N out of about M chunks balanced (K considered), P% left"
+func parseBalanceStatus(out string) (*BalanceStatus, error) {
+	s := &BalanceStatus{}
+	for line := range strings.SplitSeq(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "No balance found"):
+			return s, nil
+		case strings.Contains(trimmed, "is running"), strings.Contains(trimmed, "is cancelling"):
+			s.Running = true
+		case strings.Contains(trimmed, "is paused"):
+			s.Running = true
+			s.Paused = true
+		}
+		if strings.Contains(trimmed, "chunks balanced") {
+			fields := strings.Fields(trimmed)
+			// "N out of about M chunks balanced (K considered), P% left"
+			if len(fields) >= 10 && fields[1] == "out" && fields[2] == "of" && fields[3] == "about" {
+				s.ChunksDone, _ = strconv.ParseUint(fields[0], 10, 64)
+				s.ChunksTotal, _ = strconv.ParseUint(fields[4], 10, 64)
+			}
+		}
+	}
+	return s, nil
+}
+
 // subvolEntry holds a parsed line from `btrfs subvolume list -o`.
 type subvolEntry struct {
 	ID   string

--- a/agent/storage/scrub.go
+++ b/agent/storage/scrub.go
@@ -12,14 +12,19 @@ import (
 
 // StartScrub starts a btrfs scrub as a background task and returns the task ID.
 func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
-	for _, t := range s.tasks.List(string(task.TypeScrub)) {
+	s.maintenanceMu.Lock()
+	defer s.maintenanceMu.Unlock()
+	for _, t := range s.tasks.List(string(task.TypeScrub), string(task.TypeBalance)) {
 		if t.Status == task.TaskRunning || t.Status == task.TaskPending {
-			return "", &StorageError{Code: ErrBusy, Message: "scrub already running"}
+			return "", &StorageError{Code: ErrBusy, Message: "another maintenance task is already running"}
 		}
 	}
 	status, err := s.btrfs.ScrubStatus(ctx, s.mountPoint)
 	if err == nil && status.Running {
 		return "", &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
+	}
+	if bst, _ := s.btrfs.BalanceStatus(ctx, s.mountPoint); bst != nil && bst.Running {
+		return "", &StorageError{Code: ErrBusy, Message: "balance already running on filesystem"}
 	}
 
 	if err := config.ValidateLabels(labels); err != nil {

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -33,8 +34,15 @@ type Storage struct {
 	tasks              *task.Manager
 	taskDefaultTimeout time.Duration
 	taskScrubTimeout   time.Duration
+	taskBalanceTimeout time.Duration
 
 	immutableLabelKeys []string
+
+	// maintenanceMu serializes StartScrub and StartBalance so the tasks.List
+	// check and subsequent tasks.Create cannot race between concurrent callers.
+	// Kept at Storage level so scrub and balance share one lock (they are
+	// mutually exclusive by design).
+	maintenanceMu sync.Mutex
 
 	volumes   *meta.Store[VolumeMetadata]
 	snapshots *meta.Store[SnapshotMetadata]
@@ -49,7 +57,7 @@ type Storage struct {
 	cachedFilesystem atomic.Pointer[btrfs.FilesystemUsage]
 }
 
-func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin, immutableLabels string, taskMaxConcurrent int, taskDefaultTimeout, taskScrubTimeout, taskPollInterval time.Duration) *Storage {
+func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin, immutableLabels string, taskMaxConcurrent int, taskDefaultTimeout, taskScrubTimeout, taskBalanceTimeout, taskPollInterval time.Duration) *Storage {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -120,7 +128,7 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 		initialStates[i] = DeviceState{BTRFSDevice: d}
 	}
 	taskDir := filepath.Join(basePath, config.TasksDir)
-	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, immutableLabelKeys: ImmutableLabelKeys(immutableLabels), tasks: task.NewManager(taskDir, taskMaxConcurrent, taskPollInterval), taskDefaultTimeout: taskDefaultTimeout, taskScrubTimeout: taskScrubTimeout, volumes: meta.NewStore[VolumeMetadata](basePath), snapshots: meta.NewStore[SnapshotMetadata](basePath, config.SnapshotsDir)}
+	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, immutableLabelKeys: ImmutableLabelKeys(immutableLabels), tasks: task.NewManager(taskDir, taskMaxConcurrent, taskPollInterval), taskDefaultTimeout: taskDefaultTimeout, taskScrubTimeout: taskScrubTimeout, taskBalanceTimeout: taskBalanceTimeout, volumes: meta.NewStore[VolumeMetadata](basePath), snapshots: meta.NewStore[SnapshotMetadata](basePath, config.SnapshotsDir)}
 	s.cachedDevices.Store(&initialStates)
 	s.loadCache()
 	return s

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -432,11 +432,12 @@ func (s *StorageIntegrationSuite) TestStartScrub() {
 func (s *StorageIntegrationSuite) TestStartScrubDuplicate() {
 	// start a blocking scrub in background
 	started := make(chan struct{})
-	s.storage.Tasks().Create(string(task.TypeScrub), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
+	id := s.storage.Tasks().Create(string(task.TypeScrub), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
 		close(started)
 		<-ctx.Done()
 		return ctx.Err()
 	})
+	defer s.cancelAndAwait(id)
 	<-started
 
 	// second scrub should be rejected
@@ -445,6 +446,21 @@ func (s *StorageIntegrationSuite) TestStartScrubDuplicate() {
 	var se *StorageError
 	s.Require().ErrorAs(err, &se)
 	s.Assert().Equal(ErrBusy, se.Code)
+}
+
+// cancelAndAwait cancels the task and waits until it leaves the Running/Pending
+// states, so the next test in the suite starts from a clean maintenance slot.
+func (s *StorageIntegrationSuite) cancelAndAwait(id string) {
+	_ = s.storage.Tasks().Cancel(id)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		t, err := s.storage.Tasks().Get(id)
+		if err != nil || (t.Status != task.TaskRunning && t.Status != task.TaskPending) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s.T().Logf("warning: task %s did not leave Running/Pending within 5s", id)
 }
 
 func (s *StorageIntegrationSuite) TestStartBalance_UsageFilter() {
@@ -467,27 +483,12 @@ func (s *StorageIntegrationSuite) TestStartBalance_UsageFilter() {
 
 func (s *StorageIntegrationSuite) TestStartBalance_BusyWithScrub() {
 	started := make(chan struct{})
-	s.storage.Tasks().Create(string(task.TypeScrub), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
+	id := s.storage.Tasks().Create(string(task.TypeScrub), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
 		close(started)
 		<-ctx.Done()
 		return ctx.Err()
 	})
-	<-started
-
-	_, err := s.storage.StartBalance(s.ctx, map[string]string{"dusage": "100"}, nil, 0)
-	s.Require().Error(err)
-	var se *StorageError
-	s.Require().ErrorAs(err, &se)
-	s.Assert().Equal(ErrBusy, se.Code)
-}
-
-func (s *StorageIntegrationSuite) TestStartBalance_BusyWithBalance() {
-	started := make(chan struct{})
-	s.storage.Tasks().Create(string(task.TypeBalance), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
-		close(started)
-		<-ctx.Done()
-		return ctx.Err()
-	})
+	defer s.cancelAndAwait(id)
 	<-started
 
 	_, err := s.storage.StartBalance(s.ctx, map[string]string{"dusage": "100"}, nil, 0)

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -447,6 +447,80 @@ func (s *StorageIntegrationSuite) TestStartScrubDuplicate() {
 	s.Assert().Equal(ErrBusy, se.Code)
 }
 
+func (s *StorageIntegrationSuite) TestStartBalance_UsageFilter() {
+	// dusage=100 matches every data chunk, so the balance runs even on an almost-empty fs.
+	taskID, err := s.storage.StartBalance(s.ctx, map[string]string{"dusage": "100"}, nil, 0)
+	s.Require().NoError(err)
+	s.Assert().NotEmpty(taskID)
+
+	var tsk *task.Task
+	for i := 0; i < 60; i++ {
+		tsk, err = s.storage.Tasks().Get(taskID)
+		s.Require().NoError(err)
+		if tsk.Status == task.TaskCompleted || tsk.Status == task.TaskFailed {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	s.Assert().Equal(task.TaskCompleted, tsk.Status)
+}
+
+func (s *StorageIntegrationSuite) TestStartBalance_BusyWithScrub() {
+	started := make(chan struct{})
+	s.storage.Tasks().Create(string(task.TypeScrub), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	<-started
+
+	_, err := s.storage.StartBalance(s.ctx, map[string]string{"dusage": "100"}, nil, 0)
+	s.Require().Error(err)
+	var se *StorageError
+	s.Require().ErrorAs(err, &se)
+	s.Assert().Equal(ErrBusy, se.Code)
+}
+
+func (s *StorageIntegrationSuite) TestStartBalance_BusyWithBalance() {
+	started := make(chan struct{})
+	s.storage.Tasks().Create(string(task.TypeBalance), task.TaskOpts{}, func(ctx context.Context, update *task.Update) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	<-started
+
+	_, err := s.storage.StartBalance(s.ctx, map[string]string{"dusage": "100"}, nil, 0)
+	s.Require().Error(err)
+	var se *StorageError
+	s.Require().ErrorAs(err, &se)
+	s.Assert().Equal(ErrBusy, se.Code)
+}
+
+func (s *StorageIntegrationSuite) TestStartBalance_Cancel() {
+	taskID, err := s.storage.StartBalance(s.ctx, map[string]string{"dusage": "100"}, nil, 0)
+	s.Require().NoError(err)
+
+	time.Sleep(100 * time.Millisecond)
+	s.Require().NoError(s.storage.Tasks().Cancel(taskID))
+
+	var tsk *task.Task
+	for i := 0; i < 60; i++ {
+		tsk, err = s.storage.Tasks().Get(taskID)
+		s.Require().NoError(err)
+		if tsk.Status != task.TaskRunning && tsk.Status != task.TaskPending {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	s.Assert().Contains([]task.TaskStatus{task.TaskCancelled, task.TaskCompleted}, tsk.Status,
+		"balance should end in cancelled or completed (if finished before cancel landed)")
+
+	bst, err := s.storage.btrfs.BalanceStatus(s.ctx, s.mnt)
+	s.Require().NoError(err)
+	s.Assert().False(bst.Running, "kernel-side balance must be stopped after cancel")
+}
+
 func (s *StorageIntegrationSuite) TestTaskPersistence() {
 	taskDir := filepath.Join(s.mnt, config.TasksDir)
 

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -166,7 +167,16 @@ func (tm *Manager) Get(id string) (*Task, error) {
 }
 
 // List returns copies of all tasks, optionally filtered by type.
-func (tm *Manager) List(taskType string) []Task {
+// Multiple types are OR'ed. Empty strings in the filter are ignored.
+// Calling without arguments (or with a single empty string) returns all tasks.
+func (tm *Manager) List(taskTypes ...string) []Task {
+	filter := make([]string, 0, len(taskTypes))
+	for _, t := range taskTypes {
+		if t != "" {
+			filter = append(filter, t)
+		}
+	}
+
 	tm.mu.Lock()
 	snapshot := make([]*runningTask, 0, len(tm.tasks))
 	for _, rt := range tm.tasks {
@@ -177,7 +187,7 @@ func (tm *Manager) List(taskType string) []Task {
 	result := make([]Task, 0, len(snapshot))
 	for _, rt := range snapshot {
 		t := rt.state.Load()
-		if taskType != "" && t.Type != taskType {
+		if len(filter) > 0 && !slices.Contains(filter, t.Type) {
 			continue
 		}
 		result = append(result, *t)

--- a/agent/storage/task/model.go
+++ b/agent/storage/task/model.go
@@ -24,8 +24,9 @@ const (
 type TaskType string
 
 const (
-	TypeScrub TaskType = "scrub"
-	TypeTest  TaskType = "test"
+	TypeScrub   TaskType = "scrub"
+	TypeBalance TaskType = "balance"
+	TypeTest    TaskType = "test"
 )
 
 // ErrNotFound is returned when a task ID doesn't exist.

--- a/cmd/btrfs-nfs-csi/model.go
+++ b/cmd/btrfs-nfs-csi/model.go
@@ -350,6 +350,27 @@ func taskCmd() *cli.Command {
 						Action: taskCreateScrub,
 					},
 					{
+						Name:  models.TaskTypeBalance,
+						Usage: "start a btrfs balance",
+						Flags: []cli.Flag{
+							&cli.IntFlag{Name: "dusage", Usage: "only balance data chunks with usage < N% (0-100)"},
+							&cli.IntFlag{Name: "musage", Usage: "only balance metadata chunks with usage < N% (0-100)"},
+							&cli.IntFlag{Name: "susage", Usage: "only balance system chunks with usage < N% (0-100)"},
+							&cli.StringFlag{Name: "dprofiles", Usage: "only balance data chunks on given profile (e.g. raid1)"},
+							&cli.StringFlag{Name: "mprofiles", Usage: "only balance metadata chunks on given profile"},
+							&cli.IntFlag{Name: "ddevid", Usage: "only balance data chunks on given device ID"},
+							&cli.IntFlag{Name: "mdevid", Usage: "only balance metadata chunks on given device ID"},
+							&cli.StringFlag{Name: "dconvert", Usage: "convert data profile (e.g. raid1, raid1,soft)"},
+							&cli.StringFlag{Name: "mconvert", Usage: "convert metadata profile"},
+							&cli.StringFlag{Name: "sconvert", Usage: "convert system profile"},
+							&cli.BoolFlag{Name: "force", Aliases: []string{"f"}, Usage: "allow reducing metadata integrity (required for some convert operations)"},
+							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
+							&cli.BoolFlag{Name: "wait", Aliases: []string{"W"}, Usage: "wait for completion"},
+							labelFlag(),
+						},
+						Action: taskCreateBalance,
+					},
+					{
 						Name:  models.TaskTypeTest,
 						Usage: "start a test task",
 						Flags: []cli.Flag{

--- a/cmd/btrfs-nfs-csi/task.go
+++ b/cmd/btrfs-nfs-csi/task.go
@@ -21,9 +21,37 @@ func taskResultSummary(resp *models.TaskDetailResponse) string {
 	switch resp.Type {
 	case models.TaskTypeScrub:
 		return scrubResultSummary(resp)
+	case models.TaskTypeBalance:
+		return balanceResultSummary(resp)
 	default:
 		return genericResultSummary(resp.Result)
 	}
+}
+
+func balanceResultSummary(resp *models.TaskDetailResponse) string {
+	var s btrfs.BalanceStatus
+	if json.Unmarshal(resp.Result, &s) != nil {
+		return genericResultSummary(resp.Result)
+	}
+	switch resp.Status {
+	case models.TaskStatusCompleted:
+		if s.ChunksDone > 0 {
+			return fmt.Sprintf("%d chunks balanced", s.ChunksDone)
+		}
+	case models.TaskStatusRunning:
+		if s.ChunksTotal > 0 {
+			return fmt.Sprintf("%d/%d chunks", s.ChunksDone, s.ChunksTotal)
+		}
+	case models.TaskStatusCancelled:
+		if s.ChunksTotal > 0 {
+			return fmt.Sprintf("cancelled at %d/%d chunks", s.ChunksDone, s.ChunksTotal)
+		}
+	case models.TaskStatusFailed:
+		if s.LastError != "" {
+			return s.LastError
+		}
+	}
+	return ""
 }
 
 func scrubResultSummary(resp *models.TaskDetailResponse) string {
@@ -45,9 +73,6 @@ func scrubResultSummary(resp *models.TaskDetailResponse) string {
 		if errs > 0 {
 			parts = append(parts, fmt.Sprintf("%d errors", errs))
 		}
-		if len(parts) == 0 {
-			return ""
-		}
 		return strings.Join(parts, ", ")
 	case models.TaskStatusCompleted:
 		speed := ""
@@ -62,10 +87,8 @@ func scrubResultSummary(resp *models.TaskDetailResponse) string {
 		if errs > 0 {
 			return fmt.Sprintf("%d errors", errs)
 		}
-		return ""
-	default:
-		return ""
 	}
+	return ""
 }
 
 func genericResultSummary(result json.RawMessage) string {
@@ -223,6 +246,46 @@ func taskCreateScrub(ctx context.Context, cmd *cli.Command) error {
 	}
 	if !isJSON(cmd) {
 		fmt.Printf("scrub started (task %s)\n", resp.TaskID)
+	}
+	return waitForTask(ctx, resp.TaskID)
+}
+
+func taskCreateBalance(ctx context.Context, cmd *cli.Command) error {
+	opts := map[string]string{}
+	for _, k := range []string{"dusage", "musage", "susage"} {
+		if cmd.IsSet(k) {
+			opts[k] = fmt.Sprintf("%d", cmd.Int(k))
+		}
+	}
+	for _, k := range []string{"dprofiles", "mprofiles", "dconvert", "mconvert", "sconvert"} {
+		if v := cmd.String(k); v != "" {
+			opts[k] = v
+		}
+	}
+	for _, k := range []string{"ddevid", "mdevid"} {
+		if cmd.IsSet(k) {
+			opts[k] = fmt.Sprintf("%d", cmd.Int(k))
+		}
+	}
+	if cmd.Bool("force") {
+		opts["force"] = "true"
+	}
+
+	req := models.TaskCreateRequest{Labels: parseLabelsFlag(cmd), Opts: opts}
+	if t := cmd.Duration("timeout"); t > 0 {
+		req.Timeout = t.String()
+	}
+	resp, err := apiClient.CreateTask(ctx, models.TaskTypeBalance, req)
+	if err != nil {
+		return err
+	}
+	if !cmd.Bool("wait") {
+		return output(cmd, resp, func() {
+			fmt.Printf("balance started (task %s)\n", resp.TaskID)
+		})
+	}
+	if !isJSON(cmd) {
+		fmt.Printf("balance started (task %s)\n", resp.TaskID)
 	}
 	return waitForTask(ctx, resp.TaskID)
 }

--- a/cmd/btrfs-nfs-csi/task_test.go
+++ b/cmd/btrfs-nfs-csi/task_test.go
@@ -130,3 +130,82 @@ func TestGenericResultSummary_Invalid(t *testing.T) {
 	assert.Empty(t, genericResultSummary(json.RawMessage(`{corrupt`)))
 	assert.Empty(t, genericResultSummary(nil))
 }
+
+func balanceResult(done, total uint64, running, paused bool) json.RawMessage {
+	s := btrfs.BalanceStatus{
+		ChunksDone:  done,
+		ChunksTotal: total,
+		Running:     running,
+		Paused:      paused,
+	}
+	raw, _ := json.Marshal(s)
+	return raw
+}
+
+func TestBalanceResultSummary_Completed(t *testing.T) {
+	// Typical case: last poll saw mid-flight state (running=true), task finished before next poll.
+	// We must NOT expose the stale running flag; only surface the chunk count.
+	resp := &models.TaskDetailResponse{
+		Type:   models.TaskTypeBalance,
+		Status: models.TaskStatusCompleted,
+		Result: balanceResult(3, 3, true, false),
+	}
+	assert.Equal(t, "3 chunks balanced", balanceResultSummary(resp))
+}
+
+func TestBalanceResultSummary_CompletedNoChunks(t *testing.T) {
+	// Balance finished faster than pollInterval, result has zero chunks.
+	resp := &models.TaskDetailResponse{
+		Type:   models.TaskTypeBalance,
+		Status: models.TaskStatusCompleted,
+		Result: balanceResult(0, 0, false, false),
+	}
+	assert.Empty(t, balanceResultSummary(resp))
+}
+
+func TestBalanceResultSummary_Running(t *testing.T) {
+	resp := &models.TaskDetailResponse{
+		Type:   models.TaskTypeBalance,
+		Status: models.TaskStatusRunning,
+		Result: balanceResult(1, 3, true, false),
+	}
+	assert.Equal(t, "1/3 chunks", balanceResultSummary(resp))
+}
+
+func TestBalanceResultSummary_Cancelled(t *testing.T) {
+	resp := &models.TaskDetailResponse{
+		Type:   models.TaskTypeBalance,
+		Status: models.TaskStatusCancelled,
+		Result: balanceResult(2, 10, false, false),
+	}
+	assert.Equal(t, "cancelled at 2/10 chunks", balanceResultSummary(resp))
+}
+
+func TestBalanceResultSummary_CancelledNoData(t *testing.T) {
+	resp := &models.TaskDetailResponse{
+		Type:   models.TaskTypeBalance,
+		Status: models.TaskStatusCancelled,
+		Result: balanceResult(0, 0, false, false),
+	}
+	assert.Empty(t, balanceResultSummary(resp))
+}
+
+func TestBalanceResultSummary_Failed(t *testing.T) {
+	s := btrfs.BalanceStatus{LastError: "enospc"}
+	raw, _ := json.Marshal(s)
+	resp := &models.TaskDetailResponse{
+		Type:   models.TaskTypeBalance,
+		Status: models.TaskStatusFailed,
+		Result: raw,
+	}
+	assert.Equal(t, "enospc", balanceResultSummary(resp))
+}
+
+func TestTaskResultSummary_BalanceDispatch(t *testing.T) {
+	resp := &models.TaskDetailResponse{
+		Type:   models.TaskTypeBalance,
+		Status: models.TaskStatusCompleted,
+		Result: balanceResult(5, 5, false, false),
+	}
+	assert.Equal(t, "5 chunks balanced", taskResultSummary(resp))
+}

--- a/config/config.go
+++ b/config/config.go
@@ -109,6 +109,7 @@ type AgentConfig struct {
 	TaskMaxConcurrent      int           `env:"AGENT_TASK_MAX_CONCURRENT" envDefault:"2"`
 	TaskDefaultTimeout     time.Duration `env:"AGENT_TASK_DEFAULT_TIMEOUT" envDefault:"6h"`
 	TaskScrubTimeout       time.Duration `env:"AGENT_TASK_SCRUB_TIMEOUT" envDefault:"24h"`
+	TaskBalanceTimeout     time.Duration `env:"AGENT_TASK_BALANCE_TIMEOUT" envDefault:"24h"`
 	TaskPollInterval       time.Duration `env:"AGENT_TASK_POLL_INTERVAL" envDefault:"5s"`
 	DefaultPageLimit       int           `env:"AGENT_DEFAULT_PAGE_LIMIT" envDefault:"0"`
 	PaginationSnapshotTTL  time.Duration `env:"AGENT_API_PAGINATION_SNAPSHOT_TTL" envDefault:"30s"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@
 | `AGENT_TASK_MAX_CONCURRENT` | `2` | Max concurrent tasks (`0` = unlimited) |
 | `AGENT_TASK_DEFAULT_TIMEOUT` | `6h` | Default timeout for tasks (e.g. test). `0` = no timeout |
 | `AGENT_TASK_SCRUB_TIMEOUT` | `24h` | Timeout for btrfs scrub tasks. `0` = no timeout |
+| `AGENT_TASK_BALANCE_TIMEOUT` | `24h` | Timeout for btrfs balance tasks. `0` = no timeout |
 | `AGENT_TASK_POLL_INTERVAL` | `5s` | Progress update interval for background tasks |
 | `AGENT_IMMUTABLE_LABELS` | - | Comma-separated label keys that cannot be changed after creation |
 | `AGENT_DEFAULT_PAGE_LIMIT` | `0` | Default page size for list API responses (0 = pagination disabled) |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,6 +158,39 @@ chmod 600 /etc/default/btrfs-nfs-csi
 systemctl enable --now btrfs-scrub.timer
 ```
 
+## Balance
+
+btrfs balance rewrites chunks to reclaim wasted space, consolidate half-empty chunks, or change the RAID profile. Runs as a background task via the task system. Balance and scrub are mutually exclusive: only one heavy maintenance task per filesystem at a time.
+
+**Routine maintenance** (most common use case):
+
+```bash
+btrfs-nfs-csi task create balance --dusage=50 -W   # consolidate data chunks <50% full
+btrfs-nfs-csi task create balance --musage=50 -W   # same for metadata
+```
+
+This is what you want to run on a schedule. Fixes "No space left on device" errors on btrfs when `df` still shows free space, and keeps fragmentation low over time.
+
+**RAID profile migration** (one-time operations):
+
+```bash
+btrfs-nfs-csi task create balance --dconvert=raid1 --mconvert=raid1 -W
+btrfs-nfs-csi task create balance --dconvert=single,soft -W    # only convert chunks not already single
+btrfs-nfs-csi task create balance --dconvert=single --force -W # reduce redundancy, requires -f
+```
+
+**Drain a device** before removal:
+
+```bash
+btrfs-nfs-csi task create balance --ddevid=2 --mdevid=2 -W
+```
+
+**Unfiltered balance** rewrites every chunk. This is almost never what you want on a running filesystem: huge IO load and hours-to-days runtime. The agent logs a warning when no filter is set.
+
+**Cancel behaviour:** `task cancel <id>` triggers `btrfs balance cancel` on the kernel side, not just a process kill. Balance state is not persisted across reboots, so interrupted balances do not resume automatically.
+
+**Scheduled monthly balance** (systemd timer, analogous to the scrub example above, with `ExecStart=btrfs-nfs-csi task create balance --dusage=75 -W`).
+
 ## CLI
 
 The `btrfs-nfs-csi` binary doubles as a CLI tool. Server commands (`agent`, `integration kubernetes controller|driver`) start long-running processes; everything else is a CLI command.


### PR DESCRIPTION
## Summary
- New `balance` task type with full flag set (`dusage`/`musage`/`susage`, `dprofiles`/`mprofiles`, `ddevid`/`mdevid`, `dconvert`/`mconvert`/`sconvert`, `force`). Invalid opts rejected with `INVALID`.
- Cancel propagates to kernel via explicit `btrfs balance cancel` (unlike scrub, kernel balance survives a process kill).
- `Storage.maintenanceMu` serializes Scrub and Balance starts, killing a race where concurrent requests slipped past the busy check and enqueued duplicates.
