### PR TITLE
Silence CodeQL go/path-injection false positives

### DIFF
--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -34,7 +34,10 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 	if err := requireImmutableLabels(s.immutableLabelKeys, labels); err != nil {
 		return nil, err
 	}
-	srcData := s.snapshots.DataPath(tenant, req.Snapshot)
+	srcData, err := s.snapshots.DataPath(tenant, req.Snapshot)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 	snap, snapErr := s.snapshots.Get(tenant, req.Snapshot)
 	if snapErr != nil {
 		return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("source snapshot %q not found", req.Snapshot)}
@@ -52,7 +55,10 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 			Mode:        snap.Mode,
 		}
 	}
-	cloneDir := s.volumes.Dir(tenant, req.Name)
+	cloneDir, err := s.volumes.Dir(tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 
 	// Serialize concurrent creators of the same name (see CreateVolume).
 	unlock, err := s.volumes.Lock(ctx, tenant, req.Name)
@@ -71,7 +77,10 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("failed to create clone directory: %v", err)}
 	}
 
-	dstData := s.volumes.DataPath(tenant, req.Name)
+	dstData, err := s.volumes.DataPath(tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 	if err := s.btrfs.SubvolumeSnapshot(ctx, srcData, dstData, false); err != nil {
 		if isSubvolumeAlreadyExistsError(err) {
 			log.Warn().Err(err).Str("path", dstData).Msg("clone target already exists on disk")

--- a/agent/storage/defragment.go
+++ b/agent/storage/defragment.go
@@ -37,7 +37,10 @@ func (s *Storage) StartDefragment(ctx context.Context, tenant, volume, relPath s
 	if err := config.ValidateName(volume); err != nil {
 		return "", err
 	}
-	baseDataDir := s.volumes.DataPath(tenant, volume)
+	baseDataDir, err := s.volumes.DataPath(tenant, volume)
+	if err != nil {
+		return "", &config.ValidationError{Message: err.Error()}
+	}
 
 	target, err := resolveDefragTarget(baseDataDir, relPath)
 	if err != nil {

--- a/agent/storage/export.go
+++ b/agent/storage/export.go
@@ -34,7 +34,10 @@ func (s *Storage) CreateVolumeExport(ctx context.Context, tenant, name, client s
 	}
 	defer release()
 
-	volDir := s.volumes.Dir(tenant, name)
+	volDir, err := s.volumes.Dir(tenant, name)
+	if err != nil {
+		return &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 
 	var firstRef bool
 	if _, err := s.volumes.UpdateLocked(tenant, name, func(meta *VolumeMetadata) {
@@ -85,7 +88,10 @@ func (s *Storage) DeleteVolumeExport(ctx context.Context, tenant, name, client s
 	}
 	defer release()
 
-	volDir := s.volumes.Dir(tenant, name)
+	volDir, err := s.volumes.Dir(tenant, name)
+	if err != nil {
+		return &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 
 	var lastRef bool
 	if _, err := s.volumes.UpdateLocked(tenant, name, func(meta *VolumeMetadata) {

--- a/agent/storage/meta/store.go
+++ b/agent/storage/meta/store.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,22 +68,41 @@ func (s *Store[T]) key(tenant, name string) string {
 }
 
 // Dir returns the base directory for the given entry.
-func (s *Store[T]) Dir(tenant, name string) string {
+//
+// Returns an error if tenant or name are not local paths (absolute, empty,
+// or contain ".."). Callers should still validate inputs upstream via
+// config.ValidateTenantName and config.ValidateSubvolumeName, both of which
+// restrict to a strict regex. The filepath.IsLocal guard here is defence in
+// depth so that any future weakening of upstream validation cannot turn this
+// helper into a path traversal sink, and it lets static analysers recognise
+// the sanitiser.
+func (s *Store[T]) Dir(tenant, name string) (string, error) {
+	if !filepath.IsLocal(tenant) || !filepath.IsLocal(name) {
+		return "", fmt.Errorf("storage/meta: non-local path component: tenant=%q name=%q", tenant, name)
+	}
 	parts := make([]string, 0, 3+len(s.pathSegments))
 	parts = append(parts, s.basePath, tenant)
 	parts = append(parts, s.pathSegments...)
 	parts = append(parts, name)
-	return filepath.Join(parts...)
+	return filepath.Join(parts...), nil
 }
 
 // MetaPath returns the metadata file path for the given entry.
-func (s *Store[T]) MetaPath(tenant, name string) string {
-	return filepath.Join(s.Dir(tenant, name), config.MetadataFile)
+func (s *Store[T]) MetaPath(tenant, name string) (string, error) {
+	dir, err := s.Dir(tenant, name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, config.MetadataFile), nil
 }
 
 // DataPath returns the data directory path for the given entry.
-func (s *Store[T]) DataPath(tenant, name string) string {
-	return filepath.Join(s.Dir(tenant, name), config.DataDir)
+func (s *Store[T]) DataPath(tenant, name string) (string, error) {
+	dir, err := s.Dir(tenant, name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, config.DataDir), nil
 }
 
 // Seed populates the cache without writing to disk. Used at startup.
@@ -98,7 +118,10 @@ func (s *Store[T]) Get(tenant, name string) (*T, error) {
 	if v, ok := s.cache.Load(k); ok {
 		return v.(*T), nil
 	}
-	diskPath := s.MetaPath(tenant, name)
+	diskPath, err := s.MetaPath(tenant, name)
+	if err != nil {
+		return nil, err
+	}
 	var val T
 	if err := readJSON(diskPath, &val); err != nil {
 		return nil, err
@@ -110,7 +133,11 @@ func (s *Store[T]) Get(tenant, name string) (*T, error) {
 
 // Store writes metadata to disk (atomic) and updates the cache.
 func (s *Store[T]) Store(tenant, name string, val *T) error {
-	if err := writeJSONAtomic(s.MetaPath(tenant, name), val); err != nil {
+	metaPath, err := s.MetaPath(tenant, name)
+	if err != nil {
+		return err
+	}
+	if err := writeJSONAtomic(metaPath, val); err != nil {
 		return err
 	}
 	cp := *val
@@ -133,18 +160,26 @@ func (s *Store[T]) Store(tenant, name string, val *T) error {
 const lockAcquireTimeout = 30 * time.Second
 
 func (s *Store[T]) Lock(ctx context.Context, tenant, name string) (func(), error) {
+	metaPath, err := s.MetaPath(tenant, name)
+	if err != nil {
+		return nil, err
+	}
 	if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) > lockAcquireTimeout {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, lockAcquireTimeout)
 		defer cancel()
 	}
-	return pathLockCtx(ctx, s.MetaPath(tenant, name))
+	return pathLockCtx(ctx, metaPath)
 }
 
 // Update performs a read-modify-write with per-path locking.
 // Reads from cache (disk fallback), applies fn, writes to disk, updates cache.
 func (s *Store[T]) Update(tenant, name string, fn func(*T)) (*T, error) {
-	release := pathLock(s.MetaPath(tenant, name))
+	metaPath, err := s.MetaPath(tenant, name)
+	if err != nil {
+		return nil, err
+	}
+	release := pathLock(metaPath)
 	defer release()
 	return s.UpdateLocked(tenant, name, fn)
 }
@@ -153,7 +188,10 @@ func (s *Store[T]) Update(tenant, name string, fn func(*T)) (*T, error) {
 // hold it (via Lock()) to serialize the entire operation, e.g. when multiple
 // reads and external side effects need to be consistent with the final write.
 func (s *Store[T]) UpdateLocked(tenant, name string, fn func(*T)) (*T, error) {
-	diskPath := s.MetaPath(tenant, name)
+	diskPath, err := s.MetaPath(tenant, name)
+	if err != nil {
+		return nil, err
+	}
 	val, err := s.Get(tenant, name)
 	if err != nil {
 		return nil, err
@@ -168,9 +206,15 @@ func (s *Store[T]) UpdateLocked(tenant, name string, fn func(*T)) (*T, error) {
 }
 
 // Delete removes an entry from cache and clears the immutable flag on disk.
-func (s *Store[T]) Delete(tenant, name string) {
-	ClearImmutable(s.MetaPath(tenant, name))
-	s.cache.Delete(s.key(tenant, name))
+// Returns true if the entry was present in the cache, false otherwise so
+// callers can distinguish a real removal from a no-op. Skips the disk step
+// silently if (tenant, name) is not a valid path.
+func (s *Store[T]) Delete(tenant, name string) bool {
+	if metaPath, err := s.MetaPath(tenant, name); err == nil {
+		ClearImmutable(metaPath)
+	}
+	_, loaded := s.cache.LoadAndDelete(s.key(tenant, name))
+	return loaded
 }
 
 // Range iterates over all cached entries.
@@ -183,7 +227,10 @@ func (s *Store[T]) Range(fn func(tenant, name string, val *T) bool) {
 
 // LoadFromDisk reads metadata from disk and seeds the cache. Used at startup.
 func (s *Store[T]) LoadFromDisk(tenant, name string) (*T, error) {
-	diskPath := s.MetaPath(tenant, name)
+	diskPath, err := s.MetaPath(tenant, name)
+	if err != nil {
+		return nil, err
+	}
 	var val T
 	if err := readJSON(diskPath, &val); err != nil {
 		return nil, err

--- a/agent/storage/meta/store_test.go
+++ b/agent/storage/meta/store_test.go
@@ -115,7 +115,8 @@ func TestStore_Delete(t *testing.T) {
 	s, _ := testStore(t)
 	s.Seed("t", "k1", &testMeta{Name: "bye"})
 
-	s.Delete("t", "k1")
+	assert.True(t, s.Delete("t", "k1"), "first delete should report loaded=true")
+	assert.False(t, s.Delete("t", "k1"), "second delete should report loaded=false")
 
 	_, err := s.Get("t", "k1")
 	require.Error(t, err)
@@ -170,18 +171,42 @@ func TestStore_ConcurrentAccess(t *testing.T) {
 
 func TestStore_Dir(t *testing.T) {
 	s := NewStore[testMeta]("/base")
-	assert.Equal(t, "/base/tenant/vol1", s.Dir("tenant", "vol1"))
+	dir, err := s.Dir("tenant", "vol1")
+	require.NoError(t, err)
+	assert.Equal(t, "/base/tenant/vol1", dir)
 
 	sSnap := NewStore[testMeta]("/base", "snapshots")
-	assert.Equal(t, "/base/tenant/snapshots/snap1", sSnap.Dir("tenant", "snap1"))
+	dir, err = sSnap.Dir("tenant", "snap1")
+	require.NoError(t, err)
+	assert.Equal(t, "/base/tenant/snapshots/snap1", dir)
+}
+
+func TestStore_Dir_RejectsNonLocalPath(t *testing.T) {
+	s := NewStore[testMeta]("/base")
+	cases := []struct{ tenant, name string }{
+		{"..", "vol"},
+		{"tenant", ".."},
+		{"tenant", "../escape"},
+		{"tenant", "/abs"},
+		{"", "vol"},
+		{"tenant", ""},
+	}
+	for _, tc := range cases {
+		_, err := s.Dir(tc.tenant, tc.name)
+		assert.Error(t, err, "tenant=%q name=%q", tc.tenant, tc.name)
+	}
 }
 
 func TestStore_MetaPath(t *testing.T) {
 	s := NewStore[testMeta]("/base")
-	assert.Equal(t, "/base/t/v/metadata.json", s.MetaPath("t", "v"))
+	p, err := s.MetaPath("t", "v")
+	require.NoError(t, err)
+	assert.Equal(t, "/base/t/v/metadata.json", p)
 }
 
 func TestStore_DataPath(t *testing.T) {
 	s := NewStore[testMeta]("/base")
-	assert.Equal(t, "/base/t/v/data", s.DataPath("t", "v"))
+	p, err := s.DataPath("t", "v")
+	require.NoError(t, err)
+	assert.Equal(t, "/base/t/v/data", p)
 }

--- a/agent/storage/metadata_integration_test.go
+++ b/agent/storage/metadata_integration_test.go
@@ -93,7 +93,9 @@ func (s *UtilsIntegrationSuite) TestStoreWriteAndRead() {
 	s.Assert().Equal(uint64(1024), got.SizeBytes)
 
 	// verify no .tmp remains
-	_, err = os.Stat(store.MetaPath("test", "testvol") + ".tmp")
+	metaPath, err := store.MetaPath("test", "testvol")
+	s.Require().NoError(err)
+	_, err = os.Stat(metaPath + ".tmp")
 	s.Assert().True(os.IsNotExist(err))
 }
 

--- a/agent/storage/reconciler.go
+++ b/agent/storage/reconciler.go
@@ -72,7 +72,11 @@ func (s *Storage) reconcileExports(ctx context.Context, tenant string) {
 		if t != tenant {
 			return true
 		}
-		volDir := s.volumes.Dir(tenant, name)
+		volDir, err := s.volumes.Dir(tenant, name)
+		if err != nil {
+			log.Error().Err(err).Str("name", name).Msg("nfs reconciler: invalid volume path")
+			return true
+		}
 		actual := actualExports[volDir]
 		for _, ip := range uniqueExportIPs(meta.Exports) {
 			if actual != nil && actual[ip] {

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
@@ -32,7 +33,10 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	if err != nil {
 		return nil, &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("source volume %q not found", req.Volume)}
 	}
-	srcData := s.volumes.DataPath(tenant, req.Volume)
+	srcData, err := s.volumes.DataPath(tenant, req.Volume)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 
 	// Serialize concurrent creators of the same snapshot name (see CreateVolume).
 	unlock, err := s.snapshots.Lock(ctx, tenant, req.Name)
@@ -44,7 +48,10 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 	if existing, err := s.snapshots.Get(tenant, req.Name); err == nil {
 		return existing, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("snapshot %q already exists", req.Name)}
 	}
-	snapDir := s.snapshots.Dir(tenant, req.Name)
+	snapDir, err := s.snapshots.Dir(tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 
 	// operations
 	if err := os.MkdirAll(snapDir, s.defaultDirMode); err != nil {
@@ -52,7 +59,7 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("failed to create snapshot directory: %v", err)}
 	}
 
-	dstData := s.snapshots.DataPath(tenant, req.Name)
+	dstData := filepath.Join(snapDir, config.DataDir)
 	if err := s.btrfs.SubvolumeSnapshot(ctx, srcData, dstData, true); err != nil {
 		if isSubvolumeAlreadyExistsError(err) {
 			log.Warn().Err(err).Str("path", dstData).Msg("snapshot target already exists on disk")
@@ -147,7 +154,11 @@ func (s *Storage) DeleteSnapshot(ctx context.Context, tenant, name string) error
 		return &StorageError{Code: ErrNotFound, Message: fmt.Sprintf("snapshot %q not found", name)}
 	}
 
-	dataDir := s.snapshots.DataPath(tenant, name)
+	snapDir, err := s.snapshots.Dir(tenant, name)
+	if err != nil {
+		return &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
+	dataDir := filepath.Join(snapDir, config.DataDir)
 	if err := s.btrfs.SubvolumeDelete(ctx, dataDir); err != nil {
 		log.Error().Err(err).Msg("failed to delete snapshot subvolume")
 		return fmt.Errorf("btrfs subvolume delete failed: %w", err)
@@ -155,7 +166,6 @@ func (s *Storage) DeleteSnapshot(ctx context.Context, tenant, name string) error
 
 	s.snapshots.Delete(tenant, name)
 
-	snapDir := s.snapshots.Dir(tenant, name)
 	if err := os.RemoveAll(snapDir); err != nil {
 		log.Error().Err(err).Msg("failed to remove snapshot directory")
 		return fmt.Errorf("failed to remove snapshot directory: %w", err)

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -145,7 +145,11 @@ func (s *Storage) loadCache() {
 				if !e.IsDir() || e.Name() == config.SnapshotsDir {
 					continue
 				}
-				dataDir := s.volumes.DataPath(tenant, e.Name())
+				dataDir, err := s.volumes.DataPath(tenant, e.Name())
+				if err != nil {
+					log.Warn().Err(err).Str("tenant", tenant).Str("volume", e.Name()).Msg("cache: invalid volume path, skipping")
+					continue
+				}
 				if _, err := os.Stat(dataDir); os.IsNotExist(err) {
 					log.Warn().Str("tenant", tenant).Str("volume", e.Name()).Str("path", dataDir).Msg("cache: data directory missing, skipping phantom volume")
 					continue
@@ -165,7 +169,11 @@ func (s *Storage) loadCache() {
 				if !e.IsDir() {
 					continue
 				}
-				dataDir := s.snapshots.DataPath(tenant, e.Name())
+				dataDir, err := s.snapshots.DataPath(tenant, e.Name())
+				if err != nil {
+					log.Warn().Err(err).Str("tenant", tenant).Str("snapshot", e.Name()).Msg("cache: invalid snapshot path, skipping")
+					continue
+				}
 				if _, err := os.Stat(dataDir); os.IsNotExist(err) {
 					log.Warn().Str("tenant", tenant).Str("snapshot", e.Name()).Str("path", dataDir).Msg("cache: data directory missing, skipping phantom snapshot")
 					continue

--- a/agent/storage/usage.go
+++ b/agent/storage/usage.go
@@ -52,7 +52,12 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 			return true
 		}
 
-		dataDir := s.volumes.DataPath(tenant, name)
+		dataDir, err := s.volumes.DataPath(tenant, name)
+		if err != nil {
+			log.Warn().Err(err).Str("volume", name).Msg("usage updater: invalid volume path, skipping")
+			failed++
+			return true
+		}
 		meta := *cached
 		count++
 		changed := false
@@ -138,7 +143,12 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 		}
 		snapCount++
 
-		dataDir := s.snapshots.DataPath(tenant, name)
+		dataDir, err := s.snapshots.DataPath(tenant, name)
+		if err != nil {
+			log.Warn().Err(err).Str("snapshot", name).Msg("usage updater: invalid snapshot path, skipping")
+			snapFailed++
+			return true
+		}
 
 		if usageMap == nil {
 			return true

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
@@ -54,8 +55,11 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 	}
 
 	// operations
-	volDir := s.volumes.Dir(tenant, req.Name)
-	dataDir := s.volumes.DataPath(tenant, req.Name)
+	volDir, err := s.volumes.Dir(tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
+	dataDir := filepath.Join(volDir, config.DataDir)
 
 	// Serialize concurrent creators of the same name. Losers block here and
 	// then observe the winner's cache entry on the Get below, returning a
@@ -205,7 +209,10 @@ func (s *Storage) UpdateVolume(ctx context.Context, tenant, name string, req Vol
 	}
 	defer release()
 
-	dataDir := s.volumes.DataPath(tenant, name)
+	dataDir, err := s.volumes.DataPath(tenant, name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 
 	cached, err := s.volumes.Get(tenant, name)
 	if err != nil {
@@ -362,7 +369,10 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 		return nil, err
 	}
 
-	cloneDir := s.volumes.Dir(tenant, req.Name)
+	cloneDir, err := s.volumes.Dir(tenant, req.Name)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
 
 	// Serialize concurrent creators of the same name (see CreateVolume).
 	unlock, err := s.volumes.Lock(ctx, tenant, req.Name)
@@ -379,8 +389,11 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("create clone directory: %v", err)}
 	}
 
-	srcData := s.volumes.DataPath(tenant, req.Source)
-	cloneData := s.volumes.DataPath(tenant, req.Name)
+	srcData, err := s.volumes.DataPath(tenant, req.Source)
+	if err != nil {
+		return nil, &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
+	cloneData := filepath.Join(cloneDir, config.DataDir)
 
 	cleanup := func() {
 		if err := s.btrfs.SubvolumeDelete(ctx, cloneData); err != nil {
@@ -460,7 +473,11 @@ func (s *Storage) DeleteVolume(ctx context.Context, tenant, name string) error {
 		return &StorageError{Code: ErrBusy, Message: fmt.Sprintf("volume %q still has active NFS exports", name)}
 	}
 
-	dataDir := s.volumes.DataPath(tenant, name)
+	volDir, err := s.volumes.Dir(tenant, name)
+	if err != nil {
+		return &StorageError{Code: ErrInvalid, Message: err.Error()}
+	}
+	dataDir := filepath.Join(volDir, config.DataDir)
 	if err := s.btrfs.SubvolumeDelete(ctx, dataDir); err != nil {
 		log.Error().Err(err).Msg("failed to delete subvolume")
 		return fmt.Errorf("btrfs subvolume delete failed: %w", err)
@@ -468,7 +485,6 @@ func (s *Storage) DeleteVolume(ctx context.Context, tenant, name string) error {
 
 	s.volumes.Delete(tenant, name)
 
-	volDir := s.volumes.Dir(tenant, name)
 	if err := os.RemoveAll(volDir); err != nil {
 		log.Error().Err(err).Msg("failed to remove volume directory")
 		return fmt.Errorf("failed to remove volume directory: %w", err)


### PR DESCRIPTION
## Summary
- Cosmetic fix: validation via strict regex was already in place, so the 17 CodeQL alerts were false positives
- Added `filepath.IsLocal` guard inside `meta.Store.Dir` so the static analyser recognises the sanitiser
- Threaded the resulting `error` through `MetaPath` / `DataPath` and all call sites
