### PR TITLE
Tighten logging and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,10 @@
 
 Per-request audit access log plus default-filter, CodeQL fixes, and logging hardening. Final lap before the project is replaced by ButterStore (see `RELEASE.md`).
 
-### Security
-- Drop Authorization header trace log on auth failure (#161)
-
 ### Improvements
 - Stamp caller identity onto agent request and event logs (#160)
 - Silence CodeQL go/path-injection false positives (#157)
-- Log ioctl errors in metadata immutable toggle (#161)
+- Tighten logging and error handling (#161)
 
 ### Bug Fixes
 - Honour AGENT_CSI_IDENTITY in default list filter (#158)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,17 +2,9 @@
 
 **Previous: v0.11.0** | **Date: 2026-04-30**
 
-Per-request audit access log: every API call now emits one log line with tenant, role, identity, token fingerprint, method, path, status, duration, and user agent. Storage event logs (volume created, snapshot deleted, ...) inherit the same caller fields via zerolog's contextual logger, no per-call plumbing. Plus the CLI default list filter follows `AGENT_CSI_IDENTITY`, a CodeQL hardening pass on path handling, the access log status fix (404s no longer report as 200), two logging hardenings (Authorization header no longer reachable from a trace log, immutable ioctl failures now surface as warnings), a zerolog patch bump, and documentation fixes.
+Per-request audit access log with caller identity, plus a logging hardening pass that closes a token-leak path and surfaces previously silent errors. CLI default list filter now follows `AGENT_CSI_IDENTITY`. No breaking changes.
 
-No breaking changes. `AGENT_TENANTS`, Helm values, StorageClasses, PVCs, VolumeSnapshots, and the in-tree CSI driver work without modification.
-
-> **`btrfs-nfs-csi` is being deprecated, ButterStore is the successor.** Active development is moving to a new project, **ButterStore**, which will be a hard fork of this repository. The fork is happening because the codebase has long outgrown the "Kubernetes CSI driver" framing, the agent is already a general-purpose btrfs storage backend with REST API, CLI, multi-tenancy, RBAC, tasks, and metrics, and the Kubernetes CSI driver is one of several integrations sitting on top of it. ButterStore reframes the project around that reality (NFS plus a planned FUSE backend plus btrfs send/receive replication) and opens room for Nomad, Proxmox, Docker, and other integrations alongside the existing CSI driver. The name leans into the long-running "butter-FS" colloquial pronunciation of btrfs.
->
-> **What this means for you.** A few more `btrfs-nfs-csi` releases will ship until ButterStore is public. After that, this repo is archived, no further releases or fixes. All forward work moves to ButterStore. Repo and images stay online for archival only.
->
-> **Migration.** ButterStore drops in over `btrfs-nfs-csi` v0.11.x. Agent state on disk, `AGENT_TENANTS`, the REST API, the CLI, Helm values, StorageClasses, PVCs, and VolumeSnapshots all keep working as-is. The migration is a container-image swap and a Helm chart rename, no data movement, no API rewrites. A migration guide ships with the first ButterStore release.
->
-> **Nothing breaks today.** v0.11.1 ships as `btrfs-nfs-csi` everywhere. You do not need to do anything for this release.
+> **`btrfs-nfs-csi` is being deprecated, ButterStore is the successor.** Active development moves to a hard fork named **ButterStore**, which reframes the project around what it has actually become: a general-purpose btrfs storage backend where the Kubernetes CSI driver is one of several integrations. Migration is a drop-in: tokens, REST API, CLI, Helm values, StorageClasses, PVCs, and VolumeSnapshots all keep working. A migration guide ships with the first ButterStore release. Until then, this repo gets a few more releases, then archive.
 
 ---
 
@@ -20,55 +12,43 @@ No breaking changes. `AGENT_TENANTS`, Helm values, StorageClasses, PVCs, VolumeS
 
 ### Per-request audit access log
 
-Every API call now produces one access log line with full caller identity:
+Every API call produces one access log line with full caller identity:
 
 ```
 INF request method=POST path=/v1/volumes code=201 took=9.4ms tenant=ops role=user identity=ci-bot token_fingerprint=ab12...e1f4 client=10.0.0.5 user_agent=btrfs-nfs-csi-cli/0.11.1
-INF volume created  name=my-vol path=/export/data/ops/my-vol  tenant=ops role=user identity=ci-bot token_fingerprint=ab12...e1f4
 ```
 
-Storage event logs (volume created, snapshot deleted, NFS export added, ...) carry the same audit fields via zerolog's contextual logger, no per-call plumbing. To find every action a token took: `grep token_fingerprint=ab12 access.log`.
-
-Behaviour summary:
-
-- **Level by status**: 5xx → error, 4xx → warn, 2xx/3xx → info. Operators can silence success-path traffic with `LOG_LEVEL=warn` while keeping denials and server errors visible.
-- **`/healthz` skipped**: the CSI node driver polls it every few seconds, no audit value.
-- **Denial reasons**: 401 carries `reason=invalid_token`, 403 carries `reason=role_denied / ownership / identity_mismatch`, matching the existing Prometheus `http_requests_total{reason=...}` label.
-- **Background workers**: the NFS reconciler and usage updater tag their tenant the same way, so log lines emitted from those loops still carry `tenant=...` (without `identity` or `fingerprint`, since there is no caller).
+Storage events inherit the same caller fields. Level by status: 5xx → error, 4xx → warn, 2xx/3xx → info. `/healthz` is skipped. To trace every action a token took: `grep token_fingerprint=ab12 access.log`.
 
 ### Default list filter follows the active identity
 
-Before v0.11.1 the CLI hardcoded `created-by=cli` as its default filter on every `list` command. Set `AGENT_CSI_IDENTITY=ansible` and the CLI still hid your own resources unless you passed `--all`. The CLI now resolves its identity at startup (via `/v1/whoami`) and filters by whatever the agent sees on the wire.
-
-```bash
-export AGENT_CSI_IDENTITY=ansible
-btrfs-nfs-csi volume list                # shows volumes created by ansible
-btrfs-nfs-csi volume list --all          # show every volume in the tenant
-```
-
-Identical for the agent. The only thing that changes is what shows up by default in the CLI table.
+The CLI used to hardcode `created-by=cli` regardless of `AGENT_CSI_IDENTITY`. It now follows the configured identity. `--all` / `-A` still bypasses.
 
 ---
 
 ## Security
 
-- **Drop Authorization header trace log on auth failure** (#161). `authFailed` previously emitted a second log line at trace level containing the raw `Authorization` header, which made debugging easier but meant a misconfigured `LOG_LEVEL=trace` would persist tokens in logs. Removed entirely. Auth failures still log at warn with `client`, `path`, and `reason`, none of which carry the token. Operators who relied on the trace line for debugging should diff the request payload against `AGENT_TENANTS` directly instead.
+- Auth tokens can no longer leak into logs at any level (#161).
+- Truncated root secret file is rejected at startup instead of producing predictable subkeys (#161).
 
 ## Bug Fixes
 
-- **`AGENT_CSI_IDENTITY` honoured in default list filter** (#158). The CLI default filter was always `created-by=cli`, regardless of the configured identity. Lists now filter by the resolved identity from `/v1/whoami`, falling back to `cli` if no identity is set on the token. The `--all` / `-A` flag still bypasses the filter entirely.
-- **Access log and Prometheus counter report the real status** (#160). Echo's `DefaultHTTPErrorHandler` writes the 4xx/5xx status after middleware unwinds, so reading `c.Response().Status` directly defaulted to 200 for handler-returned errors. The agent now uses `echo.ResolveResponseStatus`, so 404s, 401s, and 403s log at the right level (`warn`) and the Prometheus `http_requests_total{code=...}` counter classifies them correctly.
+- `AGENT_CSI_IDENTITY` honoured in default list filter (#158).
+- 4xx/5xx HTTP responses now log at the right level and are counted under the right Prometheus code label (#160).
 
 ## Improvements
 
-- **CodeQL path-injection false positives silenced** (#157). Storage-layer file operations now route through a small `meta/store` boundary that re-validates paths under the configured base. No behaviour change at runtime, the agent already rejected traversal at the API layer, but CodeQL can no longer point at a long list of `os.ReadFile`/`os.WriteFile` call sites as suspect.
-- **Per-request access log with caller identity** (#160). New `LoggerMiddleware` clones the global zerolog logger into the request context, `AuthMiddleware` stamps `tenant`/`role`/`identity`/`token_fingerprint` onto it via `UpdateContext`, `MetricsMiddleware` emits the access log line at info/warn/error by status (`/healthz` skipped, optional `user_agent` and denial `reason` included). Storage event logs use `log.Ctx(ctx)` so they inherit the same fields without per-call plumbing.
-- **Log ioctl errors in metadata immutable toggle** (#161). The `toggleImmutable` helper in `agent/storage/meta/store.go` previously discarded the `errno` return from both `FS_IOC_GETFLAGS` and `FS_IOC_SETFLAGS`, and silently swallowed `OpenFile` failures. A failure to set the immutable bit on a metadata file (for example on a non-btrfs filesystem, or without `CAP_LINUX_IMMUTABLE`) left the file unprotected with no log signal. The helper now logs at warn level on every non-`ENOENT` open failure and on every non-zero ioctl errno, with `path` and `set` fields attached.
+- CodeQL path-injection false positives silenced (#157).
+- Per-request access log with caller identity (#160). See Highlights.
+- Failed immutable-bit operations on metadata files now log a warning (#161).
+- Task cleanup retries failed file deletions instead of leaving ghost tasks behind (#161).
+- Initialisation, listen-bind, and server-runtime failures shut down through the normal error path instead of `os.Exit` from inside library code (#161).
+- Failed rollback of half-created volumes, snapshots, or clones is logged (#161).
 
 ## Documentation
 
-- **Quickstart curl typo fixed** (`docs/installation.md`).
-- **Task system architecture page brought up to date** (`docs/architecture.md`). Lists all five task types (`scrub`, `balance`, `quota-rescan`, `defragment`, `test`) and the filesystem-wide mutex.
+- Quickstart curl typo fixed.
+- Task system architecture page brought up to date.
 
 ## Dependencies
 
@@ -78,19 +58,11 @@ Identical for the agent. The only thing that changes is what shows up by default
 
 ## Upgrade Guide
 
-Drop-in upgrade from v0.11.0. Bump the image tag to `0.11.1`.
+Drop-in from v0.11.0. Bump the image tag to `0.11.1`.
 
-### Kubernetes CSI users
-
-No action required. The CSI controller and node driver run with `AGENT_CSI_IDENTITY=k8s` and were never affected by the `created-by=cli` default filter (it only ran in the CLI binary).
-
-### CLI users with a custom identity
-
-If you set `AGENT_CSI_IDENTITY` to anything other than `cli` and worked around the old filter with `--all`, you can drop the flag, the default now matches your identity. The agent makes one extra `GET /v1/whoami` call when the CLI starts to resolve the identity.
-
-### Operators / log shippers
-
-Expect one extra info-level access log line per authenticated API call. CSI node-driver `/healthz` polling does **not** log, so the noise floor stays manageable. To silence the success path on busy clusters, set `LOG_LEVEL=warn`, denials and errors stay visible. The `http_requests_total` Prometheus counter now classifies 4xx/5xx correctly (previously many of them were undercounted as `code="200"`).
+- **Kubernetes CSI users:** no action required.
+- **CLI users with a custom identity:** drop any `--all` workaround, the default now matches your identity.
+- **Operators / log shippers:** expect one info-level access log line per authenticated API call. `/healthz` polling does not log. Set `LOG_LEVEL=warn` to silence the success path.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,13 +12,14 @@ Per-request audit access log with caller identity, plus a logging hardening pass
 
 ### Per-request audit access log
 
-Every API call produces one access log line with full caller identity:
+Every API call produces an access log line with full caller identity, and any storage events emitted during the call inherit the same fields. A volume create from the CLI looks like this:
 
 ```
-INF request method=POST path=/v1/volumes code=201 took=9.4ms tenant=ops role=user identity=ci-bot token_fingerprint=ab12...e1f4 client=10.0.0.5 user_agent=btrfs-nfs-csi-cli/0.11.1
+INF volume created name=my-vol path=/export/data/ops/my-vol tenant=ops role=user identity=cli token_fingerprint=ab12...e1f4
+INF request method=POST path=/v1/volumes/my-vol code=201 took=15.2ms tenant=ops role=user identity=cli token_fingerprint=ab12...e1f4 client=10.0.0.5 user_agent=btrfs-nfs-csi-cli/0.11.1
 ```
 
-Storage events inherit the same caller fields. Level by status: 5xx → error, 4xx → warn, 2xx/3xx → info. `/healthz` is skipped. To trace every action a token took: `grep token_fingerprint=ab12 access.log`.
+Level by status: 5xx → error, 4xx → warn, 2xx/3xx → info. `/healthz` is skipped. To trace every action a token took: `grep token_fingerprint=ab12 access.log`.
 
 ### Default list filter follows the active identity
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release v0.11.1
 
-**Previous: v0.11.0** | **Date: 2026-04-30**
+**Previous: v0.11.0** | **Date: 2026-05-01**
 
 Per-request audit access log with caller identity, plus a logging hardening pass that closes a token-leak path and surfaces previously silent errors. CLI default list filter now follows `AGENT_CSI_IDENTITY`. No breaking changes.
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,7 +7,9 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -105,7 +107,14 @@ func NewAgent(cfg *config.AgentConfig, version, commit string) (*Agent, error) {
 	e.Use(middleware.BodyLimit(1024 * 1024)) // 1MB
 	e.Use(v1.MetricsMiddleware())
 
-	secrets, err := secret.NewManager(cfg.BasePath)
+	metadataDir := filepath.Join(cfg.BasePath, config.MetadataDir)
+	if err := os.MkdirAll(metadataDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create metadata dir: %w", err)
+	}
+	if err := os.Chmod(metadataDir, 0o700); err != nil {
+		return nil, fmt.Errorf("chmod metadata dir: %w", err)
+	}
+	secrets, err := secret.NewManager(metadataDir, "root_secret")
 	if err != nil {
 		return nil, fmt.Errorf("init agent secrets: %w", err)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -71,11 +71,24 @@ func NewAgent(cfg *config.AgentConfig, version, commit string) (*Agent, error) {
 	}
 
 	// storage layer
-	store := storage.New(
-		cfg.BasePath, cfg.QuotaEnabled, exp, tenantNames,
-		cfg.DefaultDirMode, cfg.DefaultDataMode, cfg.BtrfsBin, cfg.ImmutableLabels,
-		cfg.TaskMaxConcurrent, cfg.TaskDefaultTimeout, cfg.TaskScrubTimeout, cfg.TaskBalanceTimeout, cfg.TaskPollInterval,
-	)
+	store, err := storage.New(storage.Config{
+		BasePath:           cfg.BasePath,
+		QuotaEnabled:       cfg.QuotaEnabled,
+		Exporter:           exp,
+		Tenants:            tenantNames,
+		DefaultDirMode:     cfg.DefaultDirMode,
+		DefaultDataMode:    cfg.DefaultDataMode,
+		BtrfsBin:           cfg.BtrfsBin,
+		ImmutableLabels:    cfg.ImmutableLabels,
+		TaskMaxConcurrent:  cfg.TaskMaxConcurrent,
+		TaskDefaultTimeout: cfg.TaskDefaultTimeout,
+		TaskScrubTimeout:   cfg.TaskScrubTimeout,
+		TaskBalanceTimeout: cfg.TaskBalanceTimeout,
+		TaskPollInterval:   cfg.TaskPollInterval,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("init storage: %w", err)
+	}
 
 	// echo + routes. Use a router that rejects auto-OPTIONS: Echo's default
 	// OptionsMethodHandler returns 204 + Allow without running middleware,
@@ -163,24 +176,38 @@ func Run(version, commit string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	a.Start(ctx)
+	srvErr, err := a.Start(ctx)
+	if err != nil {
+		return err
+	}
 
-	<-ctx.Done()
-	log.Info().Msg("shutting down")
-	return nil
+	select {
+	case <-ctx.Done():
+		log.Info().Msg("shutting down")
+		return nil
+	case err := <-srvErr:
+		return fmt.Errorf("agent server failed: %w", err)
+	}
 }
 
-func (a *Agent) Start(ctx context.Context) {
+// Start launches the metrics server, background workers, and the HTTP/HTTPS
+// agent server. The listener is bound synchronously, so a bind failure is
+// returned as an error. The returned channel emits a single error if the
+// server exits unexpectedly (anything other than http.ErrServerClosed) and
+// is closed once the server goroutine returns.
+func (a *Agent) Start(ctx context.Context) (<-chan error, error) {
 	startMetricsServer(a.cfg.MetricsAddr)
 
 	a.store.StartWorkers(ctx, a.cfg.UsageInterval, a.cfg.NFSReconcileInterval, a.cfg.DeviceIOInterval, a.cfg.DeviceStatsInterval, a.cfg.TaskCleanupInterval)
 
 	ln, err := net.Listen("tcp", a.cfg.ListenAddr)
 	if err != nil {
-		log.Fatal().Err(err).Str("addr", a.cfg.ListenAddr).Msg("failed to bind listen address")
+		return nil, fmt.Errorf("bind listen address %q: %w", a.cfg.ListenAddr, err)
 	}
 
+	errCh := make(chan error, 1)
 	go func() {
+		defer close(errCh)
 		var srvErr error
 		// MaxHeaderBytes shrinks per-connection header buffer from Go's 1 MiB
 		// default. ReadHeaderTimeout caps slowloris-style open connections
@@ -209,9 +236,10 @@ func (a *Agent) Start(ctx context.Context) {
 			srvErr = s.Serve(ln)
 		}
 		if srvErr != nil && srvErr != http.ErrServerClosed {
-			log.Fatal().Err(srvErr).Msg("agent server failed")
+			errCh <- srvErr
 		}
 	}()
+	return errCh, nil
 }
 
 // parseTenants parses comma-separated `name:token[:role[:identity]]`

--- a/agent/secret/secret.go
+++ b/agent/secret/secret.go
@@ -13,15 +13,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 )
 
 const (
-	fileName       = "root_secret"
 	backupSuffix   = ".bak"
 	secretFileMode = 0o600
-	secretDirMode  = 0o700
 	entropyLen     = 512
 
 	// purposeFingerprintV1 is the HKDF info string for the fingerprint
@@ -36,10 +32,11 @@ type Manager struct {
 	fpKey []byte
 }
 
-// NewManager loads or creates basePath/metadata/root_secret and derives the
-// subkeys the agent needs. A primary/backup mismatch aborts startup.
-func NewManager(basePath string) (*Manager, error) {
-	root, err := loadOrCreate(basePath)
+// NewManager loads or creates the root secret at dir/name and derives the
+// subkeys the agent needs. A backup at dir/name.bak is kept in lockstep; a
+// primary/backup mismatch aborts startup.
+func NewManager(dir, name string) (*Manager, error) {
+	root, err := loadOrCreate(dir, name)
 	if err != nil {
 		return nil, err
 	}
@@ -63,17 +60,8 @@ func (m *Manager) Fingerprint(token string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func loadOrCreate(basePath string) ([]byte, error) {
-	dir := filepath.Join(basePath, config.MetadataDir)
-	if err := os.MkdirAll(dir, secretDirMode); err != nil {
-		return nil, fmt.Errorf("create metadata dir: %w", err)
-	}
-	// Tighten dir mode unconditionally: MkdirAll only sets it on creation, so
-	// a pre-existing dir from another tool may be world-readable.
-	if err := os.Chmod(dir, secretDirMode); err != nil {
-		return nil, fmt.Errorf("chmod metadata dir: %w", err)
-	}
-	primary := filepath.Join(dir, fileName)
+func loadOrCreate(dir, name string) ([]byte, error) {
+	primary := filepath.Join(dir, name)
 	backup := primary + backupSuffix
 
 	pData, pErr := readExisting(primary)

--- a/agent/secret/secret.go
+++ b/agent/secret/secret.go
@@ -13,10 +13,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 )
 
 const (
-	metadataDir    = "metadata" // shares the name reserved in config.ReservedTenantNames so it can never collide with a tenant
 	fileName       = "root_secret"
 	backupSuffix   = ".bak"
 	secretFileMode = 0o600
@@ -63,7 +64,7 @@ func (m *Manager) Fingerprint(token string) string {
 }
 
 func loadOrCreate(basePath string) ([]byte, error) {
-	dir := filepath.Join(basePath, metadataDir)
+	dir := filepath.Join(basePath, config.MetadataDir)
 	if err := os.MkdirAll(dir, secretDirMode); err != nil {
 		return nil, fmt.Errorf("create metadata dir: %w", err)
 	}
@@ -119,6 +120,10 @@ func loadOrCreate(basePath string) ([]byte, error) {
 // absent is recoverable by restoring from the other replica. Permissions
 // are checked: any group/world bits abort startup so a chmod-by-mistake
 // (or a malicious actor) can't turn the secret into a leaked credential.
+// A truncated file (size below entropyLen, e.g. from a writeAtomic crash
+// before rename) is treated as broken so low-entropy input is never fed
+// to HKDF as IKM. Larger files are accepted to keep the format
+// forward-compatible if entropyLen ever shrinks.
 func readExisting(path string) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -129,6 +134,9 @@ func readExisting(path string) ([]byte, error) {
 	}
 	if mode := info.Mode().Perm(); mode&0o077 != 0 {
 		return nil, fmt.Errorf("%s has insecure permissions %#o, expected %#o (chmod %#o and restart)", path, mode, secretFileMode, secretFileMode)
+	}
+	if size := info.Size(); size < entropyLen {
+		return nil, fmt.Errorf("%s is %d bytes, expected at least %d (truncated write?), inspect both replicas and remove the broken one before restarting", path, size, entropyLen)
 	}
 	return os.ReadFile(path)
 }

--- a/agent/storage/clone.go
+++ b/agent/storage/clone.go
@@ -86,7 +86,9 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 			log.Warn().Err(err).Str("path", dstData).Msg("clone target already exists on disk")
 			return nil, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("clone %q already exists on disk", req.Name)}
 		}
-		_ = os.RemoveAll(cloneDir)
+		if rmErr := os.RemoveAll(cloneDir); rmErr != nil {
+			log.Warn().Err(rmErr).Str("path", cloneDir).Msg("cleanup: failed to remove directory")
+		}
 		log.Error().Err(err).Msg("failed to create clone")
 		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("btrfs snapshot failed: %v", err)}
 	}
@@ -97,7 +99,9 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 			if delErr := s.btrfs.SubvolumeDelete(ctx, dstData); delErr != nil {
 				log.Warn().Err(delErr).Str("path", dstData).Msg("cleanup: failed to delete subvolume")
 			}
-			_ = os.RemoveAll(cloneDir)
+			if rmErr := os.RemoveAll(cloneDir); rmErr != nil {
+				log.Warn().Err(rmErr).Str("path", cloneDir).Msg("cleanup: failed to remove directory")
+			}
 			return nil, fmt.Errorf("qgroup limit failed: %w", err)
 		}
 	}
@@ -123,7 +127,9 @@ func (s *Storage) CreateClone(ctx context.Context, tenant string, req CloneCreat
 		if delErr := s.btrfs.SubvolumeDelete(ctx, dstData); delErr != nil {
 			log.Warn().Err(delErr).Str("path", dstData).Msg("cleanup: failed to delete subvolume")
 		}
-		_ = os.RemoveAll(cloneDir)
+		if rmErr := os.RemoveAll(cloneDir); rmErr != nil {
+			log.Warn().Err(rmErr).Str("path", cloneDir).Msg("cleanup: failed to remove directory")
+		}
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 

--- a/agent/storage/snapshot.go
+++ b/agent/storage/snapshot.go
@@ -65,7 +65,9 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 			log.Warn().Err(err).Str("path", dstData).Msg("snapshot target already exists on disk")
 			return nil, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("snapshot %q already exists on disk", req.Name)}
 		}
-		_ = os.RemoveAll(snapDir)
+		if rmErr := os.RemoveAll(snapDir); rmErr != nil {
+			log.Warn().Err(rmErr).Str("path", snapDir).Msg("cleanup: failed to remove directory")
+		}
 		log.Error().Err(err).Msg("failed to create snapshot")
 		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("btrfs snapshot failed: %v", err)}
 	}
@@ -92,7 +94,9 @@ func (s *Storage) CreateSnapshot(ctx context.Context, tenant string, req Snapsho
 		if delErr := s.btrfs.SubvolumeDelete(ctx, dstData); delErr != nil {
 			log.Warn().Err(delErr).Str("path", dstData).Msg("cleanup: failed to delete subvolume")
 		}
-		_ = os.RemoveAll(snapDir)
+		if rmErr := os.RemoveAll(snapDir); rmErr != nil {
+			log.Warn().Err(rmErr).Str("path", snapDir).Msg("cleanup: failed to remove directory")
+		}
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 

--- a/agent/storage/storage.go
+++ b/agent/storage/storage.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -58,63 +57,82 @@ type Storage struct {
 	cachedFilesystem atomic.Pointer[btrfs.FilesystemUsage]
 }
 
-func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []string, dirMode, dataMode, btrfsBin, immutableLabels string, taskMaxConcurrent int, taskDefaultTimeout, taskScrubTimeout, taskBalanceTimeout, taskPollInterval time.Duration) *Storage {
+// Config bundles the parameters required to construct a Storage.
+type Config struct {
+	BasePath        string
+	QuotaEnabled    bool
+	Exporter        nfs.Exporter
+	Tenants         []string
+	DefaultDirMode  string
+	DefaultDataMode string
+	BtrfsBin        string
+	ImmutableLabels string
+
+	TaskMaxConcurrent  int
+	TaskDefaultTimeout time.Duration
+	TaskScrubTimeout   time.Duration
+	TaskBalanceTimeout time.Duration
+	TaskPollInterval   time.Duration
+}
+
+func New(cfg Config) (*Storage, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	parsedDirMode, err := strconv.ParseUint(dirMode, 8, 32)
-	if err != nil {
-		log.Fatal().Str("mode", dirMode).Msg("invalid dir mode")
-	}
-	if _, err := strconv.ParseUint(dataMode, 8, 32); err != nil {
-		log.Fatal().Str("mode", dataMode).Msg("invalid data mode")
+	if cfg.Exporter == nil {
+		return nil, fmt.Errorf("exporter must not be nil")
 	}
 
-	info, err := os.Stat(basePath)
+	parsedDirMode, err := utils.ValidateMode(cfg.DefaultDirMode)
+	if err != nil {
+		return nil, fmt.Errorf("dir mode: %w", err)
+	}
+	if _, err := utils.ValidateMode(cfg.DefaultDataMode); err != nil {
+		return nil, fmt.Errorf("data mode: %w", err)
+	}
+
+	info, err := os.Stat(cfg.BasePath)
 	if err != nil || !info.IsDir() {
-		log.Fatal().Str("path", basePath).Msg("base path does not exist or is not a directory")
+		return nil, fmt.Errorf("base path %q does not exist or is not a directory", cfg.BasePath)
 	}
-	if !btrfs.IsBtrfs(basePath) {
-		log.Fatal().Str("path", basePath).Msg("base path is not on a btrfs filesystem")
+	if !btrfs.IsBtrfs(cfg.BasePath) {
+		return nil, fmt.Errorf("base path %q is not on a btrfs filesystem", cfg.BasePath)
 	}
-	mountPoint, err := utils.FindMountPoint(basePath)
+	mountPoint, err := utils.FindMountPoint(cfg.BasePath)
 	if err != nil {
-		log.Fatal().Err(err).Str("path", basePath).Msg("failed to resolve btrfs mount point")
+		return nil, fmt.Errorf("resolve btrfs mount point for %q: %w", cfg.BasePath, err)
 	}
-	if mountPoint != basePath {
-		log.Info().Str("basePath", basePath).Str("mountPoint", mountPoint).Msg("base path is a subdirectory of btrfs mount")
+	if mountPoint != cfg.BasePath {
+		log.Info().Str("basePath", cfg.BasePath).Str("mountPoint", mountPoint).Msg("base path is a subdirectory of btrfs mount")
 	}
-	mgr := btrfs.NewManager(btrfsBin)
+	mgr := btrfs.NewManager(cfg.BtrfsBin)
 	if !mgr.IsAvailable(ctx) {
-		log.Fatal().Msg("btrfs tools not found - is btrfs-progs installed?")
-	}
-	if exporter == nil {
-		log.Fatal().Msg("exporter must not be nil")
+		return nil, fmt.Errorf("btrfs tools not found, is btrfs-progs installed?")
 	}
 
-	if quotaEnabled {
-		if err := mgr.QuotaCheck(ctx, basePath); err != nil {
-			log.Fatal().Str("path", basePath).Msg("AGENT_FEATURE_QUOTA_ENABLED=true but btrfs quota is not enabled (run: btrfs quota enable " + basePath + ")")
+	if cfg.QuotaEnabled {
+		if err := mgr.QuotaCheck(ctx, cfg.BasePath); err != nil {
+			return nil, fmt.Errorf("AGENT_FEATURE_QUOTA_ENABLED=true but btrfs quota is not enabled on %q (run: btrfs quota enable %s): %w", cfg.BasePath, cfg.BasePath, err)
 		}
 	}
 
-	for _, name := range tenants {
+	for _, name := range cfg.Tenants {
 		if err := config.ValidateTenantName(name); err != nil {
-			log.Fatal().Err(err).Str("tenant", name).Msg("invalid tenant name")
+			return nil, fmt.Errorf("invalid tenant name %q: %w", name, err)
 		}
-		td := filepath.Join(basePath, name)
-		if err := os.MkdirAll(td, os.FileMode(parsedDirMode)); err != nil {
-			log.Fatal().Err(err).Str("path", td).Msg("failed to create tenant directory")
+		td := filepath.Join(cfg.BasePath, name)
+		if err := os.MkdirAll(td, fileMode(parsedDirMode)); err != nil {
+			return nil, fmt.Errorf("create tenant directory %q: %w", td, err)
 		}
-		if err := os.MkdirAll(filepath.Join(td, config.SnapshotsDir), os.FileMode(parsedDirMode)); err != nil {
-			log.Fatal().Err(err).Str("path", td).Msg("failed to create tenant snapshots directory")
+		if err := os.MkdirAll(filepath.Join(td, config.SnapshotsDir), fileMode(parsedDirMode)); err != nil {
+			return nil, fmt.Errorf("create tenant snapshots directory under %q: %w", td, err)
 		}
 	}
-	log.Info().Int("count", len(tenants)).Msg("tenants configured")
+	log.Info().Int("count", len(cfg.Tenants)).Msg("tenants configured")
 
 	devices, err := mgr.Devices(ctx, mountPoint)
 	if err != nil {
-		log.Fatal().Err(err).Msg("failed to resolve block devices")
+		return nil, fmt.Errorf("resolve block devices: %w", err)
 	}
 	for _, d := range devices {
 		if d.Missing {
@@ -128,11 +146,31 @@ func New(basePath string, quotaEnabled bool, exporter nfs.Exporter, tenants []st
 	for i, d := range devices {
 		initialStates[i] = DeviceState{BTRFSDevice: d}
 	}
-	taskDir := filepath.Join(basePath, config.TasksDir)
-	s := &Storage{basePath: basePath, mountPoint: mountPoint, quotaEnabled: quotaEnabled, btrfs: mgr, exporter: exporter, tenants: tenants, defaultDirMode: os.FileMode(parsedDirMode), defaultDataMode: dataMode, immutableLabelKeys: ImmutableLabelKeys(immutableLabels), tasks: task.NewManager(taskDir, taskMaxConcurrent, taskPollInterval), taskDefaultTimeout: taskDefaultTimeout, taskScrubTimeout: taskScrubTimeout, taskBalanceTimeout: taskBalanceTimeout, volumes: meta.NewStore[VolumeMetadata](basePath), snapshots: meta.NewStore[SnapshotMetadata](basePath, config.SnapshotsDir)}
+	taskDir := filepath.Join(cfg.BasePath, config.TasksDir)
+	tm, err := task.NewManager(taskDir, cfg.TaskMaxConcurrent, cfg.TaskPollInterval)
+	if err != nil {
+		return nil, fmt.Errorf("init task manager: %w", err)
+	}
+	s := &Storage{
+		basePath:           cfg.BasePath,
+		mountPoint:         mountPoint,
+		quotaEnabled:       cfg.QuotaEnabled,
+		btrfs:              mgr,
+		exporter:           cfg.Exporter,
+		tenants:            cfg.Tenants,
+		defaultDirMode:     fileMode(parsedDirMode),
+		defaultDataMode:    cfg.DefaultDataMode,
+		immutableLabelKeys: ImmutableLabelKeys(cfg.ImmutableLabels),
+		tasks:              tm,
+		taskDefaultTimeout: cfg.TaskDefaultTimeout,
+		taskScrubTimeout:   cfg.TaskScrubTimeout,
+		taskBalanceTimeout: cfg.TaskBalanceTimeout,
+		volumes:            meta.NewStore[VolumeMetadata](cfg.BasePath),
+		snapshots:          meta.NewStore[SnapshotMetadata](cfg.BasePath, config.SnapshotsDir),
+	}
 	s.cachedDevices.Store(&initialStates)
 	s.loadCache()
-	return s
+	return s, nil
 }
 
 func (s *Storage) loadCache() {

--- a/agent/storage/storage_integration_test.go
+++ b/agent/storage/storage_integration_test.go
@@ -99,6 +99,9 @@ func (s *StorageIntegrationSuite) SetupSuite() {
 	taskDir := filepath.Join(s.mnt, config.TasksDir)
 	s.Require().NoError(os.MkdirAll(taskDir, 0o755))
 
+	tm, err := task.NewManager(taskDir, 0, 0)
+	s.Require().NoError(err)
+
 	s.storage = &Storage{
 		basePath:        s.mnt,
 		mountPoint:      s.mnt,
@@ -108,7 +111,7 @@ func (s *StorageIntegrationSuite) SetupSuite() {
 		tenants:         []string{"test"},
 		defaultDirMode:  0o755,
 		defaultDataMode: "2770",
-		tasks:           task.NewManager(taskDir, 0, 0),
+		tasks:           tm,
 		volumes:         meta.NewStore[VolumeMetadata](s.mnt),
 		snapshots:       meta.NewStore[SnapshotMetadata](s.mnt, config.SnapshotsDir),
 	}
@@ -556,7 +559,8 @@ func (s *StorageIntegrationSuite) TestTaskLoadFromDisk() {
 	writeTestJSONFile(s.T(), filepath.Join(taskDir, "stale-task-123.json"), &staleTask)
 
 	// create new TaskManager (triggers loadFromDisk)
-	tm := task.NewManager(taskDir, 0, 0)
+	tm, err := task.NewManager(taskDir, 0, 0)
+	s.Require().NoError(err)
 
 	// stale task should be marked failed
 	tsk, err := tm.Get("stale-task-123")
@@ -619,7 +623,8 @@ func (s *StorageIntegrationSuite) TestScrubRestartRecovery() {
 	writeTestJSONFile(s.T(), filepath.Join(taskDir, "stale-scrub.json"), &staleTask)
 
 	// create new TaskManager (simulates agent restart)
-	tm := task.NewManager(taskDir, 0, 0)
+	tm, err := task.NewManager(taskDir, 0, 0)
+	s.Require().NoError(err)
 
 	// stale scrub should be failed
 	tsk, err := tm.Get("stale-scrub")

--- a/agent/storage/task/manager.go
+++ b/agent/storage/task/manager.go
@@ -24,9 +24,9 @@ type Manager struct {
 
 // NewManager creates a new Manager with persistence under taskDir.
 // maxConcurrent limits the number of tasks running simultaneously.
-func NewManager(taskDir string, maxConcurrent int, pollInterval time.Duration) *Manager {
+func NewManager(taskDir string, maxConcurrent int, pollInterval time.Duration) (*Manager, error) {
 	if err := os.MkdirAll(taskDir, 0o755); err != nil {
-		log.Fatal().Err(err).Str("path", taskDir).Msg("failed to create tasks directory")
+		return nil, fmt.Errorf("create tasks directory %q: %w", taskDir, err)
 	}
 	if pollInterval <= 0 {
 		pollInterval = 5 * time.Second
@@ -45,7 +45,7 @@ func NewManager(taskDir string, maxConcurrent int, pollInterval time.Duration) *
 		log.Warn().Msg("task manager initialized with unlimited concurrency")
 	}
 	tm.loadFromDisk()
-	return tm
+	return tm, nil
 }
 
 // Create starts a task as a background goroutine and returns its ID.
@@ -244,8 +244,11 @@ func (tm *Manager) Cleanup(maxAge time.Duration) {
 		switch t.Status {
 		case TaskCompleted, TaskFailed, TaskCancelled:
 			if t.CompletedAt != nil && t.CompletedAt.Before(cutoff) {
+				if err := os.Remove(tm.taskFile(id)); err != nil && !os.IsNotExist(err) {
+					log.Warn().Err(err).Str("task", id).Msg("task cleanup: failed to remove file, retrying on next tick")
+					continue
+				}
 				delete(tm.tasks, id)
-				_ = os.Remove(tm.taskFile(id))
 				removed++
 			}
 		}

--- a/agent/storage/task/manager_test.go
+++ b/agent/storage/task/manager_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustNewManager(t *testing.T, dir string, maxConcurrent int, pollInterval time.Duration) *Manager {
+	t.Helper()
+	tm, err := NewManager(dir, maxConcurrent, pollInterval)
+	require.NoError(t, err)
+	return tm
+}
+
 // awaitStatus polls until a task reaches the expected status or times out.
 func awaitStatus(t *testing.T, tm *Manager, id string, status TaskStatus) *Task {
 	t.Helper()
@@ -46,7 +53,7 @@ func awaitDone(t *testing.T, tm *Manager, id string) *Task {
 }
 
 func TestManager_SubmitAndGet(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	started := make(chan struct{})
 	done := make(chan struct{})
@@ -74,7 +81,7 @@ func TestManager_SubmitAndGet(t *testing.T) {
 }
 
 func TestManager_SubmitWithError(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return fmt.Errorf("something broke")
@@ -86,7 +93,7 @@ func TestManager_SubmitWithError(t *testing.T) {
 }
 
 func TestManager_Cancel(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	started := make(chan struct{})
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
@@ -103,7 +110,7 @@ func TestManager_Cancel(t *testing.T) {
 }
 
 func TestManager_CancelFinished(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
@@ -114,21 +121,21 @@ func TestManager_CancelFinished(t *testing.T) {
 }
 
 func TestManager_CancelUnknown(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	err := tm.Cancel("nonexistent")
 	assert.Error(t, err)
 }
 
 func TestManager_GetUnknown(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	_, err := tm.Get("nonexistent")
 	assert.Error(t, err)
 }
 
 func TestManager_List(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id1 := tm.Create("scrub", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
@@ -156,7 +163,7 @@ func TestManager_List(t *testing.T) {
 }
 
 func TestManager_ListReturnsCopies(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
@@ -175,7 +182,7 @@ func TestManager_ListReturnsCopies(t *testing.T) {
 }
 
 func TestManager_ProgressUpdate(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	checkpoint := make(chan struct{})
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
@@ -201,7 +208,7 @@ func TestManager_ResultStruct(t *testing.T) {
 		Name  string `json:"name"`
 	}
 
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return update.SetResult(TestResult{Count: 42, Name: "hello"})
@@ -217,7 +224,7 @@ func TestManager_ResultStruct(t *testing.T) {
 }
 
 func TestManager_Cleanup(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
@@ -231,7 +238,7 @@ func TestManager_Cleanup(t *testing.T) {
 }
 
 func TestManager_CleanupKeepsRunning(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	done := make(chan struct{})
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
@@ -259,7 +266,7 @@ func TestManager_CorruptTaskFile(t *testing.T) {
 	valid, _ := json.MarshalIndent(Task{ID: "good", Type: "test", Status: TaskCompleted}, "", "  ")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "good.json"), valid, 0o644))
 
-	tm := NewManager(dir, 0, 0)
+	tm := mustNewManager(t, dir, 0, 0)
 
 	tasks := tm.List("")
 	assert.Len(t, tasks, 1)
@@ -271,13 +278,13 @@ func TestManager_EmptyTaskFile(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.json"), []byte(""), 0o644))
 
-	tm := NewManager(dir, 0, 0)
+	tm := mustNewManager(t, dir, 0, 0)
 	tasks := tm.List("")
 	assert.Empty(t, tasks)
 }
 
 func TestManager_ConcurrentSubmit(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	ids := make([]string, 50)
 	var wg sync.WaitGroup
@@ -304,7 +311,7 @@ func TestManager_ConcurrentSubmit(t *testing.T) {
 }
 
 func TestManager_WorkerPoolBlocksSecondTask(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1, 0)
+	tm := mustNewManager(t, t.TempDir(), 1, 0)
 
 	started := make(chan struct{})
 	blocker := make(chan struct{})
@@ -331,7 +338,7 @@ func TestManager_WorkerPoolBlocksSecondTask(t *testing.T) {
 }
 
 func TestManager_WorkerPoolMaxTwo(t *testing.T) {
-	tm := NewManager(t.TempDir(), 2, 0)
+	tm := mustNewManager(t, t.TempDir(), 2, 0)
 
 	started1 := make(chan struct{})
 	started2 := make(chan struct{})
@@ -367,7 +374,7 @@ func TestManager_WorkerPoolMaxTwo(t *testing.T) {
 }
 
 func TestManager_WorkerPoolUnlimited(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	started := make(chan struct{}, 10)
 	blocker := make(chan struct{})
@@ -398,7 +405,7 @@ func TestManager_WorkerPoolUnlimited(t *testing.T) {
 }
 
 func TestManager_CancelPending(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1, 0)
+	tm := mustNewManager(t, t.TempDir(), 1, 0)
 
 	started := make(chan struct{})
 	blocker := make(chan struct{})
@@ -427,7 +434,7 @@ func TestManager_CancelPending(t *testing.T) {
 }
 
 func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1, 0)
+	tm := mustNewManager(t, t.TempDir(), 1, 0)
 
 	order := make([]string, 0, 3)
 	var mu sync.Mutex
@@ -466,7 +473,7 @@ func TestManager_PendingTaskRunsAfterSlotFreed(t *testing.T) {
 }
 
 func TestManager_WorkerPoolTaskError(t *testing.T) {
-	tm := NewManager(t.TempDir(), 1, 0)
+	tm := mustNewManager(t, t.TempDir(), 1, 0)
 
 	id1 := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return fmt.Errorf("boom")
@@ -482,7 +489,7 @@ func TestManager_WorkerPoolTaskError(t *testing.T) {
 }
 
 func TestManager_Stress(t *testing.T) {
-	tm := NewManager(t.TempDir(), 4, 0)
+	tm := mustNewManager(t, t.TempDir(), 4, 0)
 
 	const total = 1000
 	var running atomic.Int32
@@ -536,7 +543,7 @@ func TestManager_Stress(t *testing.T) {
 }
 
 func TestManager_CreateWithOpts(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{
 		Opts:    map[string]string{"sleep": "5s"},
@@ -553,7 +560,7 @@ func TestManager_CreateWithOpts(t *testing.T) {
 
 func TestManager_CreateWithLabels(t *testing.T) {
 	dir := t.TempDir()
-	tm := NewManager(dir, 0, 0)
+	tm := mustNewManager(t, dir, 0, 0)
 
 	labels := map[string]string{"env": "prod", "team": "storage"}
 	id := tm.Create("test", TaskOpts{
@@ -574,7 +581,7 @@ func TestManager_CreateWithLabels(t *testing.T) {
 }
 
 func TestManager_CreateWithoutLabels(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil
@@ -585,7 +592,7 @@ func TestManager_CreateWithoutLabels(t *testing.T) {
 }
 
 func TestManager_Timeout(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{
 		Timeout: 50 * time.Millisecond,
@@ -600,7 +607,7 @@ func TestManager_Timeout(t *testing.T) {
 }
 
 func TestManager_TimeoutCompletesBeforeDeadline(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{
 		Timeout: 10 * time.Second,
@@ -613,7 +620,7 @@ func TestManager_TimeoutCompletesBeforeDeadline(t *testing.T) {
 }
 
 func TestManager_ZeroTimeoutMeansNoTimeout(t *testing.T) {
-	tm := NewManager(t.TempDir(), 0, 0)
+	tm := mustNewManager(t, t.TempDir(), 0, 0)
 
 	id := tm.Create("test", TaskOpts{}, func(ctx context.Context, update *Update) error {
 		return nil

--- a/agent/storage/volume.go
+++ b/agent/storage/volume.go
@@ -98,7 +98,9 @@ func (s *Storage) CreateVolume(ctx context.Context, tenant string, req VolumeCre
 			log.Warn().Err(err).Str("path", dataDir).Msg("subvolume already exists on disk")
 			return nil, &StorageError{Code: ErrAlreadyExists, Message: fmt.Sprintf("volume %q already exists on disk", req.Name)}
 		}
-		_ = os.RemoveAll(volDir)
+		if rmErr := os.RemoveAll(volDir); rmErr != nil {
+			log.Warn().Err(rmErr).Str("path", volDir).Msg("cleanup: failed to remove directory")
+		}
 		log.Error().Err(err).Str("path", dataDir).Msg("failed to create subvolume")
 		return nil, &StorageError{Code: ErrInternal, Message: fmt.Sprintf("btrfs subvolume create failed: %v", err)}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ const (
 
 const (
 	DataDir      = "data"
+	MetadataDir  = "metadata"
 	MetadataFile = "metadata.json"
 	SnapshotsDir = "snapshots"
 	TasksDir     = "tasks"
@@ -42,7 +43,7 @@ const (
 // create directly under AGENT_BASE_PATH. Tenant names are compared
 // case-insensitively because btrfs on Linux is case-sensitive but users
 // would otherwise be surprised by a mixed-case bypass.
-var ReservedTenantNames = []string{TasksDir, SnapshotsDir, DataDir, "metadata"}
+var ReservedTenantNames = []string{TasksDir, SnapshotsDir, DataDir, MetadataDir}
 
 // SoftReservedLabelKeys are server-managed labels. CLI and K8s integrations
 // reject these client-side for UX; Agent API consumers should use v1.Client


### PR DESCRIPTION
## Summary

- Tokens cannot leak via logs anymore: the trace-level line on auth failure that included the raw `Authorization` header is gone, and the agent now refuses to start if the root secret file is truncated (which would otherwise be fed to HKDF and produce predictable subkeys).
- Previously silent error paths now log a warn: `toggleImmutable` ioctl failures, task-cleanup `os.Remove` failures (which used to leave ghost tasks for `loadFromDisk` to resurrect), and rollback `os.RemoveAll` failures during volume/snapshot/clone create.
- `log.Fatal` removed from inside library code: `storage.New` and `task.NewManager` return errors, `Agent.Start` returns `(<-chan error, error)` so listen-bind and runtime server errors propagate through `Run` instead of taking the process down from a goroutine. `storage.New`'s 13 positional parameters become a `storage.Config` struct, and the `metadata` directory name is now `config.MetadataDir` instead of a stray string literal.
- secret.NewManager now takes (dir, name) instead of basePath so the package no longer knows the directory convention
