### PR TITLE
Reject client-supplied clone.source.* labels at API boundary

### DIFF
--- a/agent/api/v1/middleware_test.go
+++ b/agent/api/v1/middleware_test.go
@@ -582,6 +582,15 @@ func TestPolicyApply(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			name:     "UpdateVolume with client-supplied clone.source.name: 400 even with same value",
+			policy:   policyUpdateVolume,
+			role:     models.RoleUser,
+			identity: "ci-bot",
+			owner:    map[string]string{config.LabelCreatedBy: "ci-bot", config.LabelCloneSourceName: "snap-1"},
+			stamp:    map[string]string{config.LabelCloneSourceName: "snap-1"},
+			wantErr:  true,
+		},
+		{
 			name:    "UpdateVolume as admin rewrites created-by: still 403",
 			policy:  policyUpdateVolume,
 			role:    models.RoleAdmin,
@@ -609,5 +618,54 @@ func TestPolicyApply(t *testing.T) {
 				assert.Equal(t, tc.wantStamped, stamp[config.LabelCreatedBy])
 			}
 		})
+	}
+}
+
+// TestPolicyApply_RejectsHardReservedLabels exercises every policy that
+// stamps or preserves labels against every server-managed key. Any
+// combination must fail at the API boundary rather than silently overwrite
+// or pass through.
+func TestPolicyApply_RejectsHardReservedLabels(t *testing.T) {
+	type policyCase struct {
+		name      string
+		policy    Policy
+		needOwner bool // true for policies with EnforceOwnership (need a non-empty owner map)
+	}
+	policies := []policyCase{
+		{"CreateVolume", policyCreateVolume, false},
+		{"CloneVolume", policyCloneVolume, true},
+		{"CreateClone", policyCreateClone, true},
+		{"CreateSnapshot", policyCreateSnapshot, true},
+		{"CreateExport", policyCreateExport, true},
+		{"CreateTask", policyCreateTask, false},
+		{"CreateTaskOnVolume", policyCreateTaskOnVolume, true},
+		{"UpdateVolume", policyUpdateVolume, true},
+	}
+	forgeKeys := []string{
+		config.LabelTenant,
+		config.LabelCloneSourceType,
+		config.LabelCloneSourceName,
+	}
+
+	for _, p := range policies {
+		for _, key := range forgeKeys {
+			t.Run(p.name+"_forges_"+key, func(t *testing.T) {
+				e := echo.New()
+				req := httptest.NewRequest(http.MethodPost, "/v1/x", nil)
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+				c.Set("role", models.RoleUser)
+				c.Set("identity", "ci-bot")
+				c.Set("tenant", "ci")
+
+				stamp := map[string]string{key: "haxx"}
+				var owner map[string]string
+				if p.needOwner {
+					owner = map[string]string{config.LabelCreatedBy: "ci-bot"}
+				}
+				err := p.policy.Apply(c, owner, &stamp)
+				require.Error(t, err, "policy %s must reject client-supplied %s", p.name, key)
+			})
+		}
 	}
 }

--- a/cmd/btrfs-nfs-csi/auth.go
+++ b/cmd/btrfs-nfs-csi/auth.go
@@ -126,7 +126,7 @@ func listTokens(ctx context.Context, cmd *cli.Command) error {
 		for _, tok := range resp.Tokens {
 			id := tok.Identity
 			if id == "" {
-				id = "-"
+				id = "*"
 			}
 			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", tok.Role, id, shortFP(tok.Fingerprint, wide))
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -52,7 +52,7 @@ var SoftReservedLabelKeys = []string{LabelCreatedBy, LabelCloneSourceType, Label
 // HardReservedLabelKeys are rejected by the HTTP API itself if a client
 // tries to set them. `created-by` is not listed here because the API
 // handles it via identity matching (stamp/preserve), not blanket rejection.
-var HardReservedLabelKeys = []string{LabelTenant}
+var HardReservedLabelKeys = []string{LabelTenant, LabelCloneSourceType, LabelCloneSourceName}
 
 // ValidationError is returned by ValidateName and ValidateLabels.
 // Consumers can type-assert to distinguish validation errors from other errors.


### PR DESCRIPTION
## Summary
- Add `clone.source.type` and `clone.source.name` to `HardReservedLabelKeys` so the API rejects them at the boundary instead of letting clients forge clone provenance on plain volume creates.
- Use `*` as the placeholder for tokens without an identity in the `tokens` table so the column reads as a wildcard rather than a missing value.