### PR TITLE
Honour AGENT_CSI_IDENTITY in default list filter

### DIFF
--- a/agent/api/v1/client/client.go
+++ b/agent/api/v1/client/client.go
@@ -105,6 +105,7 @@ type Client struct {
 	token         string
 	http          *http.Client
 	identity      string
+	whoami        *models.WhoamiResponse
 	pageLimit     int
 	prefetch      int
 	prefetchBytes int64
@@ -161,8 +162,27 @@ func newClient(url, token string, cfg ClientConfig) (*Client, error) {
 }
 
 // Identity returns the client's identity label value (e.g. "cli", "k8s").
+// This is the env-configured identity used to stamp `created-by` labels;
+// it can differ from the per-token identity returned by Whoami.
 func (c *Client) Identity() string {
 	return c.identity
+}
+
+// Whoami returns the cached caller info (tenant, role, identity, fingerprint).
+// Returns nil until Resolve succeeds.
+func (c *Client) Whoami() *models.WhoamiResponse {
+	return c.whoami
+}
+
+// Resolve fetches the caller's tenant, role, identity, and fingerprint via
+// /v1/whoami and caches them. Safe to call multiple times; later calls overwrite.
+func (c *Client) Resolve(ctx context.Context) error {
+	var resp models.WhoamiResponse
+	if err := c.do(ctx, http.MethodGet, "/v1/whoami", nil, &resp); err != nil {
+		return err
+	}
+	c.whoami = &resp
+	return nil
 }
 
 func (c *Client) ensureIdentity(labels map[string]string) map[string]string {
@@ -480,16 +500,6 @@ func (c *Client) CancelTask(ctx context.Context, id string) error {
 }
 
 // --- Auth ---
-
-// Whoami returns the caller's own tenant, role, identity, and fingerprint.
-// GET /v1/whoami
-func (c *Client) Whoami(ctx context.Context) (*models.WhoamiResponse, error) {
-	var resp models.WhoamiResponse
-	if err := c.do(ctx, http.MethodGet, "/v1/whoami", nil, &resp); err != nil {
-		return nil, err
-	}
-	return &resp, nil
-}
 
 // ListTokens returns the tokens configured for the caller's tenant (admin-only).
 // Tokens are represented by fingerprint only; never in plaintext.

--- a/cmd/btrfs-nfs-csi/auth.go
+++ b/cmd/btrfs-nfs-csi/auth.go
@@ -100,10 +100,7 @@ func shortFP(fp string, wide bool) string {
 }
 
 func showWhoami(ctx context.Context, cmd *cli.Command) error {
-	resp, err := apiClient.Whoami(ctx)
-	if err != nil {
-		return err
-	}
+	resp := apiClient.Whoami()
 	return output(cmd, resp, func() {
 		fmt.Printf("tenant:      %s\n", resp.Tenant)
 		fmt.Printf("role:        %s\n", resp.Role)

--- a/cmd/btrfs-nfs-csi/flags.go
+++ b/cmd/btrfs-nfs-csi/flags.go
@@ -17,7 +17,7 @@ func labelFlag() cli.Flag {
 }
 
 func allFlag() cli.Flag {
-	return &cli.BoolFlag{Name: "all", Aliases: []string{"A"}, Usage: "show all (default: only created-by=cli)"}
+	return &cli.BoolFlag{Name: "all", Aliases: []string{"A"}, Usage: "show all (default: only resources created by the active identity)"}
 }
 
 func sortFlag() cli.Flag {
@@ -80,7 +80,7 @@ func buildListOpts(cmd *cli.Command) cliListOpts {
 	labels := splitLabelsFlag(cmd)
 	allSet := cmd.Bool("all")
 	if !allSet {
-		labels = append(labels, config.LabelCreatedBy+"="+config.IdentityCLI)
+		labels = append(labels, config.LabelCreatedBy+"="+apiClient.Identity())
 	}
 	return cliListOpts{
 		ListOpts: models.ListOpts{Labels: labels},

--- a/cmd/btrfs-nfs-csi/model.go
+++ b/cmd/btrfs-nfs-csi/model.go
@@ -315,7 +315,11 @@ func taskCmd() *cli.Command {
 						sortBy = sortCreated
 					}
 					rev := !cmd.Bool("asc")
-					opts := buildListOpts(cmd)
+					opts := cliListOpts{
+						ListOpts: models.ListOpts{Labels: splitLabelsFlag(cmd)},
+						allSet:   cmd.Bool("all"),
+						labelSet: cmd.IsSet("label"),
+					}
 					if !opts.allSet {
 						opts.Labels = append(opts.Labels, config.LabelTenant+"="+apiClient.Whoami().Tenant)
 					}

--- a/cmd/btrfs-nfs-csi/model.go
+++ b/cmd/btrfs-nfs-csi/model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/urfave/cli/v3"
 )
 
@@ -315,6 +316,9 @@ func taskCmd() *cli.Command {
 					}
 					rev := !cmd.Bool("asc")
 					opts := buildListOpts(cmd)
+					if !opts.allSet {
+						opts.Labels = append(opts.Labels, config.LabelTenant+"="+apiClient.Whoami().Tenant)
+					}
 					return runWatch(ctx, cmd, func() error {
 						return listTasks(ctx, cmd, taskType, sortBy, rev, opts)
 					})

--- a/cmd/btrfs-nfs-csi/utils.go
+++ b/cmd/btrfs-nfs-csi/utils.go
@@ -352,10 +352,13 @@ var (
 	timingLine string
 )
 
-func initClient(cmd *cli.Command) error {
+func initClient(ctx context.Context, cmd *cli.Command) error {
 	var err error
 	apiClient, err = agentclient.NewClient(cmd.String("agent-url"), cmd.String("agent-token"), config.IdentityCLI)
-	return err
+	if err != nil {
+		return err
+	}
+	return apiClient.Resolve(ctx)
 }
 
 func withCLIHooks(cmds ...*cli.Command) []*cli.Command {
@@ -366,7 +369,7 @@ func withCLIHooks(cmds ...*cli.Command) []*cli.Command {
 			&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Value: outputTable, Usage: "output format: table, wide, json, json,wide"},
 		)
 		cmd.Before = func(ctx context.Context, c *cli.Command) (context.Context, error) {
-			if err := initClient(c); err != nil {
+			if err := initClient(ctx, c); err != nil {
 				return ctx, err
 			}
 			cmdStart = time.Now()


### PR DESCRIPTION
## Summary

- Bugfix: `task ls` showed tasks from other tenants when they shared the same `created-by` identity
- CLI now caches the Whoami response on init and adds `tenant=<own>` to the default filter; `-A` keeps cross-tenant view
- Also fixes `volume ls`/`snapshot ls`/`export ls`/`task ls` to honour `AGENT_CSI_IDENTITY` instead of hardcoded `cli`
