### PR TITLE
Add defragment task, tenant-scoped with path-traversal safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - New `balance` task type (`task create balance`) with full flag set (usage/profile/device filters, RAID conversion via `dconvert`/`mconvert`/`sconvert`, `force`). Mutex serializes Scrub and Balance so they cannot run concurrently. Cancel propagates to kernel via `btrfs balance cancel`.
 - Scrub task accepts `--readonly`, `--force`, `--ioprio-class`, and `--ioprio-classdata` (CLI) / `opts` (API). Invalid values rejected with `INVALID`; `-B` remains hardcoded for progress tracking.
+- New `defragment` task type (`task create defragment`) targeting a specific `--volume`, optionally scoped to a `--path` sub-directory. Supports `--compress`, `--no-recursive`, and `--threshold`. Path traversal and symlink escapes are rejected at the validation layer. Snapshots are not supported because the agent creates them read-only; clones (writable) can be defragmented like any volume.
 
 ### Security
 - Constant-time token comparison in the agent auth middleware, replacing the map lookup

--- a/agent/api/v1/handler_task.go
+++ b/agent/api/v1/handler_task.go
@@ -55,11 +55,11 @@ func taskDetailResponseFrom(t *task.Task) models.TaskDetailResponse {
 
 // CreateTask godoc
 // @Summary      Create a background task
-// @Description  Creates a background task (scrub, balance, test). Returns 202 Accepted with task ID.
+// @Description  Creates a background task (scrub, balance, defragment, test). Returns 202 Accepted with task ID.
 // @Tags         tasks
 // @Accept       json
 // @Produce      json
-// @Param        type    path string true "Task type" Enums(scrub, balance, test)
+// @Param        type    path string true "Task type" Enums(scrub, balance, defragment, test)
 // @Param        request body models.TaskCreateRequest false "Task options"
 // @Success      202 {object} models.TaskCreateResponse
 // @Failure      400 {object} models.ErrorResponse
@@ -88,15 +88,20 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "label \"" + config.LabelCreatedBy + "\" is required", Code: storage.ErrInvalid})
 	}
 
+	ctx := c.Request().Context()
+	tenant := c.Get("tenant").(string)
+
 	var taskID string
 	var err error
 	switch taskType {
 	case models.TaskTypeScrub:
-		taskID, err = h.Store.StartScrub(c.Request().Context(), req.Opts, req.Labels, timeout)
+		taskID, err = h.Store.StartScrub(ctx, req.Opts, req.Labels, timeout)
 	case models.TaskTypeBalance:
-		taskID, err = h.Store.StartBalance(c.Request().Context(), req.Opts, req.Labels, timeout)
+		taskID, err = h.Store.StartBalance(ctx, req.Opts, req.Labels, timeout)
+	case models.TaskTypeDefragment:
+		taskID, err = h.Store.StartDefragment(ctx, tenant, req.Volume, req.Path, req.Opts, req.Labels, timeout)
 	case models.TaskTypeTest:
-		taskID, err = h.Store.StartTestTask(c.Request().Context(), req.Opts, req.Labels, timeout)
+		taskID, err = h.Store.StartTestTask(ctx, req.Opts, req.Labels, timeout)
 	default:
 		return c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "unknown task type: " + taskType, Code: storage.ErrInvalid})
 	}
@@ -111,7 +116,7 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 // @Description  Returns background tasks. Filter by type. Supports detail, pagination, and label filtering.
 // @Tags         tasks
 // @Produce      json
-// @Param        type   query string false "Filter by task type" Enums(scrub, balance, test)
+// @Param        type   query string false "Filter by task type" Enums(scrub, balance, defragment, test)
 // @Param        detail query string false "Return full detail" Enums(true)
 // @Param        limit  query int    false "Items per page (0 = pagination disabled)"
 // @Param        after  query string false "Pagination cursor"

