### PR TITLE
Add quota-rescan task with squota-aware error translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New `balance` task type (`task create balance`) with full flag set (usage/profile/device filters, RAID conversion via `dconvert`/`mconvert`/`sconvert`, `force`). Mutex serializes Scrub and Balance so they cannot run concurrently. Cancel propagates to kernel via `btrfs balance cancel`.
 - Scrub task accepts `--readonly`, `--force`, `--ioprio-class`, and `--ioprio-classdata` (CLI) / `opts` (API). Invalid values rejected with `INVALID`; `-B` remains hardcoded for progress tracking.
 - New `defragment` task type (`task create defragment`) targeting a specific `--volume`, optionally scoped to a `--path` sub-directory. Supports `--compress`, `--no-recursive`, and `--threshold`. Path traversal and symlink escapes are rejected at the validation layer. Snapshots are not supported because the agent creates them read-only; clones (writable) can be defragmented like any volume.
+- New `quota-rescan` task type (`task create quota-rescan`) rebuilds btrfs qgroup accounting filesystem-wide. Mutually exclusive with scrub and balance. Note: only supported on classic qgroups; simple quotas (squota) fail fast with a clear error, as btrfs does not support rescan on that mode.
 
 ### Security
 - Constant-time token comparison in the agent auth middleware, replacing the map lookup
