### PR TITLE
Fix pagination defaults and reject invalid cursors

### DIFF
--- a/agent/api/v1/handler.go
+++ b/agent/api/v1/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) deleteSnapshot(id string) {
 func paginatedList[T labeled, R any](h *Handler, c *echo.Context, items []T, mapFn func(*T) R, wrapFn func([]R, int, string) any) error {
 	after := c.QueryParam("after")
 	limit, _ := strconv.Atoi(c.QueryParam("limit"))
-	if limit < 0 {
+	if limit <= 0 {
 		limit = h.DefaultPageLimit
 	}
 
@@ -104,17 +104,35 @@ func paginatedList[T labeled, R any](h *Handler, c *echo.Context, items []T, map
 	var snap []T
 	var offset int
 	var snapID string
-	cur, ok := decodeCursor(after)
-	if ok {
-		if v, loaded := h.pageSnapshots.Load(cur.SnapID); loaded {
-			ps := v.(*pageSnapshot)
-			if typed, ok := ps.items.([]T); ok {
-				snap = typed
-				offset = cur.Offset
-				snapID = cur.SnapID
-				ps.timer.Reset(h.paginationSnapshotTTL())
-			}
+	if after != "" {
+		cur, ok := decodeCursor(after)
+		if !ok {
+			return StorageError(c, &storage.StorageError{
+				Code:    storage.ErrInvalid,
+				Message: "invalid pagination cursor",
+			})
 		}
+		v, loaded := h.pageSnapshots.Load(cur.SnapID)
+		if !loaded {
+			return StorageError(c, &storage.StorageError{
+				Code:    storage.ErrInvalid,
+				Message: "pagination cursor expired; restart listing without 'after'",
+			})
+		}
+		ps := v.(*pageSnapshot)
+		typed, typeOK := ps.items.([]T)
+		if !typeOK {
+			// Cursor refers to a snapshot of a different list type (e.g. a
+			// /v1/volumes cursor sent against /v1/snapshots). Treat as invalid.
+			return StorageError(c, &storage.StorageError{
+				Code:    storage.ErrInvalid,
+				Message: "pagination cursor does not match this list",
+			})
+		}
+		snap = typed
+		offset = cur.Offset
+		snapID = cur.SnapID
+		ps.timer.Reset(h.paginationSnapshotTTL())
 	}
 
 	// No valid snapshot -- use items directly or create a snapshot if multi-page.

--- a/agent/api/v1/models/models.go
+++ b/agent/api/v1/models/models.go
@@ -472,18 +472,19 @@ const (
 // ListOpts configures list endpoint queries (pagination + label filtering).
 type ListOpts struct {
 	After  string   // opaque cursor from a previous response's Next field
-	Limit  int      // items per page (0 = pagination disabled, negative = use client default)
+	Limit  int      // items per page (0 or negative = use client default; positive = explicit)
 	Labels []string // label filters in "key=value" format
 }
 
-// Query builds url.Values for a list request. defaultLimit is used when Limit is negative.
+// Query builds url.Values for a list request. defaultLimit is used when Limit
+// is zero or negative (i.e. the caller did not specify an explicit page size).
 func (o ListOpts) Query(defaultLimit int) url.Values {
 	q := GenerateLabelQuery(o.Labels)
 	if o.After != "" {
 		q.Set("after", o.After)
 	}
 	limit := o.Limit
-	if limit < 0 {
+	if limit <= 0 {
 		limit = defaultLimit
 	}
 	if limit > 0 {

--- a/agent/api/v1/pagination_test.go
+++ b/agent/api/v1/pagination_test.go
@@ -39,6 +39,15 @@ func makeItems(names ...string) []testItem {
 
 func callPaginatedList(t *testing.T, h *Handler, items []testItem, after string, limit string) testListResp {
 	t.Helper()
+	resp, status := callPaginatedListRaw(t, h, items, after, limit)
+	require.Equal(t, http.StatusOK, status, "unexpected status: body=%s", resp)
+	var out testListResp
+	require.NoError(t, json.Unmarshal(resp, &out))
+	return out
+}
+
+func callPaginatedListRaw(t *testing.T, h *Handler, items []testItem, after string, limit string) ([]byte, int) {
+	t.Helper()
 	e := echo.New()
 	target := "/test"
 	sep := "?"
@@ -60,10 +69,7 @@ func callPaginatedList(t *testing.T, h *Handler, items []testItem, after string,
 
 	err := paginatedList(h, c, items, mapFn, wrapFn)
 	require.NoError(t, err)
-
-	var resp testListResp
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	return resp
+	return rec.Body.Bytes(), rec.Code
 }
 
 func TestPagination_NoLimit(t *testing.T) {
@@ -120,17 +126,16 @@ func TestPagination_SnapshotIsolation(t *testing.T) {
 	assert.Equal(t, 5, resp2.Total, "total from snapshot, not live data")
 }
 
-func TestPagination_InvalidToken_FallsBack(t *testing.T) {
+func TestPagination_InvalidCursor_Returns400(t *testing.T) {
 	h := &Handler{}
 	items := makeItems("a", "b", "c")
 
-	resp := callPaginatedList(t, h, items, "garbage!!!", "2")
-	assert.Len(t, resp.Items, 2)
-	assert.Equal(t, "a", resp.Items[0].Name, "falls back to page 1")
-	assert.Equal(t, 3, resp.Total)
+	body, status := callPaginatedListRaw(t, h, items, "garbage!!!", "2")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, string(body), "invalid pagination cursor")
 }
 
-func TestPagination_ExpiredSnapshot_FallsBack(t *testing.T) {
+func TestPagination_ExpiredSnapshot_Returns400(t *testing.T) {
 	h := &Handler{}
 	items := makeItems("a", "b", "c", "d")
 
@@ -147,11 +152,12 @@ func TestPagination_ExpiredSnapshot_FallsBack(t *testing.T) {
 		h.pageSnapshots.Delete(cur.SnapID)
 	}
 
-	// Using expired token falls back to page 1 of current data
+	// Using expired cursor against any data must surface a 400 instead of
+	// silently restarting from page 1.
 	newItems := makeItems("x", "y", "z")
-	resp2 := callPaginatedList(t, h, newItems, resp.Next, "2")
-	assert.Equal(t, "x", resp2.Items[0].Name, "falls back to page 1 of new data")
-	assert.Equal(t, 3, resp2.Total)
+	body, status := callPaginatedListRaw(t, h, newItems, resp.Next, "2")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, string(body), "expired")
 }
 
 func TestPagination_AutoCleanup(t *testing.T) {

--- a/cmd/btrfs-nfs-csi/auth.go
+++ b/cmd/btrfs-nfs-csi/auth.go
@@ -126,7 +126,7 @@ func listTokens(ctx context.Context, cmd *cli.Command) error {
 		for _, tok := range resp.Tokens {
 			id := tok.Identity
 			if id == "" {
-				id = "*"
+				id = "-"
 			}
 			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", tok.Role, id, shortFP(tok.Fingerprint, wide))
 		}


### PR DESCRIPTION
## Summary
- Apply `AGENT_DEFAULT_PAGE_LIMIT` and `AGENT_HTTP_CLIENT_PAGE_LIMIT` when the caller passes zero (not only on explicit negatives), and surface malformed, unknown, or cross-list cursors as 400 INVALID instead of silently restarting from page 1.