--- a/agent/api/v1/models/models.go
+++ b/agent/api/v1/models/models.go
@@ -108,12 +108,20 @@ type VolumeExportDeleteRequest struct {
 
 // --- Task requests ---
 
-// TaskCreateRequest creates a background task (scrub, test).
+// TaskCreateRequest creates a background task (scrub, balance, defragment, test).
 // POST /v1/tasks/:type
+//
+// Volume and Path are consumed by type="defragment" to target a specific
+// volume and optionally a sub-path within it; other task types ignore these
+// fields. Defragment does not support snapshots because snapshots are
+// read-only in this agent; clones (which are writable) can be defragmented
+// like any other volume.
 type TaskCreateRequest struct {
 	Timeout string            `json:"timeout,omitempty"` // Go duration string, e.g. "6h", "30m"
 	Opts    map[string]string `json:"opts,omitempty"`    // task-specific options
 	Labels  map[string]string `json:"labels,omitempty"`
+	Volume  string            `json:"volume,omitempty"` // defragment target
+	Path    string            `json:"path,omitempty"`   // defragment sub-path (relative, requires Volume)
 }
 
 // --- Volume responses ---
@@ -394,9 +402,10 @@ const (
 
 // Task type identifiers for POST /v1/tasks/:type.
 const (
-	TaskTypeScrub   = "scrub"
-	TaskTypeBalance = "balance"
-	TaskTypeTest    = "test"
+	TaskTypeScrub      = "scrub"
+	TaskTypeBalance    = "balance"
+	TaskTypeDefragment = "defragment"
+	TaskTypeTest       = "test"
 )
 
 // --- Pagination helpers ---

--- a/agent/storage/btrfs/btrfs.go
+++ b/agent/storage/btrfs/btrfs.go
@@ -203,6 +203,15 @@ func (m *Manager) BalanceCancel(ctx context.Context, path string) error {
 	return m.run(ctx, "balance", "cancel", path)
 }
 
+// Defragment runs a btrfs filesystem defragment against the given path.
+// Blocks until complete or the context is cancelled. Extra args (compression,
+// recursion, threshold) are inserted between the subcommand and the path.
+func (m *Manager) Defragment(ctx context.Context, path string, args []string) error {
+	cmdArgs := append([]string{"filesystem", "defragment"}, args...)
+	cmdArgs = append(cmdArgs, path)
+	return m.run(ctx, cmdArgs...)
+}
+
 // QgroupUsageBulk returns qgroup usage for all subvolumes under path.
 // Runs `btrfs subvolume list -o` and `btrfs qgroup show -re --raw` once each,
 // joins by subvolume ID. Returns map keyed by relative subvolume path.

--- a/agent/storage/btrfs/btrfs_test.go
+++ b/agent/storage/btrfs/btrfs_test.go
@@ -612,6 +612,26 @@ func TestScrubStatus(t *testing.T) {
 		require.Len(t, m.Calls, 1)
 		assert.Equal(t, []string{"scrub", "start", "-B", "-r", "-c", "3", "/mnt/data"}, m.Calls[0])
 	})
+
+	t.Run("defragment builds command with extra args", func(t *testing.T) {
+		m := &utils.MockRunner{}
+		mgr := newTestManager(m)
+
+		err := mgr.Defragment(context.Background(), "/mnt/data/vol/data", []string{"-r", "-czstd"})
+		require.NoError(t, err)
+		require.Len(t, m.Calls, 1)
+		assert.Equal(t, []string{"filesystem", "defragment", "-r", "-czstd", "/mnt/data/vol/data"}, m.Calls[0])
+	})
+
+	t.Run("defragment without args", func(t *testing.T) {
+		m := &utils.MockRunner{}
+		mgr := newTestManager(m)
+
+		err := mgr.Defragment(context.Background(), "/mnt/data/vol/data", nil)
+		require.NoError(t, err)
+		require.Len(t, m.Calls, 1)
+		assert.Equal(t, []string{"filesystem", "defragment", "/mnt/data/vol/data"}, m.Calls[0])
+	})
 }
 
 func TestParseSubvolumeListFull(t *testing.T) {

--- a/agent/storage/defragment.go
+++ b/agent/storage/defragment.go
@@ -22,8 +22,8 @@ const (
 )
 
 var (
-	defragmentOptsKeys     = []string{defragmentOptCompress, defragmentOptRecursive, defragmentOptThreshold}
-	validCompressionAlgos  = []string{"zstd", "lzo", "zlib", "none"}
+	defragmentOptsKeys    = []string{defragmentOptCompress, defragmentOptRecursive, defragmentOptThreshold}
+	validCompressionAlgos = []string{"zstd", "lzo", "zlib", "none"}
 )
 
 // StartDefragment starts a btrfs defragment as a background task against a

--- a/agent/storage/defragment.go
+++ b/agent/storage/defragment.go
@@ -1,0 +1,146 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage/task"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defragmentOptCompress  = "compress"
+	defragmentOptRecursive = "recursive"
+	defragmentOptThreshold = "threshold"
+)
+
+var (
+	defragmentOptsKeys     = []string{defragmentOptCompress, defragmentOptRecursive, defragmentOptThreshold}
+	validCompressionAlgos  = []string{"zstd", "lzo", "zlib", "none"}
+)
+
+// StartDefragment starts a btrfs defragment as a background task against a
+// single volume, optionally scoped to a sub-path relative to the volume's
+// data dir. Snapshots are not supported because the agent creates them
+// read-only; use a clone instead.
+func (s *Storage) StartDefragment(ctx context.Context, tenant, volume, relPath string, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
+	if volume == "" {
+		return "", &config.ValidationError{Message: "defragment requires a volume"}
+	}
+	if err := config.ValidateName(volume); err != nil {
+		return "", err
+	}
+	baseDataDir := s.volumes.DataPath(tenant, volume)
+
+	target, err := resolveDefragTarget(baseDataDir, relPath)
+	if err != nil {
+		return "", err
+	}
+
+	if err := config.ValidateLabels(labels); err != nil {
+		return "", err
+	}
+
+	args, err := defragmentArgsFromOpts(opts)
+	if err != nil {
+		return "", err
+	}
+
+	t := s.taskDefaultTimeout
+	if timeout > 0 {
+		t = timeout
+	}
+	id := s.tasks.Create(string(task.TypeDefragment), task.TaskOpts{Opts: opts, Labels: labels, Timeout: t}, func(ctx context.Context, update *task.Update) error {
+		return s.runDefragment(ctx, update, target, args)
+	})
+
+	log.Info().Str("task", id).Str("target", target).Strs("args", args).Msg("defragment started")
+	return id, nil
+}
+
+func (s *Storage) runDefragment(ctx context.Context, update *task.Update, target string, args []string) error {
+	// btrfs defragment has no native progress reporting; we set a coarse
+	// midpoint so clients can distinguish "still running" from "not yet
+	// started". The framework takes the task to 100 on success.
+	update.SetProgress(50)
+	if err := s.btrfs.Defragment(ctx, target, args); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("btrfs defragment: %w", err)
+	}
+	return nil
+}
+
+// resolveDefragTarget joins baseDataDir with relPath, enforcing that the
+// result stays under baseDataDir after symlink resolution. An empty relPath
+// returns baseDataDir; the base itself must still exist.
+func resolveDefragTarget(baseDataDir, relPath string) (string, error) {
+	if relPath == "" {
+		if _, err := os.Stat(baseDataDir); err != nil {
+			if os.IsNotExist(err) {
+				return "", &config.ValidationError{Message: "defragment target volume not found"}
+			}
+			return "", &config.ValidationError{Message: fmt.Sprintf("defragment target: %s", err)}
+		}
+		return baseDataDir, nil
+	}
+	if filepath.IsAbs(relPath) {
+		return "", &config.ValidationError{Message: "defragment path must be relative"}
+	}
+	cleaned := filepath.Clean(relPath)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", &config.ValidationError{Message: fmt.Sprintf("defragment path %q escapes volume directory", relPath)}
+	}
+	joined := filepath.Join(baseDataDir, cleaned)
+	real, err := filepath.EvalSymlinks(joined)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", &config.ValidationError{Message: fmt.Sprintf("defragment path %q does not exist", relPath)}
+		}
+		return "", &config.ValidationError{Message: fmt.Sprintf("defragment path %q: %s", relPath, err)}
+	}
+	if real != baseDataDir && !strings.HasPrefix(real, baseDataDir+string(filepath.Separator)) {
+		return "", &config.ValidationError{Message: fmt.Sprintf("defragment path %q escapes volume directory via symlink", relPath)}
+	}
+	return joined, nil
+}
+
+func defragmentArgsFromOpts(opts map[string]string) ([]string, error) {
+	for k := range opts {
+		if !slices.Contains(defragmentOptsKeys, k) {
+			return nil, &config.ValidationError{Message: fmt.Sprintf("unknown defragment option %q", k)}
+		}
+	}
+
+	args := make([]string, 0, len(opts))
+
+	// Recursive defaults to true; "false" disables.
+	if opts[defragmentOptRecursive] != "false" {
+		args = append(args, "-r")
+	}
+
+	if v, ok := opts[defragmentOptCompress]; ok && v != "" && v != "none" {
+		if !slices.Contains(validCompressionAlgos, v) {
+			return nil, &config.ValidationError{Message: fmt.Sprintf("invalid compress value %q (expected one of: zstd, lzo, zlib, none)", v)}
+		}
+		args = append(args, "-c"+v)
+	}
+
+	if v, ok := opts[defragmentOptThreshold]; ok {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return nil, &config.ValidationError{Message: fmt.Sprintf("invalid threshold value %q (expected positive integer bytes)", v)}
+		}
+		args = append(args, "-t", strconv.Itoa(n))
+	}
+
+	return args, nil
+}