@@ -117,7 +118,7 @@ This release adds the Helm chart as the primary deployment method for the CSI dr
 - Rename `helm.yml` to `ci-helm.yml`, add `helm-release.yml` as reusable workflow (#71)
 
 ### Breaking Changes
-- `btrfs_nfs_csi_controller_agent_health_total` metric removed — use `agent_ops_total{operation="health_check"}` instead (#69)
+- `btrfs_nfs_csi_controller_agent_health_total` metric removed, use `agent_ops_total{operation="health_check"}` instead (#69)
 - Health checks now tracked in `agent_ops_total` and `agent_duration_seconds` with `operation=health_check` (#69)
 
 ## v0.9.9
@@ -139,7 +140,7 @@ This release adds the Helm chart as the primary deployment method for the CSI dr
 - Unit tests for driver utils (ResolveNodeIP) (#59)
 
 ### Security
-- Bump `google.golang.org/grpc` to v1.79.3 — fixes CVE-2026-33186 (authorization bypass via missing leading slash in `:path`, CVSS 9.1 Critical)
+- Bump `google.golang.org/grpc` to v1.79.3, fixes CVE-2026-33186 (authorization bypass via missing leading slash in `:path`, CVSS 9.1 Critical)
 
 ### Other
 - Improved controller agent version check message on non-matching commit builds, issue #54 (#56)

--- a/agent/api/v1/handler_task.go
+++ b/agent/api/v1/handler_task.go
@@ -55,11 +55,11 @@ func taskDetailResponseFrom(t *task.Task) models.TaskDetailResponse {
 
 // CreateTask godoc
 // @Summary      Create a background task
-// @Description  Creates a background task (scrub, balance, defragment, test). Returns 202 Accepted with task ID.
+// @Description  Creates a background task (scrub, balance, defragment, quota-rescan, test). Returns 202 Accepted with task ID.
 // @Tags         tasks
 // @Accept       json
 // @Produce      json
-// @Param        type    path string true "Task type" Enums(scrub, balance, defragment, test)
+// @Param        type    path string true "Task type" Enums(scrub, balance, defragment, quota-rescan, test)
 // @Param        request body models.TaskCreateRequest false "Task options"
 // @Success      202 {object} models.TaskCreateResponse
 // @Failure      400 {object} models.ErrorResponse
@@ -100,6 +100,8 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 		taskID, err = h.Store.StartBalance(ctx, req.Opts, req.Labels, timeout)
 	case models.TaskTypeDefragment:
 		taskID, err = h.Store.StartDefragment(ctx, tenant, req.Volume, req.Path, req.Opts, req.Labels, timeout)
+	case models.TaskTypeQuotaRescan:
+		taskID, err = h.Store.StartQuotaRescan(ctx, req.Opts, req.Labels, timeout)
 	case models.TaskTypeTest:
 		taskID, err = h.Store.StartTestTask(ctx, req.Opts, req.Labels, timeout)
 	default:
@@ -116,7 +118,7 @@ func (h *Handler) CreateTask(c *echo.Context) error {
 // @Description  Returns background tasks. Filter by type. Supports detail, pagination, and label filtering.
 // @Tags         tasks
 // @Produce      json
-// @Param        type   query string false "Filter by task type" Enums(scrub, balance, defragment, test)
+// @Param        type   query string false "Filter by task type" Enums(scrub, balance, defragment, quota-rescan, test)
 // @Param        detail query string false "Return full detail" Enums(true)
 // @Param        limit  query int    false "Items per page (0 = pagination disabled)"
 // @Param        after  query string false "Pagination cursor"

--- a/agent/api/v1/models/models.go
+++ b/agent/api/v1/models/models.go
@@ -402,10 +402,11 @@ const (
 
 // Task type identifiers for POST /v1/tasks/:type.
 const (
-	TaskTypeScrub      = "scrub"
-	TaskTypeBalance    = "balance"
-	TaskTypeDefragment = "defragment"
-	TaskTypeTest       = "test"
+	TaskTypeScrub       = "scrub"
+	TaskTypeBalance     = "balance"
+	TaskTypeDefragment  = "defragment"
+	TaskTypeQuotaRescan = "quota-rescan"
+	TaskTypeTest        = "test"
 )
 
 // --- Pagination helpers ---

--- a/agent/storage/balance.go
+++ b/agent/storage/balance.go
@@ -26,16 +26,8 @@ var balanceOptsKeys = []string{
 func (s *Storage) StartBalance(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
 	s.maintenanceMu.Lock()
 	defer s.maintenanceMu.Unlock()
-	for _, t := range s.tasks.List(string(task.TypeScrub), string(task.TypeBalance)) {
-		if t.Status == task.TaskRunning || t.Status == task.TaskPending {
-			return "", &StorageError{Code: ErrBusy, Message: "another maintenance task is already running"}
-		}
-	}
-	if bst, _ := s.btrfs.BalanceStatus(ctx, s.mountPoint); bst != nil && bst.Running {
-		return "", &StorageError{Code: ErrBusy, Message: "balance already running on filesystem"}
-	}
-	if sst, err := s.btrfs.ScrubStatus(ctx, s.mountPoint); err == nil && sst.Running {
-		return "", &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
+	if err := s.ensureMaintenanceFree(ctx); err != nil {
+		return "", err
 	}
 
 	if err := config.ValidateLabels(labels); err != nil {

--- a/agent/storage/btrfs/btrfs.go
+++ b/agent/storage/btrfs/btrfs.go
@@ -212,6 +212,20 @@ func (m *Manager) Defragment(ctx context.Context, path string, args []string) er
 	return m.run(ctx, cmdArgs...)
 }
 
+// QuotaRescan triggers a btrfs quota rescan and waits for it to finish via -w.
+func (m *Manager) QuotaRescan(ctx context.Context, path string) error {
+	return m.run(ctx, "quota", "rescan", "-w", path)
+}
+
+// QuotaRescanStatus returns whether a rescan is currently in progress.
+func (m *Manager) QuotaRescanStatus(ctx context.Context, path string) (*QuotaRescanStatus, error) {
+	out, err := m.cmd.Run(ctx, m.bin, "quota", "rescan", "-s", path)
+	if err != nil {
+		return nil, err
+	}
+	return parseQuotaRescanStatus(out), nil
+}
+
 // QgroupUsageBulk returns qgroup usage for all subvolumes under path.
 // Runs `btrfs subvolume list -o` and `btrfs qgroup show -re --raw` once each,
 // joins by subvolume ID. Returns map keyed by relative subvolume path.

--- a/agent/storage/btrfs/btrfs_test.go
+++ b/agent/storage/btrfs/btrfs_test.go
@@ -632,6 +632,34 @@ func TestScrubStatus(t *testing.T) {
 		require.Len(t, m.Calls, 1)
 		assert.Equal(t, []string{"filesystem", "defragment", "/mnt/data/vol/data"}, m.Calls[0])
 	})
+
+	t.Run("quota rescan uses -w wait flag", func(t *testing.T) {
+		m := &utils.MockRunner{}
+		mgr := newTestManager(m)
+
+		err := mgr.QuotaRescan(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		require.Len(t, m.Calls, 1)
+		assert.Equal(t, []string{"quota", "rescan", "-w", "/mnt/data"}, m.Calls[0])
+	})
+
+	t.Run("quota rescan status parses idle", func(t *testing.T) {
+		m := &utils.MockRunner{Out: "no rescan operation in progress\n"}
+		mgr := newTestManager(m)
+
+		st, err := mgr.QuotaRescanStatus(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		assert.False(t, st.Running)
+	})
+
+	t.Run("quota rescan status parses running", func(t *testing.T) {
+		m := &utils.MockRunner{Out: "quota rescan status:\nrunning, current key (256 96 0)\n"}
+		mgr := newTestManager(m)
+
+		st, err := mgr.QuotaRescanStatus(context.Background(), "/mnt/data")
+		require.NoError(t, err)
+		assert.True(t, st.Running)
+	})
 }
 
 func TestParseSubvolumeListFull(t *testing.T) {

--- a/agent/storage/btrfs/model.go
+++ b/agent/storage/btrfs/model.go
@@ -66,3 +66,7 @@ type BalanceStatus struct {
 	ChunksTotal uint64 `json:"chunks_total"`
 	LastError   string `json:"last_error,omitempty"`
 }
+
+type QuotaRescanStatus struct {
+	Running bool `json:"running"`
+}

--- a/agent/storage/btrfs/utils.go
+++ b/agent/storage/btrfs/utils.go
@@ -257,6 +257,24 @@ func parseBalanceStatus(out string) (*BalanceStatus, error) {
 	return s, nil
 }
 
+// parseQuotaRescanStatus parses `btrfs quota rescan -s` output.
+// btrfs-progs emits:
+//   - "no rescan operation in progress"                  -> idle
+//   - "quota rescan status:\nrunning, current key ..."   -> running
+func parseQuotaRescanStatus(out string) *QuotaRescanStatus {
+	s := &QuotaRescanStatus{}
+	for line := range strings.SplitSeq(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "no rescan") {
+			return s
+		}
+		if strings.HasPrefix(trimmed, "running") {
+			s.Running = true
+		}
+	}
+	return s
+}
+
 // subvolEntry holds a parsed line from `btrfs subvolume list -o`.
 type subvolEntry struct {
 	ID   string

--- a/agent/storage/scrub.go
+++ b/agent/storage/scrub.go
@@ -25,17 +25,8 @@ var scrubOptsKeys = []string{scrubOptReadonly, scrubOptForce, scrubOptIoPrioClas
 func (s *Storage) StartScrub(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
 	s.maintenanceMu.Lock()
 	defer s.maintenanceMu.Unlock()
-	for _, t := range s.tasks.List(string(task.TypeScrub), string(task.TypeBalance)) {
-		if t.Status == task.TaskRunning || t.Status == task.TaskPending {
-			return "", &StorageError{Code: ErrBusy, Message: "another maintenance task is already running"}
-		}
-	}
-	status, err := s.btrfs.ScrubStatus(ctx, s.mountPoint)
-	if err == nil && status.Running {
-		return "", &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
-	}
-	if bst, _ := s.btrfs.BalanceStatus(ctx, s.mountPoint); bst != nil && bst.Running {
-		return "", &StorageError{Code: ErrBusy, Message: "balance already running on filesystem"}
+	if err := s.ensureMaintenanceFree(ctx); err != nil {
+		return "", err
 	}
 
 	if err := config.ValidateLabels(labels); err != nil {

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -200,6 +201,71 @@ func (s *Storage) BasePath() string       { return s.basePath }
 func (s *Storage) QuotaEnabled() bool     { return s.quotaEnabled }
 func (s *Storage) Exporter() nfs.Exporter { return s.exporter }
 func (s *Storage) Tasks() *task.Manager   { return s.tasks }
+
+// StartQuotaRescan triggers a filesystem-wide btrfs quota rescan. Mutually
+// exclusive with scrub and balance. btrfs has no configurable flags for
+// rescan, so opts must be empty.
+func (s *Storage) StartQuotaRescan(ctx context.Context, opts map[string]string, labels map[string]string, timeout time.Duration) (string, error) {
+	s.maintenanceMu.Lock()
+	defer s.maintenanceMu.Unlock()
+
+	if len(opts) > 0 {
+		return "", &config.ValidationError{Message: "quota rescan accepts no options"}
+	}
+	if err := s.ensureMaintenanceFree(ctx); err != nil {
+		return "", err
+	}
+	if err := config.ValidateLabels(labels); err != nil {
+		return "", err
+	}
+
+	t := s.taskDefaultTimeout
+	if timeout > 0 {
+		t = timeout
+	}
+	id := s.tasks.Create(string(task.TypeQuotaRescan), task.TaskOpts{Labels: labels, Timeout: t}, func(ctx context.Context, update *task.Update) error {
+		return s.runQuotaRescan(ctx, update)
+	})
+	log.Info().Str("task", id).Str("path", s.mountPoint).Msg("quota rescan started")
+	return id, nil
+}
+
+func (s *Storage) runQuotaRescan(ctx context.Context, update *task.Update) error {
+	update.SetProgress(50)
+	if err := s.btrfs.QuotaRescan(ctx, s.mountPoint); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		// Simple qgroups (squota, kernel 6.7+) do not support rescan; btrfs
+		// emits "Invalid argument" for this case. Translate for clarity.
+		if strings.Contains(err.Error(), "Invalid argument") {
+			return fmt.Errorf("quota rescan not supported on this filesystem (simple quotas / squota mode cannot be rescanned)")
+		}
+		return fmt.Errorf("btrfs quota rescan: %w", err)
+	}
+	return nil
+}
+
+// ensureMaintenanceFree checks that no scrub, balance, or quota-rescan is
+// currently Running/Pending on the agent and that the kernel reports no such
+// operation in progress. Callers must hold s.maintenanceMu.
+func (s *Storage) ensureMaintenanceFree(ctx context.Context) error {
+	for _, t := range s.tasks.List(string(task.TypeScrub), string(task.TypeBalance), string(task.TypeQuotaRescan)) {
+		if t.Status == task.TaskRunning || t.Status == task.TaskPending {
+			return &StorageError{Code: ErrBusy, Message: "another maintenance task is already running"}
+		}
+	}
+	if sst, err := s.btrfs.ScrubStatus(ctx, s.mountPoint); err == nil && sst.Running {
+		return &StorageError{Code: ErrBusy, Message: "scrub already running on filesystem"}
+	}
+	if bst, _ := s.btrfs.BalanceStatus(ctx, s.mountPoint); bst != nil && bst.Running {
+		return &StorageError{Code: ErrBusy, Message: "balance already running on filesystem"}
+	}
+	if qst, _ := s.btrfs.QuotaRescanStatus(ctx, s.mountPoint); qst != nil && qst.Running {
+		return &StorageError{Code: ErrBusy, Message: "quota rescan already running on filesystem"}
+	}
+	return nil
+}
 
 func (s *Storage) tenantPath(tenant string) (string, error) {
 	if err := config.ValidateName(tenant); err != nil {

--- a/agent/storage/task/model.go
+++ b/agent/storage/task/model.go
@@ -24,10 +24,11 @@ const (
 type TaskType string
 
 const (
-	TypeScrub      TaskType = "scrub"
-	TypeBalance    TaskType = "balance"
-	TypeDefragment TaskType = "defragment"
-	TypeTest       TaskType = "test"
+	TypeScrub       TaskType = "scrub"
+	TypeBalance     TaskType = "balance"
+	TypeDefragment  TaskType = "defragment"
+	TypeQuotaRescan TaskType = "quota-rescan"
+	TypeTest        TaskType = "test"
 )
 
 // ErrNotFound is returned when a task ID doesn't exist.

--- a/cmd/btrfs-nfs-csi/model.go
+++ b/cmd/btrfs-nfs-csi/model.go
@@ -390,6 +390,16 @@ func taskCmd() *cli.Command {
 						Action: taskCreateDefragment,
 					},
 					{
+						Name:  models.TaskTypeQuotaRescan,
+						Usage: "rebuild btrfs qgroup accounting (filesystem-wide)",
+						Flags: []cli.Flag{
+							&cli.DurationFlag{Name: "timeout", Aliases: []string{"t"}, Usage: "timeout (e.g. 1h, 30m)"},
+							&cli.BoolFlag{Name: "wait", Aliases: []string{"W"}, Usage: "wait for completion"},
+							labelFlag(),
+						},
+						Action: taskCreateQuotaRescan,
+					},
+					{
 						Name:  models.TaskTypeTest,
 						Usage: "start a test task",
 						Flags: []cli.Flag{

--- a/cmd/btrfs-nfs-csi/task.go
+++ b/cmd/btrfs-nfs-csi/task.go
@@ -345,6 +345,26 @@ func taskCreateDefragment(ctx context.Context, cmd *cli.Command) error {
 	return waitForTask(ctx, resp.TaskID)
 }
 
+func taskCreateQuotaRescan(ctx context.Context, cmd *cli.Command) error {
+	req := models.TaskCreateRequest{Labels: parseLabelsFlag(cmd)}
+	if t := cmd.Duration("timeout"); t > 0 {
+		req.Timeout = t.String()
+	}
+	resp, err := apiClient.CreateTask(ctx, models.TaskTypeQuotaRescan, req)
+	if err != nil {
+		return err
+	}
+	if !cmd.Bool("wait") {
+		return output(cmd, resp, func() {
+			fmt.Printf("quota rescan started (task %s)\n", resp.TaskID)
+		})
+	}
+	if !isJSON(cmd) {
+		fmt.Printf("quota rescan started (task %s)\n", resp.TaskID)
+	}
+	return waitForTask(ctx, resp.TaskID)
+}
+
 func taskCreateTest(ctx context.Context, cmd *cli.Command) error {
 	req := models.TaskCreateRequest{Labels: parseLabelsFlag(cmd)}
 	if s := cmd.Duration("sleep"); s > 0 {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -172,9 +172,21 @@ chmod 600 /etc/default/btrfs-nfs-csi
 systemctl enable --now btrfs-scrub.timer
 ```
 
+## Quota Rescan
+
+`btrfs quota rescan` rebuilds qgroup accounting from scratch. Useful after qgroup inconsistencies (can happen if quotas were enabled on an existing filesystem, or after unusual delete/snapshot patterns). Filesystem-wide; no volume or tenant scoping possible.
+
+```bash
+btrfs-nfs-csi task create quota-rescan -W
+```
+
+**Only works on classic btrfs quotas (`btrfs quota enable`).** Simple quotas (`btrfs quota enable -s`, squota, kernel 6.7+) do not support rescan, accounting is per-extent-lifetime and has no historical state to rescan. Trying anyway on squota filesystems fails fast with a clear error.
+
+No flags beyond `--timeout`, `--wait`, and labels. Mutually exclusive with scrub and balance. Progress reports 0/50/100 (btrfs has no structured progress for rescan).
+
 ## Defragment
 
-btrfs filesystem defragment rewrites files to reduce extent fragmentation. Unlike scrub and balance (which operate filesystem-wide), defragment targets a specific **volume** or **sub-path within a volume** — so it fits naturally into the multi-tenant model.
+btrfs filesystem defragment rewrites files to reduce extent fragmentation. Unlike scrub and balance (which operate filesystem-wide), defragment targets a specific **volume** or **sub-path within a volume**, so it fits naturally into the multi-tenant model.
 
 Snapshots are read-only in this agent and cannot be defragmented. Use a clone (which is a writable snapshot) if you need to defragment a point-in-time copy.
 
@@ -190,11 +202,11 @@ btrfs-nfs-csi task create defragment --volume pg-main --compress=zstd -W  # reco
 - `--path`: sub-path relative to the volume data dir. Absolute paths and `..` traversal are rejected; symlinks must resolve to stay under the target dir.
 - `--compress zstd|lzo|zlib|none` (default `none`): recompress during defrag.
 - `--no-recursive`: do not recurse into subdirectories (by default, directories are recursed).
-- `--threshold <bytes>`: target extent size — btrfs skips files whose extents already exceed this size.
+- `--threshold <bytes>`: target extent size, btrfs skips files whose extents already exceed this size.
 
 **Free-space requirement:** Defragment writes new extents before freeing the old ones, so the target volume needs headroom. A volume at 100% of its qgroup quota will fail with `Disk quota exceeded` during defrag. Either expand the quota temporarily or free some data first.
 
-**Concurrency:** Defragment does not take the scrub/balance mutex — it can run in parallel with either. Expect heavy IO if combined.
+**Concurrency:** Defragment does not take the scrub/balance mutex, it can run in parallel with either. Expect heavy IO if combined.
 
 **Progress reporting:** btrfs does not expose a native progress indicator for defragment (unlike scrub and balance). The task reports a coarse state instead: `0%` while pending, `50%` once running, `100%` on successful completion. A failed or cancelled defragment that had already started shows `50%` at the final state, distinguishing it from one that never got going.
 


### PR DESCRIPTION
## Summary
- New `quota-rescan` task type rebuilds btrfs qgroup accounting filesystem-wide. No configurable flags (btrfs has none); mutually exclusive with scrub and balance.
- On squota (simple quotas) filesystems, where btrfs rejects rescan with "Invalid argument", the error is translated to a clear message so users understand the mode incompatibility.
- Mutex triplication across Start{Scrub,Balance,QuotaRescan} consolidated into `Storage.ensureMaintenanceFree(ctx)`.