### PR TITLE
Add scrub task flags: readonly, force, ioprio-class, ioprio-classdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.10.1 (unreleased)
 
+### Features
+- New `balance` task type (`task create balance`) with full flag set (usage/profile/device filters, RAID conversion via `dconvert`/`mconvert`/`sconvert`, `force`). Mutex serializes Scrub and Balance so they cannot run concurrently. Cancel propagates to kernel via `btrfs balance cancel`.
+- Scrub task accepts `--readonly`, `--force`, `--ioprio-class`, and `--ioprio-classdata` (CLI) / `opts` (API). Invalid values rejected with `INVALID`; `-B` remains hardcoded for progress tracking.
+
 ### Security
 - Constant-time token comparison in the agent auth middleware, replacing the map lookup
 

--- a/agent/storage/balance.go
+++ b/agent/storage/balance.go
@@ -148,9 +148,9 @@ func balanceArgsFromOpts(opts map[string]string) ([]string, error) {
 
 	for _, k := range []string{"dusage", "musage", "susage"} {
 		if v, ok := opts[k]; ok {
-			pct, err := strconv.Atoi(v)
-			if err != nil || pct < 0 || pct > 100 {
-				return nil, &config.ValidationError{Message: fmt.Sprintf("invalid %s value %q (expected integer 0-100)", k, v)}
+			pct, err := config.ValidateIntInRange(v, 0, 100, k)
+			if err != nil {
+				return nil, err
 			}
 			args = append(args, fmt.Sprintf("-%s=%d", k, pct))
 		}

--- a/agent/storage/btrfs/btrfs.go
+++ b/agent/storage/btrfs/btrfs.go
@@ -166,8 +166,11 @@ func (m *Manager) FilesystemUsage(ctx context.Context, path string) (FilesystemU
 
 // ScrubStart runs a btrfs scrub in foreground mode (-B).
 // Blocks until the scrub completes or the context is cancelled.
-func (m *Manager) ScrubStart(ctx context.Context, path string) error {
-	return m.run(ctx, "scrub", "start", "-B", path)
+// Extra args are inserted between -B and path (e.g. -r, -f, -c N, -n N).
+func (m *Manager) ScrubStart(ctx context.Context, path string, args []string) error {
+	cmdArgs := append([]string{"scrub", "start", "-B"}, args...)
+	cmdArgs = append(cmdArgs, path)
+	return m.run(ctx, cmdArgs...)
 }
 
 // ScrubStatus returns the status of the last/current scrub on the filesystem at path.

--- a/agent/storage/btrfs/btrfs_test.go
+++ b/agent/storage/btrfs/btrfs_test.go
@@ -597,10 +597,20 @@ func TestScrubStatus(t *testing.T) {
 		m := &utils.MockRunner{}
 		mgr := newTestManager(m)
 
-		err := mgr.ScrubStart(context.Background(), "/mnt/data")
+		err := mgr.ScrubStart(context.Background(), "/mnt/data", nil)
 		require.NoError(t, err)
 		require.Len(t, m.Calls, 1)
 		assert.Equal(t, []string{"scrub", "start", "-B", "/mnt/data"}, m.Calls[0])
+	})
+
+	t.Run("scrub start inserts extra args between -B and path", func(t *testing.T) {
+		m := &utils.MockRunner{}
+		mgr := newTestManager(m)
+
+		err := mgr.ScrubStart(context.Background(), "/mnt/data", []string{"-r", "-c", "3"})
+		require.NoError(t, err)
+		require.Len(t, m.Calls, 1)
+		assert.Equal(t, []string{"scrub", "start", "-B", "-r", "-c", "3", "/mnt/data"}, m.Calls[0])
 	})
 }
 

--- a/agent/storage/btrfs/integration_test.go
+++ b/agent/storage/btrfs/integration_test.go
@@ -266,7 +266,7 @@ func (s *BtrfsIntegrationSuite) TestScrubStartAndStatus() {
 	s.Require().NoError(err, "sync")
 
 	// run scrub in foreground (-B)
-	err = s.mgr.ScrubStart(s.ctx, s.mnt)
+	err = s.mgr.ScrubStart(s.ctx, s.mnt, nil)
 	s.Require().NoError(err, "ScrubStart")
 
 	// check result
@@ -284,7 +284,7 @@ func (s *BtrfsIntegrationSuite) TestScrubCancelViaContext() {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- s.mgr.ScrubStart(ctx, s.mnt)
+		done <- s.mgr.ScrubStart(ctx, s.mnt, nil)
 	}()
 
 	// cancel immediately

--- a/agent/storage/scrub.go
+++ b/agent/storage/scrub.go
@@ -3,12 +3,23 @@ package storage
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strconv"
 	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/task"
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/rs/zerolog/log"
 )
+
+const (
+	scrubOptReadonly        = "readonly"
+	scrubOptForce           = "force"
+	scrubOptIoPrioClass     = "ioprio_class"
+	scrubOptIoPrioClassData = "ioprio_classdata"
+)
+
+var scrubOptsKeys = []string{scrubOptReadonly, scrubOptForce, scrubOptIoPrioClass, scrubOptIoPrioClassData}
 
 // StartScrub starts a btrfs scrub as a background task and returns the task ID.
 func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
@@ -31,19 +42,24 @@ func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, labels
 		return "", err
 	}
 
+	args, err := scrubArgsFromOpts(opts)
+	if err != nil {
+		return "", err
+	}
+
 	t := s.taskScrubTimeout
 	if timeout > 0 {
 		t = timeout
 	}
 	id := s.tasks.Create(string(task.TypeScrub), task.TaskOpts{Opts: opts, Labels: labels, Timeout: t}, func(ctx context.Context, update *task.Update) error {
-		return s.runScrub(ctx, update)
+		return s.runScrub(ctx, update, args)
 	})
 
-	log.Info().Str("task", id).Str("path", s.mountPoint).Msg("scrub started")
+	log.Info().Str("task", id).Str("path", s.mountPoint).Strs("args", args).Msg("scrub started")
 	return id, nil
 }
 
-func (s *Storage) runScrub(ctx context.Context, update *task.Update) error {
+func (s *Storage) runScrub(ctx context.Context, update *task.Update, args []string) error {
 	stop := update.PollProgress(ctx, func() int {
 		status, err := s.btrfs.ScrubStatus(ctx, s.mountPoint)
 		if err != nil {
@@ -61,7 +77,7 @@ func (s *Storage) runScrub(ctx context.Context, update *task.Update) error {
 		return 0
 	})
 
-	err := s.btrfs.ScrubStart(ctx, s.mountPoint)
+	err := s.btrfs.ScrubStart(ctx, s.mountPoint, args)
 	stop()
 
 	if err != nil {
@@ -77,6 +93,40 @@ func (s *Storage) runScrub(ctx context.Context, update *task.Update) error {
 		log.Warn().Err(err).Msg("failed to store scrub result")
 	}
 	return nil
+}
+
+func scrubArgsFromOpts(opts map[string]string) ([]string, error) {
+	if len(opts) == 0 {
+		return nil, nil
+	}
+	for k := range opts {
+		if !slices.Contains(scrubOptsKeys, k) {
+			return nil, &config.ValidationError{Message: fmt.Sprintf("unknown scrub option %q", k)}
+		}
+	}
+
+	args := make([]string, 0, len(opts))
+	if opts[scrubOptReadonly] == "true" {
+		args = append(args, "-r")
+	}
+	if opts[scrubOptForce] == "true" {
+		args = append(args, "-f")
+	}
+	if v, ok := opts[scrubOptIoPrioClass]; ok {
+		n, err := config.ValidateIntInRange(v, 0, 3, scrubOptIoPrioClass)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "-c", strconv.Itoa(n))
+	}
+	if v, ok := opts[scrubOptIoPrioClassData]; ok {
+		n, err := config.ValidateIntInRange(v, 0, 7, scrubOptIoPrioClassData)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "-n", strconv.Itoa(n))
+	}
+	return args, nil
 }
 
 func (s *Storage) filesystemUsedBytes() uint64 {

--- a/agent/storage/scrub_args_test.go
+++ b/agent/storage/scrub_args_test.go
@@ -1,0 +1,51 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrubArgsFromOpts(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", opts: nil, want: nil},
+		{name: "readonly", opts: map[string]string{"readonly": "true"}, want: []string{"-r"}},
+		{name: "force", opts: map[string]string{"force": "true"}, want: []string{"-f"}},
+		{name: "readonly_false_omitted", opts: map[string]string{"readonly": "false"}, want: []string{}},
+		{name: "ioprio_class_idle", opts: map[string]string{"ioprio_class": "3"}, want: []string{"-c", "3"}},
+		{name: "ioprio_classdata_highest", opts: map[string]string{"ioprio_classdata": "0"}, want: []string{"-n", "0"}},
+		{name: "ioprio_classdata_lowest", opts: map[string]string{"ioprio_classdata": "7"}, want: []string{"-n", "7"}},
+		{
+			name: "all_combined",
+			opts: map[string]string{"readonly": "true", "force": "true", "ioprio_class": "2", "ioprio_classdata": "4"},
+			want: []string{"-r", "-f", "-c", "2", "-n", "4"},
+		},
+		{name: "unknown_key", opts: map[string]string{"bogus": "1"}, wantErr: true},
+		{name: "ioprio_class_out_of_range", opts: map[string]string{"ioprio_class": "4"}, wantErr: true},
+		{name: "ioprio_class_negative", opts: map[string]string{"ioprio_class": "-1"}, wantErr: true},
+		{name: "ioprio_class_not_int", opts: map[string]string{"ioprio_class": "abc"}, wantErr: true},
+		{name: "ioprio_classdata_out_of_range", opts: map[string]string{"ioprio_classdata": "8"}, wantErr: true},
+		{name: "ioprio_classdata_negative", opts: map[string]string{"ioprio_classdata": "-1"}, wantErr: true},
+		{name: "ioprio_classdata_not_int", opts: map[string]string{"ioprio_classdata": "abc"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := scrubArgsFromOpts(tt.opts)
+			if tt.wantErr {
+				require.Error(t, err)
+				var ve *config.ValidationError
+				require.ErrorAs(t, err, &ve)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/btrfs-nfs-csi/model.go
+++ b/cmd/btrfs-nfs-csi/model.go
@@ -343,6 +343,10 @@ func taskCmd() *cli.Command {
 						Name:  models.TaskTypeScrub,
 						Usage: "start a btrfs scrub",
 						Flags: []cli.Flag{
+							&cli.BoolFlag{Name: "readonly", Aliases: []string{"r"}, Usage: "scan only, do not attempt repair"},
+							&cli.BoolFlag{Name: "force", Aliases: []string{"f"}, Usage: "force start even if a finished scrub is recorded"},
+							&cli.IntFlag{Name: "ioprio-class", Usage: "IO priority class (0=none, 1=realtime, 2=best-effort, 3=idle)"},
+							&cli.IntFlag{Name: "ioprio-classdata", Usage: "IO priority within class (0-7, 0=highest)"},
 							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
 							&cli.BoolFlag{Name: "wait", Aliases: []string{"W"}, Usage: "wait for completion"},
 							labelFlag(),

--- a/cmd/btrfs-nfs-csi/task.go
+++ b/cmd/btrfs-nfs-csi/task.go
@@ -231,7 +231,21 @@ func taskCancel(ctx context.Context, cmd *cli.Command) error {
 }
 
 func taskCreateScrub(ctx context.Context, cmd *cli.Command) error {
-	req := models.TaskCreateRequest{Labels: parseLabelsFlag(cmd)}
+	opts := map[string]string{}
+	if cmd.Bool("readonly") {
+		opts["readonly"] = "true"
+	}
+	if cmd.Bool("force") {
+		opts["force"] = "true"
+	}
+	if cmd.IsSet("ioprio-class") {
+		opts["ioprio_class"] = fmt.Sprintf("%d", cmd.Int("ioprio-class"))
+	}
+	if cmd.IsSet("ioprio-classdata") {
+		opts["ioprio_classdata"] = fmt.Sprintf("%d", cmd.Int("ioprio-classdata"))
+	}
+
+	req := models.TaskCreateRequest{Labels: parseLabelsFlag(cmd), Opts: opts}
 	if t := cmd.Duration("timeout"); t > 0 {
 		req.Timeout = t.String()
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -69,6 +70,16 @@ func ValidateTenantName(name string) error {
 		return &ValidationError{Message: fmt.Sprintf("tenant name %q is reserved", name)}
 	}
 	return nil
+}
+
+// ValidateIntInRange parses val as an integer and checks it is between min and
+// max (inclusive). Returns a ValidationError with the fieldName for reporting.
+func ValidateIntInRange(val string, min, max int, fieldName string) (int, error) {
+	n, err := strconv.Atoi(val)
+	if err != nil || n < min || n > max {
+		return 0, &ValidationError{Message: fmt.Sprintf("invalid %s value %q (expected integer %d-%d)", fieldName, val, min, max)}
+	}
+	return n, nil
 }
 
 func ValidateLabels(labels map[string]string) error {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -117,6 +117,20 @@ btrfs-nfs-csi task list                # check progress
 btrfs-nfs-csi task cancel <id>         # cancel
 ```
 
+**Optional flags** (mirror `btrfs scrub start`):
+
+```bash
+btrfs-nfs-csi task create scrub --readonly -W       # audit only, no repair attempt
+btrfs-nfs-csi task create scrub --ioprio-class=3 -W # idle IO priority (good for scheduled scrubs)
+```
+
+- `--readonly` (`-r`): Read-only scan, report errors without attempting repair.
+- `--force` (`-f`): Start even if a previously-finished scrub record exists on the FS.
+- `--ioprio-class`: IO priority class (`0`=none, `1`=realtime, `2`=best-effort, `3`=idle).
+- `--ioprio-classdata`: Priority within the class (`0`-`7`, `0`=highest).
+
+`-B` (foreground) is always set so the agent can track progress and enforce timeouts.
+
 Only one scrub can run at a time per filesystem. The agent detects externally started scrubs (e.g. via `btrfs scrub start` on the host) and rejects duplicates.
 
 Completed tasks include a result with bytes scrubbed and error counts. Tasks are persisted to disk and cleaned up after `AGENT_TASK_CLEANUP_INTERVAL` (default 24h).


### PR DESCRIPTION
## Summary
- `task create scrub` accepts `--readonly`, `--force`, `--ioprio-class` (0-3), `--ioprio-classdata` (0-7). Invalid values rejected with `INVALID`. `-B` stays hardcoded for progress tracking.
- New `config.ValidateIntInRange` helper replaces 5 inline parse+range copies across scrub and balance.