--- a/agent/storage/defragment_test.go
+++ b/agent/storage/defragment_test.go
@@ -1,0 +1,126 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefragmentArgsFromOpts(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty_defaults_recursive", opts: nil, want: []string{"-r"}},
+		{name: "recursive_explicit_true", opts: map[string]string{"recursive": "true"}, want: []string{"-r"}},
+		{name: "recursive_false_omits_r", opts: map[string]string{"recursive": "false"}, want: []string{}},
+		{name: "compress_zstd", opts: map[string]string{"compress": "zstd"}, want: []string{"-r", "-czstd"}},
+		{name: "compress_lzo", opts: map[string]string{"compress": "lzo"}, want: []string{"-r", "-clzo"}},
+		{name: "compress_zlib", opts: map[string]string{"compress": "zlib"}, want: []string{"-r", "-czlib"}},
+		{name: "compress_none_no_flag", opts: map[string]string{"compress": "none"}, want: []string{"-r"}},
+		{name: "threshold_valid", opts: map[string]string{"threshold": "1048576"}, want: []string{"-r", "-t", "1048576"}},
+		{
+			name: "combined",
+			opts: map[string]string{"compress": "zstd", "recursive": "false", "threshold": "4096"},
+			want: []string{"-czstd", "-t", "4096"},
+		},
+		{name: "unknown_key", opts: map[string]string{"bogus": "1"}, wantErr: true},
+		{name: "compress_invalid_algo", opts: map[string]string{"compress": "snappy"}, wantErr: true},
+		{name: "threshold_zero", opts: map[string]string{"threshold": "0"}, wantErr: true},
+		{name: "threshold_negative", opts: map[string]string{"threshold": "-1"}, wantErr: true},
+		{name: "threshold_not_int", opts: map[string]string{"threshold": "abc"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := defragmentArgsFromOpts(tt.opts)
+			if tt.wantErr {
+				require.Error(t, err)
+				var ve *config.ValidationError
+				require.ErrorAs(t, err, &ve)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveDefragTarget(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(base, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "sub", "file.txt"), []byte("x"), 0o644))
+
+	// Symlink pointing outside the base: build a "secret" dir next to base.
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret"), []byte("nope"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join(outside, "secret"), filepath.Join(base, "escape-link")))
+	// Symlink pointing within the base (valid).
+	require.NoError(t, os.Symlink(filepath.Join(base, "sub"), filepath.Join(base, "inside-link")))
+
+	t.Run("empty_returns_base", func(t *testing.T) {
+		got, err := resolveDefragTarget(base, "")
+		require.NoError(t, err)
+		assert.Equal(t, base, got)
+	})
+
+	t.Run("valid_subdir", func(t *testing.T) {
+		got, err := resolveDefragTarget(base, "sub")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "sub"), got)
+	})
+
+	t.Run("valid_file", func(t *testing.T) {
+		got, err := resolveDefragTarget(base, "sub/file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "sub", "file.txt"), got)
+	})
+
+	t.Run("absolute_path_rejected", func(t *testing.T) {
+		_, err := resolveDefragTarget(base, "/etc/passwd")
+		var ve *config.ValidationError
+		require.ErrorAs(t, err, &ve)
+	})
+
+	t.Run("dotdot_rejected", func(t *testing.T) {
+		_, err := resolveDefragTarget(base, "..")
+		var ve *config.ValidationError
+		require.ErrorAs(t, err, &ve)
+	})
+
+	t.Run("dotdot_prefix_rejected", func(t *testing.T) {
+		_, err := resolveDefragTarget(base, "../evil")
+		var ve *config.ValidationError
+		require.ErrorAs(t, err, &ve)
+	})
+
+	t.Run("nonexistent_rejected", func(t *testing.T) {
+		_, err := resolveDefragTarget(base, "does-not-exist")
+		var ve *config.ValidationError
+		require.ErrorAs(t, err, &ve)
+	})
+
+	t.Run("symlink_inside_base_allowed", func(t *testing.T) {
+		got, err := resolveDefragTarget(base, "inside-link")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "inside-link"), got)
+	})
+
+	t.Run("symlink_escape_rejected", func(t *testing.T) {
+		_, err := resolveDefragTarget(base, "escape-link")
+		var ve *config.ValidationError
+		require.ErrorAs(t, err, &ve, "symlink pointing outside base must be rejected")
+	})
+
+	t.Run("empty_path_but_base_missing_rejected", func(t *testing.T) {
+		missing := filepath.Join(base, "not-a-real-volume")
+		_, err := resolveDefragTarget(missing, "")
+		var ve *config.ValidationError
+		require.ErrorAs(t, err, &ve)
+	})
+}

