### PR TITLE
Log ioctl errors on immutable toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## v0.11.1
 
-Per-request audit access log plus default-filter and CodeQL fixes. Final lap before the project is replaced by ButterStore (see `RELEASE.md`).
+Per-request audit access log plus default-filter, CodeQL fixes, and logging hardening. Final lap before the project is replaced by ButterStore (see `RELEASE.md`).
+
+### Security
+- Drop Authorization header trace log on auth failure (#161)
 
 ### Improvements
 - Stamp caller identity onto agent request and event logs (#160)
 - Silence CodeQL go/path-injection false positives (#157)
+- Log ioctl errors in metadata immutable toggle (#161)
 
 ### Bug Fixes
 - Honour AGENT_CSI_IDENTITY in default list filter (#158)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 # Release v0.11.1
 
-**Previous: v0.11.0** | **Date: 2026-04-29**
+**Previous: v0.11.0** | **Date: 2026-04-30**
 
-Per-request audit access log: every API call now emits one log line with tenant, role, identity, token fingerprint, method, path, status, duration, and user agent. Storage event logs (volume created, snapshot deleted, ...) inherit the same caller fields via zerolog's contextual logger, no per-call plumbing. Plus the CLI default list filter follows `AGENT_CSI_IDENTITY`, a CodeQL hardening pass on path handling, the access log status fix (404s no longer report as 200), a zerolog patch bump, and documentation fixes.
+Per-request audit access log: every API call now emits one log line with tenant, role, identity, token fingerprint, method, path, status, duration, and user agent. Storage event logs (volume created, snapshot deleted, ...) inherit the same caller fields via zerolog's contextual logger, no per-call plumbing. Plus the CLI default list filter follows `AGENT_CSI_IDENTITY`, a CodeQL hardening pass on path handling, the access log status fix (404s no longer report as 200), two logging hardenings (Authorization header no longer reachable from a trace log, immutable ioctl failures now surface as warnings), a zerolog patch bump, and documentation fixes.
 
 No breaking changes. `AGENT_TENANTS`, Helm values, StorageClasses, PVCs, VolumeSnapshots, and the in-tree CSI driver work without modification.
 
@@ -50,6 +50,10 @@ Identical for the agent. The only thing that changes is what shows up by default
 
 ---
 
+## Security
+
+- **Drop Authorization header trace log on auth failure** (#161). `authFailed` previously emitted a second log line at trace level containing the raw `Authorization` header, which made debugging easier but meant a misconfigured `LOG_LEVEL=trace` would persist tokens in logs. Removed entirely. Auth failures still log at warn with `client`, `path`, and `reason`, none of which carry the token. Operators who relied on the trace line for debugging should diff the request payload against `AGENT_TENANTS` directly instead.
+
 ## Bug Fixes
 
 - **`AGENT_CSI_IDENTITY` honoured in default list filter** (#158). The CLI default filter was always `created-by=cli`, regardless of the configured identity. Lists now filter by the resolved identity from `/v1/whoami`, falling back to `cli` if no identity is set on the token. The `--all` / `-A` flag still bypasses the filter entirely.
@@ -59,6 +63,7 @@ Identical for the agent. The only thing that changes is what shows up by default
 
 - **CodeQL path-injection false positives silenced** (#157). Storage-layer file operations now route through a small `meta/store` boundary that re-validates paths under the configured base. No behaviour change at runtime, the agent already rejected traversal at the API layer, but CodeQL can no longer point at a long list of `os.ReadFile`/`os.WriteFile` call sites as suspect.
 - **Per-request access log with caller identity** (#160). New `LoggerMiddleware` clones the global zerolog logger into the request context, `AuthMiddleware` stamps `tenant`/`role`/`identity`/`token_fingerprint` onto it via `UpdateContext`, `MetricsMiddleware` emits the access log line at info/warn/error by status (`/healthz` skipped, optional `user_agent` and denial `reason` included). Storage event logs use `log.Ctx(ctx)` so they inherit the same fields without per-call plumbing.
+- **Log ioctl errors in metadata immutable toggle** (#161). The `toggleImmutable` helper in `agent/storage/meta/store.go` previously discarded the `errno` return from both `FS_IOC_GETFLAGS` and `FS_IOC_SETFLAGS`, and silently swallowed `OpenFile` failures. A failure to set the immutable bit on a metadata file (for example on a non-btrfs filesystem, or without `CAP_LINUX_IMMUTABLE`) left the file unprotected with no log signal. The helper now logs at warn level on every non-`ENOENT` open failure and on every non-zero ioctl errno, with `path` and `set` fields attached.
 
 ## Documentation
 

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -127,7 +127,6 @@ func AuthMiddleware(tokens *TokenSet) echo.MiddlewareFunc {
 
 func authFailed(c *echo.Context, reason string) error {
 	log.Ctx(c.Request().Context()).Warn().Str("client", c.RealIP()).Str("path", c.Request().URL.Path).Str("reason", reason).Msg("auth failed")
-	log.Ctx(c.Request().Context()).Trace().Str("client", c.RealIP()).Str("authorization", c.Request().Header.Get("Authorization")).Msg("auth failed detail")
 	c.Response().Header().Set("WWW-Authenticate", `Basic realm="agent"`)
 	return c.JSON(http.StatusUnauthorized, models.ErrorResponse{
 		Error: "invalid auth token",

--- a/agent/api/v1/middleware_test.go
+++ b/agent/api/v1/middleware_test.go
@@ -22,11 +22,10 @@ func init() {
 	zerolog.DefaultContextLogger = &log.Logger
 }
 
-func TestAuthMiddleware_InvalidToken_NoTokenInWarnLog(t *testing.T) {
-	// capture log output at warn level (trace is intentionally allowed to contain tokens)
+func TestAuthMiddleware_InvalidToken_NoTokenInLog(t *testing.T) {
 	var buf bytes.Buffer
 	orig := log.Logger
-	log.Logger = zerolog.New(&buf).With().Timestamp().Logger().Level(zerolog.WarnLevel)
+	log.Logger = zerolog.New(&buf).With().Timestamp().Logger().Level(zerolog.TraceLevel)
 	defer func() { log.Logger = orig }()
 
 	tenants := map[string]models.TenantInfo{"valid-token": {Name: "default", Role: models.RoleAdmin}}
@@ -51,39 +50,10 @@ func TestAuthMiddleware_InvalidToken_NoTokenInWarnLog(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, storage.ErrUnauthorized, resp.Code)
 
-	// verify the Authorization header / token value is NOT in warn-level log output
 	logOutput := buf.String()
-	assert.NotContains(t, logOutput, "secret-token-value", "auth token must not appear in warn logs")
-	assert.NotContains(t, logOutput, "Bearer secret-token-value", "Authorization header must not appear in warn logs")
-	// verify we still log useful context
+	assert.NotContains(t, logOutput, "secret-token-value", "auth token must not appear in any log level")
+	assert.NotContains(t, logOutput, "Bearer secret-token-value", "Authorization header must not appear in any log level")
 	assert.Contains(t, logOutput, "auth failed", "should still log the auth failure event")
-}
-
-func TestAuthMiddleware_InvalidToken_TraceContainsToken(t *testing.T) {
-	var buf bytes.Buffer
-	orig := log.Logger
-	log.Logger = zerolog.New(&buf).With().Timestamp().Logger().Level(zerolog.TraceLevel)
-	defer func() { log.Logger = orig }()
-
-	tenants := map[string]models.TenantInfo{"valid-token": {Name: "default", Role: models.RoleAdmin}}
-	mw := AuthMiddleware(tokensFromMap(t, tenants))
-
-	e := echo.New()
-	handler := mw(func(c *echo.Context) error {
-		return c.NoContent(http.StatusOK)
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/volumes", nil)
-	req.Header.Set("Authorization", "Bearer secret-token-value")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	err := handler(c)
-	require.NoError(t, err)
-
-	logOutput := buf.String()
-	assert.Contains(t, logOutput, "secret-token-value", "trace log should contain token for debugging")
-	assert.Contains(t, logOutput, "auth failed detail", "trace log should have detail message")
 }
 
 func TestAuthMiddleware_ValidToken(t *testing.T) {

--- a/agent/storage/meta/store.go
+++ b/agent/storage/meta/store.go
@@ -30,17 +30,25 @@ func ClearImmutable(path string) { toggleImmutable(path, false) }
 func toggleImmutable(path string, set bool) {
 	f, err := os.OpenFile(path, os.O_RDONLY, 0)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn().Err(err).Str("path", path).Bool("set", set).Msg("immutable: open failed")
+		}
 		return
 	}
 	defer func() { _ = f.Close() }()
 	var flags int
-	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), fsIocGetFlags, uintptr(unsafe.Pointer(&flags)))
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), fsIocGetFlags, uintptr(unsafe.Pointer(&flags))); errno != 0 {
+		log.Warn().Err(errno).Str("path", path).Msg("immutable: FS_IOC_GETFLAGS failed")
+		return
+	}
 	if set {
 		flags |= fsImmutableFL
 	} else {
 		flags &^= fsImmutableFL
 	}
-	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), fsIocSetFlags, uintptr(unsafe.Pointer(&flags)))
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), fsIocSetFlags, uintptr(unsafe.Pointer(&flags))); errno != 0 {
+		log.Warn().Err(errno).Str("path", path).Bool("set", set).Msg("immutable: FS_IOC_SETFLAGS failed")
+	}
 }
 
 // Store is a generic in-memory metadata cache backed by disk.


### PR DESCRIPTION
## Summary

- `authFailed` no longer emits the trace-level log line containing the raw `Authorization` header. Auth failures still log at warn with `client`, `path`, `reason`.
- `toggleImmutable` now logs ioctl errors. Failures to set the immutable bit (non-btrfs FS, missing `CAP_LINUX_IMMUTABLE`) previously vanished silently.
- Updated middleware test to assert the token never appears at any log level.
