### PR TITLE
Add request tracing and structured JSON log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Per-request audit access log plus default-filter, CodeQL fixes, and logging hardening. Final lap before the project is replaced by ButterStore (see `RELEASE.md`).
 
+### Features
+- Add request tracing and structured JSON log output (#163)
+
 ### Improvements
 - Stamp caller identity onto agent request and event logs (#160)
 - Silence CodeQL go/path-injection false positives (#157)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,17 @@ INF request method=POST path=/v1/volumes/my-vol code=201 took=15.2ms tenant=ops 
 
 Level by status: 5xx → error, 4xx → warn, 2xx/3xx → info. `/healthz` is skipped. To trace every action a token took: `grep token_fingerprint=ab12 access.log`.
 
+### Per-request trace IDs
+
+Every request receives a unique `X-Trace-ID` response header for log correlation. IDs are HMAC-derived (no syscalls, no entropy pool). Clients can supply their own ID via the `X-Trace-ID` request header when `AGENT_API_TRACE_ALLOW_CUSTOM_ID=true`.
+
+```bash
+$ curl -s -D - http://agent:8080/v1/volumes -H "Authorization: Bearer $TOKEN" -H "X-Trace-ID: debug-42"
+X-Trace-Id: debug-42
+```
+
+All log lines for that request carry `trace_id=debug-42`. Grep to follow one request through the entire call stack.
+
 ### Default list filter follows the active identity
 
 The CLI used to hardcode `created-by=cli` regardless of `AGENT_CSI_IDENTITY`. It now follows the configured identity. `--all` / `-A` still bypasses.
@@ -45,6 +56,7 @@ The CLI used to hardcode `created-by=cli` regardless of `AGENT_CSI_IDENTITY`. It
 - Task cleanup retries failed file deletions instead of leaving ghost tasks behind (#161).
 - Initialisation, listen-bind, and server-runtime failures shut down through the normal error path instead of `os.Exit` from inside library code (#161).
 - Failed rollback of half-created volumes, snapshots, or clones is logged (#161).
+- `LOG_FORMAT=json` for structured output in container environments (#163).
 
 ## Documentation
 
@@ -63,7 +75,8 @@ Drop-in from v0.11.0. Bump the image tag to `0.11.1`.
 
 - **Kubernetes CSI users:** no action required.
 - **CLI users with a custom identity:** drop any `--all` workaround, the default now matches your identity.
-- **Operators / log shippers:** expect one info-level access log line per authenticated API call. `/healthz` polling does not log. Set `LOG_LEVEL=warn` to silence the success path.
+- **Operators / log shippers:** expect one info-level access log line per authenticated API call with a `trace_id` field. `/healthz` polling does not log. Set `LOG_LEVEL=warn` to silence the success path. To disable trace IDs: `AGENT_API_TRACE_ENABLED=false`. For structured JSON logs: `LOG_FORMAT=json`.
+- **API consumers:** responses now include an `X-Trace-ID` header. Set `AGENT_HTTP_CLIENT_TRACE_ID` to inject a custom ID for cross-system correlation.
 
 ---
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -92,21 +92,6 @@ func NewAgent(cfg *config.AgentConfig, version, commit string) (*Agent, error) {
 		return nil, fmt.Errorf("init storage: %w", err)
 	}
 
-	// echo + routes. Use a router that rejects auto-OPTIONS: Echo's default
-	// OptionsMethodHandler returns 204 + Allow without running middleware,
-	// letting unauthenticated callers enumerate the route table. We don't
-	// serve browser clients, so dropping CORS preflight is safe.
-	e := echo.NewWithConfig(echo.Config{
-		Router: echo.NewRouter(echo.RouterConfig{
-			OptionsMethodHandler: func(c *echo.Context) error {
-				return c.NoContent(http.StatusMethodNotAllowed)
-			},
-		}),
-	})
-	e.Use(v1.LoggerMiddleware())             // place per-request logger in ctx; must run before Metrics + Auth
-	e.Use(middleware.BodyLimit(1024 * 1024)) // 1MB
-	e.Use(v1.MetricsMiddleware())
-
 	metadataDir := filepath.Join(cfg.BasePath, config.MetadataDir)
 	if err := os.MkdirAll(metadataDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create metadata dir: %w", err)
@@ -118,6 +103,21 @@ func NewAgent(cfg *config.AgentConfig, version, commit string) (*Agent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init agent secrets: %w", err)
 	}
+
+	// echo + routes. Use a router that rejects auto-OPTIONS: Echo's default
+	// OptionsMethodHandler returns 204 + Allow without running middleware,
+	// letting unauthenticated callers enumerate the route table. We don't
+	// serve browser clients, so dropping CORS preflight is safe.
+	e := echo.NewWithConfig(echo.Config{
+		Router: echo.NewRouter(echo.RouterConfig{
+			OptionsMethodHandler: func(c *echo.Context) error {
+				return c.NoContent(http.StatusMethodNotAllowed)
+			},
+		}),
+	})
+	e.Use(v1.LoggerMiddleware(secrets, cfg.TraceEnabled, cfg.TraceAllowCustomID))
+	e.Use(middleware.BodyLimit(1024 * 1024)) // 1MB
+	e.Use(v1.MetricsMiddleware())
 	tokens, err := v1.NewTokenSet(creds, secrets.Fingerprint)
 	if err != nil {
 		return nil, fmt.Errorf("init token set: %w", err)

--- a/agent/api/v1/client/client.go
+++ b/agent/api/v1/client/client.go
@@ -13,6 +13,7 @@
 //   - AGENT_HTTP_CLIENT_PAGE_LIMIT  -- items per page (default 100)
 //   - AGENT_HTTP_CLIENT_PREFETCH    -- max pages to prefetch (default 8, 0=sequential)
 //   - AGENT_HTTP_CLIENT_PREFETCH_MB -- prefetch byte budget in MB (default 4, 0=unlimited)
+//   - AGENT_HTTP_CLIENT_TRACE_ID    -- custom trace ID sent as X-Trace-ID header
 //   - AGENT_CSI_IDENTITY            -- identity label value
 //
 // # Pagination
@@ -73,6 +74,7 @@ type ClientConfig struct {
 	Timeout       time.Duration `env:"AGENT_HTTP_CLIENT_TIMEOUT" envDefault:"30s"`
 	TLSSkipVerify bool          `env:"AGENT_HTTP_CLIENT_TLS_SKIP_VERIFY"`
 	Identity      string        `env:"AGENT_CSI_IDENTITY"`
+	TraceID       string        `env:"AGENT_HTTP_CLIENT_TRACE_ID"`
 	PageLimit     int           `env:"AGENT_HTTP_CLIENT_PAGE_LIMIT" envDefault:"0"`
 	Prefetch      int           `env:"AGENT_HTTP_CLIENT_PREFETCH" envDefault:"8"`
 	PrefetchMB    int           `env:"AGENT_HTTP_CLIENT_PREFETCH_MB" envDefault:"4"`
@@ -105,6 +107,7 @@ type Client struct {
 	token         string
 	http          *http.Client
 	identity      string
+	traceID       string
 	whoami        *models.WhoamiResponse
 	pageLimit     int
 	prefetch      int
@@ -143,6 +146,9 @@ func newClient(url, token string, cfg ClientConfig) (*Client, error) {
 			return nil, err
 		}
 	}
+	if cfg.TraceID != "" && !config.ValidTraceID.MatchString(cfg.TraceID) {
+		return nil, fmt.Errorf("invalid trace ID: %q (must be 1-64 chars, only a-z A-Z 0-9 _ -)", cfg.TraceID)
+	}
 	hc := cfg.HTTPClient
 	if hc == nil {
 		hc = &http.Client{Timeout: cfg.Timeout}
@@ -155,6 +161,7 @@ func newClient(url, token string, cfg ClientConfig) (*Client, error) {
 		token:         token,
 		http:          hc,
 		identity:      cfg.Identity,
+		traceID:       cfg.TraceID,
 		pageLimit:     cfg.PageLimit,
 		prefetch:      cfg.Prefetch,
 		prefetchBytes: int64(cfg.PrefetchMB) * 1024 * 1024,
@@ -677,6 +684,9 @@ func (c *Client) do(ctx context.Context, method, path string, body any, result a
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
+	if c.traceID != "" {
+		req.Header.Set(config.HeaderTraceID, c.traceID)
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/agent/api/v1/client/client.go
+++ b/agent/api/v1/client/client.go
@@ -146,8 +146,10 @@ func newClient(url, token string, cfg ClientConfig) (*Client, error) {
 			return nil, err
 		}
 	}
-	if cfg.TraceID != "" && !config.ValidTraceID.MatchString(cfg.TraceID) {
-		return nil, fmt.Errorf("invalid trace ID: %q (must be 1-64 chars, only a-z A-Z 0-9 _ -)", cfg.TraceID)
+	if cfg.TraceID != "" {
+		if err := config.ValidateTraceID(cfg.TraceID); err != nil {
+			return nil, err
+		}
 	}
 	hc := cfg.HTTPClient
 	if hc == nil {

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/secret"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/labstack/echo/v5"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -17,11 +19,30 @@ import (
 // (adding tenant, identity, fingerprint after auth) and downstream code can
 // pick it up with log.Ctx(ctx). Without this, UpdateContext would mutate the
 // global logger.
-func LoggerMiddleware() echo.MiddlewareFunc {
+//
+// When traceEnabled is true, every request gets a trace ID in logs and the
+// X-Trace-ID response header. Clients may supply their own via X-Trace-ID
+// request header if allowCustomID is true.
+func LoggerMiddleware(secrets *secret.Manager, traceEnabled, allowCustomID bool) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			req := c.Request()
 			l := log.Logger.With().Logger()
+
+			if traceEnabled {
+				traceID := ""
+				if allowCustomID {
+					if custom := req.Header.Get(config.HeaderTraceID); custom != "" && config.ValidTraceID.MatchString(custom) {
+						traceID = custom
+					}
+				}
+				if traceID == "" {
+					traceID = secrets.GenerateID(8)
+				}
+				l = l.With().Str("trace_id", traceID).Logger()
+				c.Response().Header().Set(config.HeaderTraceID, traceID)
+			}
+
 			c.SetRequest(req.WithContext(l.WithContext(req.Context())))
 			return next(c)
 		}

--- a/agent/api/v1/middleware.go
+++ b/agent/api/v1/middleware.go
@@ -32,7 +32,13 @@ func LoggerMiddleware(secrets *secret.Manager, traceEnabled, allowCustomID bool)
 			if traceEnabled {
 				traceID := ""
 				if allowCustomID {
-					if custom := req.Header.Get(config.HeaderTraceID); custom != "" && config.ValidTraceID.MatchString(custom) {
+					if custom := req.Header.Get(config.HeaderTraceID); custom != "" {
+						if err := config.ValidateTraceID(custom); err != nil {
+							return c.JSON(http.StatusBadRequest, models.ErrorResponse{
+								Error: err.Error(),
+								Code:  storage.ErrInvalid,
+							})
+						}
 						traceID = custom
 					}
 				}

--- a/agent/api/v1/middleware_test.go
+++ b/agent/api/v1/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/secret"
 	"github.com/erikmagkekse/btrfs-nfs-csi/agent/storage"
 	"github.com/erikmagkekse/btrfs-nfs-csi/config"
 	"github.com/labstack/echo/v5"
@@ -17,6 +18,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 )
+
+func testSecrets(t *testing.T) *secret.Manager {
+	t.Helper()
+	m, err := secret.NewManager(t.TempDir(), "test_secret")
+	require.NoError(t, err)
+	return m
+}
 
 func init() {
 	zerolog.DefaultContextLogger = &log.Logger
@@ -610,7 +618,7 @@ func TestMetricsMiddleware_AccessLogIncludesAuthFields(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.Use(LoggerMiddleware())
+	e.Use(LoggerMiddleware(testSecrets(t), true, false))
 	e.Use(MetricsMiddleware())
 	api := e.Group("/v1", AuthMiddleware(tokensFromMap(t, tenants)))
 	api.GET("/whoami", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
@@ -643,7 +651,7 @@ func TestMetricsMiddleware_HealthzNotLogged(t *testing.T) {
 	defer func() { log.Logger = orig }()
 
 	e := echo.New()
-	e.Use(LoggerMiddleware())
+	e.Use(LoggerMiddleware(testSecrets(t), true, false))
 	e.Use(MetricsMiddleware())
 	e.GET("/healthz", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
 	e.GET("/v1/whatever", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
@@ -681,7 +689,7 @@ func TestStorageEventLogInheritsAuthFields(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.Use(LoggerMiddleware())
+	e.Use(LoggerMiddleware(testSecrets(t), true, false))
 	api := e.Group("/v1", AuthMiddleware(tokensFromMap(t, tenants)))
 	api.POST("/volumes", func(c *echo.Context) error {
 		// Mirror what agent/storage/volume.go does after CreateVolume.
@@ -720,7 +728,7 @@ func TestMetricsMiddleware_NotFoundLogsRealStatusAndUserAgent(t *testing.T) {
 	defer func() { log.Logger = orig }()
 
 	e := echo.New()
-	e.Use(LoggerMiddleware())
+	e.Use(LoggerMiddleware(testSecrets(t), true, false))
 	e.Use(MetricsMiddleware())
 	e.GET("/known", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
 

--- a/agent/secret/secret.go
+++ b/agent/secret/secret.go
@@ -9,10 +9,12 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 )
 
 const (
@@ -30,6 +32,7 @@ const (
 // not retained after construction.
 type Manager struct {
 	fpKey []byte
+	idCtr atomic.Uint64
 }
 
 // NewManager loads or creates the root secret at dir/name and derives the
@@ -58,6 +61,23 @@ func (m *Manager) Fingerprint(token string) string {
 	h := hmac.New(sha256.New, m.fpKey)
 	h.Write([]byte(token))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// GenerateID returns a hex ID of n bytes (2*n hex chars) derived from
+// HMAC(key, counter). No syscalls, no entropy pool, safe for high-frequency
+// use. n is clamped to [1, 32].
+func (m *Manager) GenerateID(n int) string {
+	if n < 1 {
+		n = 1
+	} else if n > 32 {
+		n = 32
+	}
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], m.idCtr.Add(1))
+	h := hmac.New(sha256.New, m.fpKey)
+	h.Write(buf[:])
+	var digest [32]byte
+	return hex.EncodeToString(h.Sum(digest[:0])[:n])
 }
 
 func loadOrCreate(dir, name string) ([]byte, error) {

--- a/cmd/btrfs-nfs-csi/main.go
+++ b/cmd/btrfs-nfs-csi/main.go
@@ -38,10 +38,15 @@ func main() {
 		}
 	}
 	zerolog.SetGlobalLevel(level)
-	log.Logger = zerolog.New(zerolog.ConsoleWriter{
-		Out:        os.Stderr,
-		TimeFormat: time.RFC3339,
-	}).With().Timestamp().Logger()
+	switch os.Getenv("LOG_FORMAT") {
+	case "json":
+		log.Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
+	default:
+		log.Logger = zerolog.New(zerolog.ConsoleWriter{
+			Out:        os.Stderr,
+			TimeFormat: time.RFC3339,
+		}).With().Timestamp().Logger()
+	}
 
 	app := &cli.Command{
 		Name:  "btrfs-nfs-csi",

--- a/config/config.go
+++ b/config/config.go
@@ -75,7 +75,14 @@ func ValidateName(name string) error {
 
 func ValidateIdentity(identity string) error {
 	if !ValidIdentity.MatchString(identity) {
-		return &ValidationError{Message: fmt.Sprintf("invalid identity: %q (must be 1-32 chars, only a-z A-Z 0-9 _ -)", identity)}
+		return &ValidationError{Message: fmt.Sprintf("invalid identity: %q (must match %s)", identity, ValidIdentity)}
+	}
+	return nil
+}
+
+func ValidateTraceID(id string) error {
+	if !ValidTraceID.MatchString(id) {
+		return &ValidationError{Message: fmt.Sprintf("invalid trace ID: %q (must match %s)", id, ValidTraceID)}
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ var (
 	ValidLabelKey = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,62}$`)
 	ValidLabelVal = regexp.MustCompile(`^[a-zA-Z0-9._-]{0,128}$`)
 	ValidIdentity = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,32}$`)
+	ValidTraceID  = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 )
 
 const (
@@ -24,6 +25,8 @@ const (
 
 	IdentityCLI           = "cli"
 	IdentityK8sController = "k8s"
+
+	HeaderTraceID = "X-Trace-ID"
 )
 
 const (
@@ -171,6 +174,8 @@ type AgentConfig struct {
 	PaginationSnapshotTTL  time.Duration `env:"AGENT_API_PAGINATION_SNAPSHOT_TTL" envDefault:"30s"`
 	PaginationMaxSnapshots int           `env:"AGENT_API_PAGINATION_MAX_SNAPSHOTS" envDefault:"100"`
 	SwaggerEnabled         bool          `env:"AGENT_API_SWAGGER_ENABLED"`
+	TraceEnabled           bool          `env:"AGENT_API_TRACE_ENABLED" envDefault:"true"`
+	TraceAllowCustomID     bool          `env:"AGENT_API_TRACE_ALLOW_CUSTOM_ID"`
 }
 
 type ControllerConfig struct {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,9 @@
 | `AGENT_API_PAGINATION_SNAPSHOT_TTL` | `30s` | TTL for cursor-based pagination snapshots |
 | `AGENT_API_PAGINATION_MAX_SNAPSHOTS` | `100` | Max concurrent pagination snapshots |
 | `AGENT_API_SWAGGER_ENABLED` | `false` | Enable `GET /swagger.json` endpoint |
+| `AGENT_API_TRACE_ENABLED` | `true` | Generate a trace ID for every request (logged + returned as `X-Trace-ID` header) |
+| `AGENT_API_TRACE_ALLOW_CUSTOM_ID` | `false` | Accept client-provided trace ID via `X-Trace-ID` request header (validated: `[a-zA-Z0-9_-]{1,64}`) |
+| `LOG_FORMAT` | `console` | `json` for structured output (containers, Loki, Datadog), `console` for human-readable |
 | `LOG_LEVEL` | `info` | `trace`, `debug`, `info`, `warn`, `error` |
 
 ## API Client Environment Variables
@@ -46,6 +49,7 @@ Shared by CLI and all integrations (any `v1.Client` user).
 | `AGENT_HTTP_CLIENT_PAGE_LIMIT` | `0` | Items per page for auto-pagination (0 = pagination disabled) |
 | `AGENT_HTTP_CLIENT_PREFETCH` | `8` | Max pages to prefetch concurrently (`0` = sequential) |
 | `AGENT_HTTP_CLIENT_PREFETCH_MB` | `4` | Prefetch byte budget in MB (`0` = unlimited) |
+| `AGENT_HTTP_CLIENT_TRACE_ID` | - | Custom trace ID sent as `X-Trace-ID` header on every request (requires `AGENT_API_TRACE_ALLOW_CUSTOM_ID=true` on the agent) |
 
 ## CLI Environment Variables
 


### PR DESCRIPTION
## Summary
- Every request gets an HMAC-derived trace ID in logs and X-Trace-ID response header, with optional client-provided IDs via AGENT_API_TRACE_ALLOW_CUSTOM_ID
- Add LOG_FORMAT=json env var for structured output in container/log-pipeline environments
- Add AGENT_HTTP_CLIENT_TRACE_ID for cross-system request correlation from the client side