--- a/agent/storage/task/model.go
+++ b/agent/storage/task/model.go
@@ -24,9 +24,10 @@ const (
 type TaskType string
 
 const (
-	TypeScrub   TaskType = "scrub"
-	TypeBalance TaskType = "balance"
-	TypeTest    TaskType = "test"
+	TypeScrub      TaskType = "scrub"
+	TypeBalance    TaskType = "balance"
+	TypeDefragment TaskType = "defragment"
+	TypeTest       TaskType = "test"
 )
 
 // ErrNotFound is returned when a task ID doesn't exist.

--- a/cmd/btrfs-nfs-csi/model.go
+++ b/cmd/btrfs-nfs-csi/model.go
@@ -375,6 +375,21 @@ func taskCmd() *cli.Command {
 						Action: taskCreateBalance,
 					},
 					{
+						Name:  models.TaskTypeDefragment,
+						Usage: "defragment a volume or a sub-path within a volume",
+						Flags: []cli.Flag{
+							&cli.StringFlag{Name: "volume", Usage: "volume to defragment (required)"},
+							&cli.StringFlag{Name: "path", Usage: "sub-path relative to the volume data dir"},
+							&cli.StringFlag{Name: "compress", Usage: "recompress during defrag: zstd, lzo, zlib, or none (default none)"},
+							&cli.BoolFlag{Name: "no-recursive", Usage: "do not recurse into subdirectories"},
+							&cli.IntFlag{Name: "threshold", Usage: "target extent size in bytes; files whose extents already exceed this are skipped"},
+							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
+							&cli.BoolFlag{Name: "wait", Aliases: []string{"W"}, Usage: "wait for completion"},
+							labelFlag(),
+						},
+						Action: taskCreateDefragment,
+					},
+					{
 						Name:  models.TaskTypeTest,
 						Usage: "start a test task",
 						Flags: []cli.Flag{

--- a/cmd/btrfs-nfs-csi/task.go
+++ b/cmd/btrfs-nfs-csi/task.go
@@ -304,6 +304,47 @@ func taskCreateBalance(ctx context.Context, cmd *cli.Command) error {
 	return waitForTask(ctx, resp.TaskID)
 }
 
+func taskCreateDefragment(ctx context.Context, cmd *cli.Command) error {
+	volume := cmd.String("volume")
+	if volume == "" {
+		return fmt.Errorf("defragment requires --volume")
+	}
+
+	opts := map[string]string{}
+	if v := cmd.String("compress"); v != "" {
+		opts["compress"] = v
+	}
+	if cmd.Bool("no-recursive") {
+		opts["recursive"] = "false"
+	}
+	if cmd.IsSet("threshold") {
+		opts["threshold"] = fmt.Sprintf("%d", cmd.Int("threshold"))
+	}
+
+	req := models.TaskCreateRequest{
+		Labels: parseLabelsFlag(cmd),
+		Opts:   opts,
+		Volume: volume,
+		Path:   cmd.String("path"),
+	}
+	if t := cmd.Duration("timeout"); t > 0 {
+		req.Timeout = t.String()
+	}
+	resp, err := apiClient.CreateTask(ctx, models.TaskTypeDefragment, req)
+	if err != nil {
+		return err
+	}
+	if !cmd.Bool("wait") {
+		return output(cmd, resp, func() {
+			fmt.Printf("defragment started (task %s)\n", resp.TaskID)
+		})
+	}
+	if !isJSON(cmd) {
+		fmt.Printf("defragment started (task %s)\n", resp.TaskID)
+	}
+	return waitForTask(ctx, resp.TaskID)
+}
+
 func taskCreateTest(ctx context.Context, cmd *cli.Command) error {
 	req := models.TaskCreateRequest{Labels: parseLabelsFlag(cmd)}
 	if s := cmd.Duration("sleep"); s > 0 {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -172,6 +172,34 @@ chmod 600 /etc/default/btrfs-nfs-csi
 systemctl enable --now btrfs-scrub.timer
 ```
 
+## Defragment
+
+btrfs filesystem defragment rewrites files to reduce extent fragmentation. Unlike scrub and balance (which operate filesystem-wide), defragment targets a specific **volume** or **sub-path within a volume** — so it fits naturally into the multi-tenant model.
+
+Snapshots are read-only in this agent and cannot be defragmented. Use a clone (which is a writable snapshot) if you need to defragment a point-in-time copy.
+
+```bash
+btrfs-nfs-csi task create defragment --volume my-vol -W                   # whole volume
+btrfs-nfs-csi task create defragment --volume my-vol --path logs          # sub-path
+btrfs-nfs-csi task create defragment --volume pg-main --compress=zstd -W  # recompress while defragging
+```
+
+**Flags:**
+
+- `--volume` (required): volume to defragment.
+- `--path`: sub-path relative to the volume data dir. Absolute paths and `..` traversal are rejected; symlinks must resolve to stay under the target dir.
+- `--compress zstd|lzo|zlib|none` (default `none`): recompress during defrag.
+- `--no-recursive`: do not recurse into subdirectories (by default, directories are recursed).
+- `--threshold <bytes>`: target extent size — btrfs skips files whose extents already exceed this size.
+
+**Free-space requirement:** Defragment writes new extents before freeing the old ones, so the target volume needs headroom. A volume at 100% of its qgroup quota will fail with `Disk quota exceeded` during defrag. Either expand the quota temporarily or free some data first.
+
+**Concurrency:** Defragment does not take the scrub/balance mutex — it can run in parallel with either. Expect heavy IO if combined.
+
+**Progress reporting:** btrfs does not expose a native progress indicator for defragment (unlike scrub and balance). The task reports a coarse state instead: `0%` while pending, `50%` once running, `100%` on successful completion. A failed or cancelled defragment that had already started shows `50%` at the final state, distinguishing it from one that never got going.
+
+**Reflink caveat:** Defragment can break the block-sharing between snapshots and clones. If you have many snapshots of the volume, disk usage may grow noticeably after a defrag.
+
 ## Balance
 
 btrfs balance rewrites chunks to reclaim wasted space, consolidate half-empty chunks, or change the RAID profile. Runs as a background task via the task system. Balance and scrub are mutually exclusive: only one heavy maintenance task per filesystem at a time.


### PR DESCRIPTION
## Summary
- New `defragment` task type targeting a `--volume` plus optional `--path` sub-directory. Supports `--compress` (zstd/lzo/zlib), `--no-recursive`, and `--threshold`. Absolute paths, `..` segments, and symlink escapes are rejected before the task is queued.
- Snapshots are not supported, they are read-only in this agent. Clones (writable snapshots) can be defragmented like any volume.
- Progress reports 0/50/100 since btrfs has no native progress for defragment; a task that reaches 50% and then fails is distinguishable from one that never started.
