### PR TITLE
Stamp caller identity onto agent request and event logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## v0.11.1
 
-Patch release. Final lap before the project is replaced by ButterStore (see `RELEASE.md`).
+Per-request audit access log plus default-filter and CodeQL fixes. Final lap before the project is replaced by ButterStore (see `RELEASE.md`).
+
+### Improvements
+- Stamp caller identity onto agent request and event logs (#160)
+- Silence CodeQL go/path-injection false positives (#157)
 
 ### Bug Fixes
 - Honour AGENT_CSI_IDENTITY in default list filter (#158)
-
-### Improvements
-- Silence CodeQL go/path-injection false positives (#157)
 
 ### Dependencies
 - Bump `github.com/rs/zerolog` from 1.35.0 to 1.35.1 (#145)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 **Previous: v0.11.0** | **Date: 2026-04-29**
 
-Patch release. The CLI now respects `AGENT_CSI_IDENTITY` in its default list filter, so non-`cli` identities (Ansible, ad-hoc operator scripts, second CLI in a different role) see their own resources by default instead of always falling back to `created-by=cli`. Plus a CodeQL hardening pass on path handling, a zerolog patch bump, and documentation fixes.
+Per-request audit access log: every API call now emits one log line with tenant, role, identity, token fingerprint, method, path, status, duration, and user agent. Storage event logs (volume created, snapshot deleted, ...) inherit the same caller fields via zerolog's contextual logger, no per-call plumbing. Plus the CLI default list filter follows `AGENT_CSI_IDENTITY`, a CodeQL hardening pass on path handling, the access log status fix (404s no longer report as 200), a zerolog patch bump, and documentation fixes.
 
 No breaking changes. `AGENT_TENANTS`, Helm values, StorageClasses, PVCs, VolumeSnapshots, and the in-tree CSI driver work without modification.
 
@@ -17,6 +17,24 @@ No breaking changes. `AGENT_TENANTS`, Helm values, StorageClasses, PVCs, VolumeS
 ---
 
 ## Highlights
+
+### Per-request audit access log
+
+Every API call now produces one access log line with full caller identity:
+
+```
+INF request method=POST path=/v1/volumes code=201 took=9.4ms tenant=ops role=user identity=ci-bot token_fingerprint=ab12...e1f4 client=10.0.0.5 user_agent=btrfs-nfs-csi-cli/0.11.1
+INF volume created  name=my-vol path=/export/data/ops/my-vol  tenant=ops role=user identity=ci-bot token_fingerprint=ab12...e1f4
+```
+
+Storage event logs (volume created, snapshot deleted, NFS export added, ...) carry the same audit fields via zerolog's contextual logger, no per-call plumbing. To find every action a token took: `grep token_fingerprint=ab12 access.log`.
+
+Behaviour summary:
+
+- **Level by status**: 5xx → error, 4xx → warn, 2xx/3xx → info. Operators can silence success-path traffic with `LOG_LEVEL=warn` while keeping denials and server errors visible.
+- **`/healthz` skipped**: the CSI node driver polls it every few seconds, no audit value.
+- **Denial reasons**: 401 carries `reason=invalid_token`, 403 carries `reason=role_denied / ownership / identity_mismatch`, matching the existing Prometheus `http_requests_total{reason=...}` label.
+- **Background workers**: the NFS reconciler and usage updater tag their tenant the same way, so log lines emitted from those loops still carry `tenant=...` (without `identity` or `fingerprint`, since there is no caller).
 
 ### Default list filter follows the active identity
 
@@ -35,14 +53,16 @@ Identical for the agent. The only thing that changes is what shows up by default
 ## Bug Fixes
 
 - **`AGENT_CSI_IDENTITY` honoured in default list filter** (#158). The CLI default filter was always `created-by=cli`, regardless of the configured identity. Lists now filter by the resolved identity from `/v1/whoami`, falling back to `cli` if no identity is set on the token. The `--all` / `-A` flag still bypasses the filter entirely.
+- **Access log and Prometheus counter report the real status** (#160). Echo's `DefaultHTTPErrorHandler` writes the 4xx/5xx status after middleware unwinds, so reading `c.Response().Status` directly defaulted to 200 for handler-returned errors. The agent now uses `echo.ResolveResponseStatus`, so 404s, 401s, and 403s log at the right level (`warn`) and the Prometheus `http_requests_total{code=...}` counter classifies them correctly.
 
 ## Improvements
 
 - **CodeQL path-injection false positives silenced** (#157). Storage-layer file operations now route through a small `meta/store` boundary that re-validates paths under the configured base. No behaviour change at runtime, the agent already rejected traversal at the API layer, but CodeQL can no longer point at a long list of `os.ReadFile`/`os.WriteFile` call sites as suspect.
+- **Per-request access log with caller identity** (#160). New `LoggerMiddleware` clones the global zerolog logger into the request context, `AuthMiddleware` stamps `tenant`/`role`/`identity`/`token_fingerprint` onto it via `UpdateContext`, `MetricsMiddleware` emits the access log line at info/warn/error by status (`/healthz` skipped, optional `user_agent` and denial `reason` included). Storage event logs use `log.Ctx(ctx)` so they inherit the same fields without per-call plumbing.
 
 ## Documentation
 
-- **Quickstart curl typo fixed** (`docs/installation.md`). 
+- **Quickstart curl typo fixed** (`docs/installation.md`).
 - **Task system architecture page brought up to date** (`docs/architecture.md`). Lists all five task types (`scrub`, `balance`, `quota-rescan`, `defragment`, `test`) and the filesystem-wide mutex.
 
 ## Dependencies
@@ -62,6 +82,10 @@ No action required. The CSI controller and node driver run with `AGENT_CSI_IDENT
 ### CLI users with a custom identity
 
 If you set `AGENT_CSI_IDENTITY` to anything other than `cli` and worked around the old filter with `--all`, you can drop the flag, the default now matches your identity. The agent makes one extra `GET /v1/whoami` call when the CLI starts to resolve the identity.
+
+### Operators / log shippers
+
+Expect one extra info-level access log line per authenticated API call. CSI node-driver `/healthz` polling does **not** log, so the noise floor stays manageable. To silence the success path on busy clusters, set `LOG_LEVEL=warn`, denials and errors stay visible. The `http_requests_total` Prometheus counter now classifies 4xx/5xx correctly (previously many of them were undercounted as `code="200"`).
 
 ---
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -24,8 +24,16 @@ import (
 	env "github.com/caarlos0/env/v11"
 	"github.com/labstack/echo/v5"
 	"github.com/labstack/echo/v5/middleware"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+func init() {
+	// Make log.Ctx(ctx) fall back to the global logger when no per-request
+	// or per-worker logger has been put into the context. Storage code can
+	// then use log.Ctx(ctx) unconditionally without checking origin.
+	zerolog.DefaultContextLogger = &log.Logger
+}
 
 type Agent struct {
 	cfg     *config.AgentConfig
@@ -80,6 +88,7 @@ func NewAgent(cfg *config.AgentConfig, version, commit string) (*Agent, error) {
 			},
 		}),
 	})
+	e.Use(v1.LoggerMiddleware())             // place per-request logger in ctx; must run before Metrics + Auth
 	e.Use(middleware.BodyLimit(1024 * 1024)) // 1MB
 	e.Use(v1.MetricsMiddleware())
 

--- a/agent/api/v1/metrics.go
+++ b/agent/api/v1/metrics.go
@@ -1,12 +1,14 @@
 package v1
 
 import (
+	"context"
 	"strconv"
 	"time"
 
 	"github.com/labstack/echo/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -51,34 +53,60 @@ func MetricsMiddleware() echo.MiddlewareFunc {
 		return func(c *echo.Context) error {
 			start := time.Now()
 			err := next(c)
-			duration := time.Since(start).Seconds()
+			dur := time.Since(start)
 
 			method := c.Request().Method
 			path := c.RouteInfo().Path
-			resp := c.Response().(*echo.Response)
-			code := strconv.Itoa(resp.Status)
+			// Resolve the real status. echo's DefaultHTTPErrorHandler runs
+			// after middleware unwinds, so reading c.Response().Status alone
+			// would report 200 for handler-returned errors (e.g. 404 from a
+			// not-found path, 401 from auth). echo.ResolveResponseStatus walks
+			// err and returns the status that will actually be sent.
+			_, status := echo.ResolveResponseStatus(c.Response(), err)
+			code := strconv.Itoa(status)
 			reason, _ := c.Get(ctxKeyDenial).(string)
 
 			httpRequestsTotal.WithLabelValues(method, path, code, reason).Inc()
-			httpRequestDuration.WithLabelValues(method, path).Observe(duration)
+			httpRequestDuration.WithLabelValues(method, path).Observe(dur.Seconds())
 
-			tenant := tenantOf(c)
-			l := log.Debug().
+			// Skip the high-frequency CSI healthcheck noise. /metrics lives on
+			// a separate listener (AGENT_METRICS_ADDR), so it never reaches us.
+			if c.Request().URL.Path == "/healthz" {
+				return err
+			}
+
+			l := accessLog(c.Request().Context(), status).
 				Str("method", method).
 				Str("path", c.Request().URL.Path).
-				Str("code", code).
+				Int("code", status).
 				Str("client", c.RealIP()).
-				Str("took", time.Since(start).String())
-			if tenant != "" {
-				l = l.Str("tenant", tenant)
+				Str("took", dur.String())
+			if ua := c.Request().UserAgent(); ua != "" {
+				l = l.Str("user_agent", ua)
 			}
-			if resp.Status >= 400 {
-				l.Msg("request error")
-			} else {
-				l.Msg("request")
+			if reason != "" {
+				l = l.Str("reason", reason)
 			}
+			l.Msg("request")
 
 			return err
 		}
+	}
+}
+
+// accessLog picks the zerolog level for an access log line by status (5xx
+// error, 4xx warn, else info) and returns an event from the per-request
+// contextual logger so tenant/identity/token_fingerprint are inherited.
+// Operators can silence successful requests with LOG_LEVEL=warn while
+// keeping denials and server errors visible.
+func accessLog(ctx context.Context, status int) *zerolog.Event {
+	l := log.Ctx(ctx)
+	switch {
+	case status >= 500:
+		return l.Error()
+	case status >= 400:
+		return l.Warn()
+	default:
+		return l.Info()
 	}
 }

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -126,8 +126,8 @@ func AuthMiddleware(tokens *TokenSet) echo.MiddlewareFunc {
 }
 
 func authFailed(c *echo.Context, reason string) error {
-	log.Warn().Str("client", c.RealIP()).Str("path", c.Request().URL.Path).Str("reason", reason).Msg("auth failed")
-	log.Trace().Str("client", c.RealIP()).Str("authorization", c.Request().Header.Get("Authorization")).Msg("auth failed detail")
+	log.Ctx(c.Request().Context()).Warn().Str("client", c.RealIP()).Str("path", c.Request().URL.Path).Str("reason", reason).Msg("auth failed")
+	log.Ctx(c.Request().Context()).Trace().Str("client", c.RealIP()).Str("authorization", c.Request().Header.Get("Authorization")).Msg("auth failed detail")
 	c.Response().Header().Set("WWW-Authenticate", `Basic realm="agent"`)
 	return c.JSON(http.StatusUnauthorized, models.ErrorResponse{
 		Error: "invalid auth token",

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -8,8 +8,25 @@ import (
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
 	"github.com/labstack/echo/v5"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+// LoggerMiddleware places a per-request copy of the global logger into the
+// request context so subsequent middleware can mutate it via UpdateContext
+// (adding tenant, identity, fingerprint after auth) and downstream code can
+// pick it up with log.Ctx(ctx). Without this, UpdateContext would mutate the
+// global logger.
+func LoggerMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			req := c.Request()
+			l := log.Logger.With().Logger()
+			c.SetRequest(req.WithContext(l.WithContext(req.Context())))
+			return next(c)
+		}
+	}
+}
 
 // Context keys set by AuthMiddleware. Read via the *Of accessors below.
 const (
@@ -72,6 +89,17 @@ func AuthMiddleware(tokens *TokenSet) echo.MiddlewareFunc {
 			if fp != "" {
 				c.Set(ctxKeyFingerprint, fp)
 			}
+
+			log.Ctx(c.Request().Context()).UpdateContext(func(zc zerolog.Context) zerolog.Context {
+				zc = zc.Str("tenant", info.Name).Str("role", string(info.Role))
+				if info.Identity != "" {
+					zc = zc.Str("identity", info.Identity)
+				}
+				if fp != "" {
+					zc = zc.Str("token_fingerprint", fp)
+				}
+				return zc
+			})
 
 			method := c.Request().Method
 			if info.Role == models.RoleReadonly {

--- a/agent/api/v1/middleware_test.go
+++ b/agent/api/v1/middleware_test.go
@@ -621,6 +621,107 @@ func TestPolicyApply(t *testing.T) {
 	}
 }
 
+// TestMetricsMiddleware_AccessLogIncludesAuthFields verifies the per-request
+// access log emitted by MetricsMiddleware carries tenant/role/identity/
+// token_fingerprint after AuthMiddleware ran UpdateContext on the per-request
+// logger placed by LoggerMiddleware. Pinning this protects the audit story.
+func TestMetricsMiddleware_AccessLogIncludesAuthFields(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf).With().Timestamp().Logger()
+	defer func() { log.Logger = orig }()
+
+	tenants := map[string]models.TenantInfo{
+		"user-token": {Name: "ci", Role: models.RoleUser, Identity: "ci-bot"},
+	}
+
+	e := echo.New()
+	e.Use(LoggerMiddleware())
+	e.Use(MetricsMiddleware())
+	api := e.Group("/v1", AuthMiddleware(tokensFromMap(t, tenants)))
+	api.GET("/whoami", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/whoami", nil)
+	req.Header.Set("Authorization", "Bearer user-token")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	out := buf.String()
+	assert.Contains(t, out, `"message":"request"`, "expected access log line")
+	assert.Contains(t, out, `"tenant":"ci"`)
+	assert.Contains(t, out, `"role":"user"`)
+	assert.Contains(t, out, `"identity":"ci-bot"`)
+	assert.Contains(t, out, `"token_fingerprint":`)
+	assert.Contains(t, out, `"code":200`)
+	assert.Contains(t, out, `"method":"GET"`)
+	assert.Contains(t, out, `"path":"/v1/whoami"`)
+	assert.NotContains(t, out, `"reason":`, "no denial reason on success")
+}
+
+// TestMetricsMiddleware_HealthzNotLogged verifies that GET /healthz produces
+// no access log line. The agent's CSI node-driver pollt that endpoint every
+// few seconds and would flood the log otherwise.
+func TestMetricsMiddleware_HealthzNotLogged(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf).With().Timestamp().Logger()
+	defer func() { log.Logger = orig }()
+
+	e := echo.New()
+	e.Use(LoggerMiddleware())
+	e.Use(MetricsMiddleware())
+	e.GET("/healthz", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
+	e.GET("/v1/whatever", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	healthReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	healthRec := httptest.NewRecorder()
+	e.ServeHTTP(healthRec, healthReq)
+	require.Equal(t, http.StatusOK, healthRec.Code)
+	assert.NotContains(t, buf.String(), `"message":"request"`, "/healthz must not emit access log")
+
+	buf.Reset()
+
+	otherReq := httptest.NewRequest(http.MethodGet, "/v1/whatever", nil)
+	otherRec := httptest.NewRecorder()
+	e.ServeHTTP(otherRec, otherReq)
+	require.Equal(t, http.StatusOK, otherRec.Code)
+	otherOut := buf.String()
+	assert.Contains(t, otherOut, `"message":"request"`, "non-/healthz must emit access log")
+	assert.Contains(t, otherOut, `"path":"/v1/whatever"`)
+}
+
+// TestMetricsMiddleware_NotFoundLogsRealStatusAndUserAgent verifies that a
+// request to an unregistered path logs at warn level with code=404 (not 200)
+// and that the User-Agent header lands in the access log. echo's default
+// error handler writes the 404 after middleware unwinds, so reading
+// Response.Status directly would still show 200, the middleware therefore
+// uses echo.ResolveResponseStatus to resolve the err.
+func TestMetricsMiddleware_NotFoundLogsRealStatusAndUserAgent(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf).With().Timestamp().Logger()
+	defer func() { log.Logger = orig }()
+
+	e := echo.New()
+	e.Use(LoggerMiddleware())
+	e.Use(MetricsMiddleware())
+	e.GET("/known", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/totally-fake", nil)
+	req.Header.Set("User-Agent", "ZGrab/0.x (scanner)")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	out := buf.String()
+	assert.Contains(t, out, `"level":"warn"`, "4xx must log at warn level")
+	assert.Contains(t, out, `"code":404`)
+	assert.Contains(t, out, `"path":"/totally-fake"`)
+	assert.Contains(t, out, `"user_agent":"ZGrab/0.x (scanner)"`)
+	assert.NotContains(t, out, `"code":200`, "must not report 200 for a 404")
+}
+
 // TestPolicyApply_RejectsHardReservedLabels exercises every policy that
 // stamps or preserves labels against every server-managed key. Any
 // combination must fail at the API boundary rather than silently overwrite

--- a/agent/api/v1/middleware_test.go
+++ b/agent/api/v1/middleware_test.go
@@ -18,6 +18,10 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+func init() {
+	zerolog.DefaultContextLogger = &log.Logger
+}
+
 func TestAuthMiddleware_InvalidToken_NoTokenInWarnLog(t *testing.T) {
 	// capture log output at warn level (trace is intentionally allowed to contain tokens)
 	var buf bytes.Buffer
@@ -689,6 +693,48 @@ func TestMetricsMiddleware_HealthzNotLogged(t *testing.T) {
 	otherOut := buf.String()
 	assert.Contains(t, otherOut, `"message":"request"`, "non-/healthz must emit access log")
 	assert.Contains(t, otherOut, `"path":"/v1/whatever"`)
+}
+
+// TestStorageEventLogInheritsAuthFields verifies that downstream code (the
+// storage layer) calling log.Ctx(ctx) inside a handler picks up the
+// tenant/role/identity/token_fingerprint that AuthMiddleware stamped onto
+// the per-request logger via UpdateContext. This is what makes "volume
+// created" event lines carry the same audit fields as the access log.
+func TestStorageEventLogInheritsAuthFields(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf).With().Timestamp().Logger()
+	defer func() { log.Logger = orig }()
+
+	tenants := map[string]models.TenantInfo{
+		"user-token": {Name: "ops", Role: models.RoleUser, Identity: "ci-bot"},
+	}
+
+	e := echo.New()
+	e.Use(LoggerMiddleware())
+	api := e.Group("/v1", AuthMiddleware(tokensFromMap(t, tenants)))
+	api.POST("/volumes", func(c *echo.Context) error {
+		// Mirror what agent/storage/volume.go does after CreateVolume.
+		log.Ctx(c.Request().Context()).Info().
+			Str("name", "my-vol").
+			Str("path", "/data/ops/my-vol").
+			Msg("volume created")
+		return c.NoContent(http.StatusCreated)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/volumes", nil)
+	req.Header.Set("Authorization", "Bearer user-token")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	out := buf.String()
+	assert.Contains(t, out, `"message":"volume created"`)
+	assert.Contains(t, out, `"name":"my-vol"`)
+	assert.Contains(t, out, `"tenant":"ops"`)
+	assert.Contains(t, out, `"role":"user"`)
+	assert.Contains(t, out, `"identity":"ci-bot"`)
+	assert.Contains(t, out, `"token_fingerprint":`)
 }
 
 // TestMetricsMiddleware_NotFoundLogsRealStatusAndUserAgent verifies that a

--- a/agent/api/v1/policy.go
+++ b/agent/api/v1/policy.go
@@ -80,10 +80,10 @@ func (p Policy) checkAllowedRoles(c *echo.Context, role models.TenantRole) error
 	if len(p.AllowedRoles) == 0 || slices.Contains(p.AllowedRoles, role) {
 		return nil
 	}
-	denialLog(c, denialRoleDenied).
-		Str("method", c.Request().Method).
-		Str("role", string(role)).
-		Msg("role denied")
+	// No dedicated log line: the access log emitted by MetricsMiddleware
+	// already carries reason=role_denied plus all caller fields and is
+	// strictly a superset of what we'd write here.
+	c.Set(ctxKeyDenial, denialRoleDenied)
 	return &storage.StorageError{
 		Code:    storage.ErrForbidden,
 		Message: "role \"" + string(role) + "\" not allowed for this operation",
@@ -92,11 +92,9 @@ func (p Policy) checkAllowedRoles(c *echo.Context, role models.TenantRole) error
 
 func denialLog(c *echo.Context, reason string) *zerolog.Event {
 	c.Set(ctxKeyDenial, reason)
-	return log.Warn().
+	return log.Ctx(c.Request().Context()).Warn().
 		Str("client", c.RealIP()).
-		Str("tenant", tenantOf(c)).
-		Str("path", c.Request().URL.Path).
-		Str("token_fingerprint", fingerprintOf(c))
+		Str("path", c.Request().URL.Path)
 }
 
 func rejectHardReservedLabels(labels map[string]string) error {

--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -127,6 +127,6 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	log.Info().Str("tenant", tenant).Str("name", req.Name).Str("snapshot", req.Snapshot).Msg("clone created")
+	log.Ctx(ctx).Info().Str("name", req.Name).Str("snapshot", req.Snapshot).Msg("clone created")
 	return &vol, nil
 }

--- a/agent/storage/export.go
+++ b/agent/storage/export.go
@@ -64,7 +64,7 @@ func (s *Storage) CreateVolumeExport(ctx context.Context, tenant, name, client s
 		}
 	}
 
-	log.Info().Str("tenant", tenant).Str("name", name).Str("client", client).Msg("NFS export added")
+	log.Ctx(ctx).Info().Str("name", name).Str("client", client).Msg("NFS export added")
 	return nil
 }
 
@@ -128,7 +128,7 @@ func (s *Storage) DeleteVolumeExport(ctx context.Context, tenant, name, client s
 		}
 	}
 
-	log.Info().Str("tenant", tenant).Str("name", name).Str("client", client).Msg("NFS export removed")
+	log.Ctx(ctx).Info().Str("name", name).Str("client", client).Msg("NFS export removed")
 	return nil
 }
 

--- a/agent/storage/reconciler.go
+++ b/agent/storage/reconciler.go
@@ -28,6 +28,7 @@ func (s *Storage) startNFSReconciler(ctx context.Context, interval time.Duration
 }
 
 func (s *Storage) reconcileExports(ctx context.Context, tenant string) {
+	ctx = log.With().Str("tenant", tenant).Logger().WithContext(ctx)
 	tenantDir := filepath.Join(s.basePath, tenant)
 
 	exports, err := s.exporter.ListExports(ctx)
@@ -93,8 +94,8 @@ func (s *Storage) reconcileExports(ctx context.Context, tenant string) {
 	})
 
 	if removed > 0 || restored > 0 {
-		log.Info().Str("tenant", tenant).Int("removed", removed).Int("restored", restored).Msg("nfs reconciler: reconciliation complete")
+		log.Ctx(ctx).Info().Int("removed", removed).Int("restored", restored).Msg("nfs reconciler: reconciliation complete")
 	} else {
-		log.Debug().Str("tenant", tenant).Msg("nfs reconciler: in sync")
+		log.Ctx(ctx).Debug().Msg("nfs reconciler: in sync")
 	}
 }

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -96,7 +96,7 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	log.Info().Str("tenant", tenant).Str("name", req.Name).Str("volume", req.Volume).Msg("snapshot created")
+	log.Ctx(ctx).Info().Str("name", req.Name).Str("volume", req.Volume).Msg("snapshot created")
 	return &meta, nil
 }
 
@@ -170,6 +170,6 @@ func (s *Storage) DeleteSnapshot(ctx context.Context, tenant, name string) error
 		log.Error().Err(err).Msg("failed to remove snapshot directory")
 		return fmt.Errorf("failed to remove snapshot directory: %w", err)
 	}
-	log.Info().Str("tenant", tenant).Str("name", name).Msg("snapshot deleted")
+	log.Ctx(ctx).Info().Str("name", name).Msg("snapshot deleted")
 	return nil
 }

--- a/agent/storage/usage.go
+++ b/agent/storage/usage.go
@@ -33,8 +33,9 @@ func (s *Storage) startUsageUpdater(ctx context.Context, mgr *btrfs.Manager, int
 }
 
 func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant string) {
+	ctx = log.With().Str("tenant", tenant).Logger().WithContext(ctx)
 	start := time.Now()
-	log.Debug().Str("tenant", tenant).Msg("usage updater: starting scan")
+	log.Ctx(ctx).Debug().Msg("usage updater: starting scan")
 
 	// bulk-fetch qgroup usage: 2 btrfs commands total instead of 2*N
 	var usageMap map[string]btrfs.QgroupInfo
@@ -42,7 +43,7 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 		var err error
 		usageMap, err = mgr.QgroupUsageBulk(ctx, s.mountPoint)
 		if err != nil {
-			log.Warn().Err(err).Str("tenant", tenant).Msg("usage updater: bulk qgroup query failed, skipping usage updates")
+			log.Ctx(ctx).Warn().Err(err).Msg("usage updater: bulk qgroup query failed, skipping usage updates")
 		}
 	}
 
@@ -133,7 +134,7 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 	})
 
 	VolumesGauge.WithLabelValues(tenant).Set(float64(count))
-	log.Info().Str("tenant", tenant).Int("volumes", count).Int("updated", updated).Int("failed", failed).Str("took", time.Since(start).String()).Msg("usage updater: scan complete")
+	log.Ctx(ctx).Info().Int("volumes", count).Int("updated", updated).Int("failed", failed).Str("took", time.Since(start).String()).Msg("usage updater: scan complete")
 
 	// update snapshot usage
 	var snapUpdated, snapFailed, snapCount int
@@ -178,5 +179,5 @@ func (s *Storage) updateAll(ctx context.Context, mgr *btrfs.Manager, tenant stri
 		return true
 	})
 
-	log.Debug().Str("tenant", tenant).Int("snapshots", snapCount).Int("updated", snapUpdated).Int("failed", snapFailed).Msg("usage updater: snapshot scan complete")
+	log.Ctx(ctx).Debug().Int("snapshots", snapCount).Int("updated", snapUpdated).Int("failed", snapFailed).Msg("usage updater: snapshot scan complete")
 }

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -156,7 +156,7 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	log.Info().Str("tenant", tenant).Str("name", req.Name).Str("path", volDir).Msg("volume created")
+	log.Ctx(ctx).Info().Str("name", req.Name).Str("path", volDir).Msg("volume created")
 	return &meta, nil
 }
 
@@ -339,7 +339,7 @@ func (s *Storage) UpdateVolume(ctx context.Context, tenant, name string, req Vol
 		return nil, fmt.Errorf("failed to update metadata: %w", err)
 	}
 
-	log.Info().Str("tenant", tenant).Str("name", name).Msg("volume updated")
+	log.Ctx(ctx).Info().Str("name", name).Msg("volume updated")
 	return updated, nil
 }
 
@@ -442,7 +442,7 @@ func (s *Storage) CloneVolume(ctx context.Context, tenant string, req VolumeClon
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	log.Info().Str("tenant", tenant).Str("name", req.Name).Str("source", req.Source).Msg("volume cloned")
+	log.Ctx(ctx).Info().Str("name", req.Name).Str("source", req.Source).Msg("volume cloned")
 	return &meta, nil
 }
 
@@ -489,6 +489,6 @@ func (s *Storage) DeleteVolume(ctx context.Context, tenant, name string) error {
 		log.Error().Err(err).Msg("failed to remove volume directory")
 		return fmt.Errorf("failed to remove volume directory: %w", err)
 	}
-	log.Info().Str("tenant", tenant).Str("name", name).Msg("volume deleted")
+	log.Ctx(ctx).Info().Str("name", name).Msg("volume deleted")
 	return nil
 }


### PR DESCRIPTION
## Summary

- AuthMiddleware writes tenant/role/identity/token_fingerprint onto the per-request zerolog logger via `UpdateContext`. Storage event logs (volume created, snapshot deleted, ...) and the new access log both pick them up through `log.Ctx(ctx)`. Background workers (reconciler, usage updater) tag their tenant the same way.
- MetricsMiddleware emits one access log per request, level-by-status (5xx error / 4xx warn / else info), skips `/healthz`, and includes method, path, code, took, client plus optional user_agent and denial reason. Uses `echo.ResolveResponseStatus`, so 404s and handler-returned errors no longer log as `code=200`.
- Three tests in `middleware_test.go` pin the new behaviors: audit fields present on 200, `/healthz` not logged, 404 logged at warn with user_agent and the real code.
