### PR TITLE
Add agents subcommand for managing saved remote endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ btrfs-nfs-csi is not a distributed storage system. If you need data replication 
 - **HA.** DRBD + Pacemaker active/passive failover.
 
 ### CLI
+- **Saved agents.** `agents login` once, no more `AGENT_URL`/`AGENT_TOKEN` exports.
 - **Watch mode** (`-w`). Auto-refreshing output for any list/get command.
 - **Column filter** (`-c name,size,used`). Show only what you need.
 - **Label filter** (`-l env=prod`). Filter resources by label.
@@ -126,10 +127,12 @@ AGENT_BLOCK_DISK=/dev/sdb curl -fsSL \
 
 ### 2. Use the CLI
 
+Log into the agent once, the CLI saves the endpoint to `~/.btrfs-nfs-csi/config.json` (file `0600`) and uses it as the default for every subsequent command:
+
 ```bash
-export AGENT_URL=http://10.0.0.5:8080
-export AGENT_TOKEN=your-tenant-token    # from step 1
-# export AGENT_CSI_IDENTITY=cli         # optional, default: cli
+btrfs-nfs-csi agents login prod --url http://10.0.0.5:8080
+# enter token at the no-echo prompt, or pipe it in (Docker-style):
+# echo "$AGENT_TOKEN" | btrfs-nfs-csi agents login prod --url http://10.0.0.5:8080
 ```
 
 ```bash
@@ -138,6 +141,8 @@ btrfs-nfs-csi volume list
 btrfs-nfs-csi snapshot create my-app before-deploy
 btrfs-nfs-csi stats
 ```
+
+For one-off shells or CI, `AGENT_URL` and `AGENT_TOKEN` env vars (or `--agent-url`/`--agent-token` flags) still work and take precedence over the saved agent. See [Operations: Saved Agents](docs/operations.md#saved-agents) for `agents ls/use/verify`.
 
 That's it. The agent manages btrfs subvolumes, NFS exports, and quotas. The CLI talks to the agent via REST API. Everything else (container orchestrator integrations, automation, custom tooling) builds on top.
 

--- a/cmd/btrfs-nfs-csi/agents.go
+++ b/cmd/btrfs-nfs-csi/agents.go
@@ -417,4 +417,3 @@ func verifyNote(e verifyEntry) string {
 		return ""
 	}
 }
-

--- a/cmd/btrfs-nfs-csi/agents.go
+++ b/cmd/btrfs-nfs-csi/agents.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -29,106 +27,6 @@ type Agent struct {
 	Role          models.TenantRole `json:"role,omitempty"`
 	Fingerprint   string            `json:"fingerprint,omitempty"`
 	TLSSkipVerify bool              `json:"tls_skip_verify,omitempty"`
-}
-
-type AgentStore struct {
-	Current string           `json:"current,omitempty"`
-	Agents  map[string]Agent `json:"agents,omitempty"`
-}
-
-func (s *AgentStore) Active() (Agent, bool) {
-	if s == nil || s.Current == "" {
-		return Agent{}, false
-	}
-	a, ok := s.Agents[s.Current]
-	return a, ok
-}
-
-// agentsPath honours BTRFS_NFS_CSI_AGENTS_FILE so tests and per-project
-// profiles can redirect away from the default $HOME location.
-func agentsPath() (string, error) {
-	if override := os.Getenv("BTRFS_NFS_CSI_AGENTS_FILE"); override != "" {
-		return override, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("locate home directory: %w", err)
-	}
-	return filepath.Join(home, ".btrfs-nfs-csi", "agents.json"), nil
-}
-
-// loadAgents treats a missing file as an empty store so first-run is
-// indistinguishable from "no agents configured".
-func loadAgents() (*AgentStore, error) {
-	path, err := agentsPath()
-	if err != nil {
-		return nil, err
-	}
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return &AgentStore{Agents: map[string]Agent{}}, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", path, err)
-	}
-	var s AgentStore
-	if err := json.Unmarshal(data, &s); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
-	}
-	if s.Agents == nil {
-		s.Agents = map[string]Agent{}
-	}
-	return &s, nil
-}
-
-// save writes atomically with 0600 + 0700 because the file holds bearer
-// tokens in plaintext.
-func (s *AgentStore) save() error {
-	path, err := agentsPath()
-	if err != nil {
-		return err
-	}
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create config dir: %w", err)
-	}
-	data, err := json.MarshalIndent(s, "", "  ")
-	if err != nil {
-		return fmt.Errorf("encode agents: %w", err)
-	}
-	tmp, err := os.CreateTemp(dir, "agents-*.json.tmp")
-	if err != nil {
-		return fmt.Errorf("create temp: %w", err)
-	}
-	tmpName := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpName)
-		}
-	}()
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("chmod temp: %w", err)
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("write temp: %w", err)
-	}
-	// rename is atomic, but without fsync the new bytes can be lost on
-	// power loss while the directory entry already points at them.
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("sync temp: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return fmt.Errorf("rename into place: %w", err)
-	}
-	cleanup = false
-	return nil
 }
 
 // newAgentClient layers per-agent settings on top of AGENT_HTTP_CLIENT_*
@@ -223,12 +121,12 @@ func agentLogin(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("verify against %s: %w", url, err)
 	}
 
-	store, err := loadAgents()
+	cfg, err := loadConfig()
 	if err != nil {
 		return err
 	}
 	who := client.Whoami()
-	store.Agents[name] = Agent{
+	cfg.Agents[name] = Agent{
 		URL:           url,
 		Token:         token,
 		Identity:      identity,
@@ -237,8 +135,8 @@ func agentLogin(ctx context.Context, cmd *cli.Command) error {
 		Role:          who.Role,
 		Fingerprint:   who.Fingerprint,
 	}
-	store.Current = name
-	if err := store.save(); err != nil {
+	cfg.CurrentAgent = name
+	if err := cfg.save(); err != nil {
 		return err
 	}
 	fmt.Printf("logged in to %s as tenant %q (role=%s, identity=%s)\n", url, who.Tenant, who.Role, identity)
@@ -247,29 +145,29 @@ func agentLogin(ctx context.Context, cmd *cli.Command) error {
 }
 
 func agentLogout(_ context.Context, cmd *cli.Command) error {
-	store, err := loadAgents()
+	cfg, err := loadConfig()
 	if err != nil {
 		return err
 	}
 	name := cmd.Args().First()
 	if name == "" {
-		name = store.Current
+		name = cfg.CurrentAgent
 	}
 	if name == "" {
 		return errors.New("no active agent and no name given")
 	}
-	if _, ok := store.Agents[name]; !ok {
+	if _, ok := cfg.Agents[name]; !ok {
 		return fmt.Errorf("agent %q not found", name)
 	}
-	delete(store.Agents, name)
-	if store.Current == name {
-		store.Current = ""
+	delete(cfg.Agents, name)
+	if cfg.CurrentAgent == name {
+		cfg.CurrentAgent = ""
 	}
-	if err := store.save(); err != nil {
+	if err := cfg.save(); err != nil {
 		return err
 	}
 	fmt.Printf("removed agent %q\n", name)
-	if store.Current == "" && len(store.Agents) > 0 {
+	if cfg.CurrentAgent == "" && len(cfg.Agents) > 0 {
 		fmt.Fprintln(os.Stderr, "warning: no active agent, pick one with `btrfs-nfs-csi agents use <name>`")
 	}
 	return nil
@@ -289,16 +187,16 @@ type agentListEntry struct {
 }
 
 type agentListOutput struct {
-	Current string           `json:"current,omitempty"`
-	Agents  []agentListEntry `json:"agents"`
+	CurrentAgent string           `json:"current_agent,omitempty"`
+	Agents       []agentListEntry `json:"agents"`
 }
 
 func agentList(_ context.Context, cmd *cli.Command) error {
-	store, err := loadAgents()
+	cfg, err := loadConfig()
 	if err != nil {
 		return err
 	}
-	if len(store.Agents) == 0 {
+	if len(cfg.Agents) == 0 {
 		if isJSON(cmd) {
 			return output(cmd, agentListOutput{Agents: []agentListEntry{}}, nil)
 		}
@@ -306,13 +204,13 @@ func agentList(_ context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	names := slices.Sorted(maps.Keys(store.Agents))
+	names := slices.Sorted(maps.Keys(cfg.Agents))
 	entries := make([]agentListEntry, len(names))
 	for i, name := range names {
-		a := store.Agents[name]
+		a := cfg.Agents[name]
 		entries[i] = agentListEntry{
 			Name:          name,
-			Active:        name == store.Current,
+			Active:        name == cfg.CurrentAgent,
 			URL:           a.URL,
 			Identity:      a.Identity,
 			Tenant:        a.Tenant,
@@ -322,7 +220,7 @@ func agentList(_ context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	return output(cmd, agentListOutput{Current: store.Current, Agents: entries}, func() {
+	return output(cmd, agentListOutput{CurrentAgent: cfg.CurrentAgent, Agents: entries}, func() {
 		wide := isWide(cmd)
 		w := tab()
 		if wide {
@@ -359,15 +257,15 @@ func agentUse(_ context.Context, cmd *cli.Command) error {
 	if name == "" {
 		return errors.New("missing agent name (usage: btrfs-nfs-csi agents use <name>)")
 	}
-	store, err := loadAgents()
+	cfg, err := loadConfig()
 	if err != nil {
 		return err
 	}
-	if _, ok := store.Agents[name]; !ok {
+	if _, ok := cfg.Agents[name]; !ok {
 		return fmt.Errorf("agent %q not found", name)
 	}
-	store.Current = name
-	if err := store.save(); err != nil {
+	cfg.CurrentAgent = name
+	if err := cfg.save(); err != nil {
 		return err
 	}
 	fmt.Printf("switched to agent %q\n", name)
@@ -400,7 +298,7 @@ type verifyOutput struct {
 }
 
 func agentVerify(ctx context.Context, cmd *cli.Command) error {
-	store, err := loadAgents()
+	cfg, err := loadConfig()
 	if err != nil {
 		return err
 	}
@@ -408,23 +306,23 @@ func agentVerify(ctx context.Context, cmd *cli.Command) error {
 	var names []string
 	switch {
 	case cmd.Bool("all"):
-		if len(store.Agents) == 0 {
+		if len(cfg.Agents) == 0 {
 			if isJSON(cmd) {
 				return output(cmd, verifyOutput{Results: []verifyEntry{}}, nil)
 			}
 			fmt.Fprintln(os.Stderr, "no agents configured")
 			return nil
 		}
-		names = slices.Sorted(maps.Keys(store.Agents))
+		names = slices.Sorted(maps.Keys(cfg.Agents))
 	default:
 		name := cmd.Args().First()
 		if name == "" {
-			name = store.Current
+			name = cfg.CurrentAgent
 		}
 		if name == "" {
 			return errors.New("no active agent and no name given (use --all to verify every saved agent)")
 		}
-		if _, ok := store.Agents[name]; !ok {
+		if _, ok := cfg.Agents[name]; !ok {
 			return fmt.Errorf("agent %q not found", name)
 		}
 		names = []string{name}
@@ -434,7 +332,7 @@ func agentVerify(ctx context.Context, cmd *cli.Command) error {
 	var wg sync.WaitGroup
 	for i, name := range names {
 		wg.Go(func() {
-			entries[i] = checkAgent(ctx, name, store.Agents[name], name == store.Current)
+			entries[i] = checkAgent(ctx, name, cfg.Agents[name], name == cfg.CurrentAgent)
 		})
 	}
 	wg.Wait()

--- a/cmd/btrfs-nfs-csi/agents.go
+++ b/cmd/btrfs-nfs-csi/agents.go
@@ -1,0 +1,522 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	agentclient "github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/client"
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
+	"github.com/erikmagkekse/btrfs-nfs-csi/config"
+	"github.com/urfave/cli/v3"
+)
+
+// Tenant/Role/Fingerprint are cached so `agents ls` works offline. They
+// are deterministic from the token, so the cache only goes stale on a
+// fresh `login` with a different token, never spontaneously.
+type Agent struct {
+	URL           string            `json:"url"`
+	Token         string            `json:"token"`
+	Identity      string            `json:"identity,omitempty"`
+	Tenant        string            `json:"tenant,omitempty"`
+	Role          models.TenantRole `json:"role,omitempty"`
+	Fingerprint   string            `json:"fingerprint,omitempty"`
+	TLSSkipVerify bool              `json:"tls_skip_verify,omitempty"`
+}
+
+type AgentStore struct {
+	Current string           `json:"current,omitempty"`
+	Agents  map[string]Agent `json:"agents,omitempty"`
+}
+
+func (s *AgentStore) Active() (Agent, bool) {
+	if s == nil || s.Current == "" {
+		return Agent{}, false
+	}
+	a, ok := s.Agents[s.Current]
+	return a, ok
+}
+
+// agentsPath honours BTRFS_NFS_CSI_AGENTS_FILE so tests and per-project
+// profiles can redirect away from the default $HOME location.
+func agentsPath() (string, error) {
+	if override := os.Getenv("BTRFS_NFS_CSI_AGENTS_FILE"); override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate home directory: %w", err)
+	}
+	return filepath.Join(home, ".btrfs-nfs-csi", "agents.json"), nil
+}
+
+// loadAgents treats a missing file as an empty store so first-run is
+// indistinguishable from "no agents configured".
+func loadAgents() (*AgentStore, error) {
+	path, err := agentsPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &AgentStore{Agents: map[string]Agent{}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var s AgentStore
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if s.Agents == nil {
+		s.Agents = map[string]Agent{}
+	}
+	return &s, nil
+}
+
+// save writes atomically with 0600 + 0700 because the file holds bearer
+// tokens in plaintext.
+func (s *AgentStore) save() error {
+	path, err := agentsPath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode agents: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, "agents-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	// rename is atomic, but without fsync the new bytes can be lost on
+	// power loss while the directory entry already points at them.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename into place: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// newAgentClient layers per-agent settings on top of AGENT_HTTP_CLIENT_*
+// env defaults. A saved skip=true wins because operators store it
+// deliberately, env defaults fill the rest.
+func newAgentClient(a Agent) (*agentclient.Client, error) {
+	cfg := agentclient.DefaultClientConfig()
+	if a.TLSSkipVerify {
+		cfg.TLSSkipVerify = true
+	}
+	if cfg.Identity == "" {
+		cfg.Identity = a.Identity
+	}
+	return agentclient.NewClientWithConfig(a.URL, a.Token, cfg)
+}
+
+func agentsSubcommands() []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:      "login",
+			Usage:     "save an agent endpoint and make it active",
+			ArgsUsage: "<name>",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "url", Usage: "agent API URL"},
+				&cli.StringFlag{Name: "token", Usage: "tenant token; prefer omitting and entering at the no-echo prompt so it does not land in shell history"},
+				&cli.StringFlag{Name: "identity", Usage: "identity label value", Value: config.IdentityCLI},
+				&cli.BoolFlag{Name: "tls-skip-verify", Usage: "skip TLS certificate verification for this agent (use with self-signed certs)"},
+			},
+			Action: agentLogin,
+		},
+		{
+			Name:      "logout",
+			Usage:     "remove a saved agent (defaults to the active one)",
+			ArgsUsage: "[<name>]",
+			Action:    agentLogout,
+		},
+		{
+			Name:    "ls",
+			Aliases: []string{"list"},
+			Usage:   "list saved agents (* marks the active one)",
+			Flags:   []cli.Flag{outputFlag()},
+			Action:  agentList,
+		},
+		{
+			Name:      "use",
+			Usage:     "switch to a saved agent",
+			ArgsUsage: "<name>",
+			Action:    agentUse,
+		},
+		{
+			Name:      "verify",
+			Usage:     "check that saved tokens still authenticate and match the cached tenant/role/fingerprint",
+			ArgsUsage: "[<name>]",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: "all", Usage: "verify every saved agent in parallel"},
+				outputFlag(),
+			},
+			Action: agentVerify,
+		},
+	}
+}
+
+func agentLogin(ctx context.Context, cmd *cli.Command) error {
+	name := cmd.Args().First()
+	if name == "" {
+		return errors.New("missing agent name (usage: btrfs-nfs-csi agents login <name> --url ...)")
+	}
+	url := cmd.String("url")
+	if url == "" {
+		return errors.New("--url is required")
+	}
+	identity := cmd.String("identity")
+	tlsSkipVerify := cmd.Bool("tls-skip-verify")
+	token := cmd.String("token")
+	if token == "" {
+		t, err := readToken()
+		if err != nil {
+			return err
+		}
+		if t == "" {
+			return errors.New("empty token")
+		}
+		token = t
+	}
+
+	candidate := Agent{URL: url, Token: token, Identity: identity, TLSSkipVerify: tlsSkipVerify}
+	client, err := newAgentClient(candidate)
+	if err != nil {
+		return fmt.Errorf("client init: %w", err)
+	}
+	if err := client.Resolve(ctx); err != nil {
+		return fmt.Errorf("verify against %s: %w", url, err)
+	}
+
+	store, err := loadAgents()
+	if err != nil {
+		return err
+	}
+	who := client.Whoami()
+	store.Agents[name] = Agent{
+		URL:           url,
+		Token:         token,
+		Identity:      identity,
+		TLSSkipVerify: tlsSkipVerify,
+		Tenant:        who.Tenant,
+		Role:          who.Role,
+		Fingerprint:   who.Fingerprint,
+	}
+	store.Current = name
+	if err := store.save(); err != nil {
+		return err
+	}
+	fmt.Printf("logged in to %s as tenant %q (role=%s, identity=%s)\n", url, who.Tenant, who.Role, identity)
+	fmt.Printf("agent %q is now active\n", name)
+	return nil
+}
+
+func agentLogout(_ context.Context, cmd *cli.Command) error {
+	store, err := loadAgents()
+	if err != nil {
+		return err
+	}
+	name := cmd.Args().First()
+	if name == "" {
+		name = store.Current
+	}
+	if name == "" {
+		return errors.New("no active agent and no name given")
+	}
+	if _, ok := store.Agents[name]; !ok {
+		return fmt.Errorf("agent %q not found", name)
+	}
+	delete(store.Agents, name)
+	if store.Current == name {
+		store.Current = ""
+	}
+	if err := store.save(); err != nil {
+		return err
+	}
+	fmt.Printf("removed agent %q\n", name)
+	if store.Current == "" && len(store.Agents) > 0 {
+		fmt.Fprintln(os.Stderr, "warning: no active agent, pick one with `btrfs-nfs-csi agents use <name>`")
+	}
+	return nil
+}
+
+// agentListEntry deliberately omits the token so `-o json` is safe to
+// redirect or pipe.
+type agentListEntry struct {
+	Name          string            `json:"name"`
+	Active        bool              `json:"active,omitempty"`
+	URL           string            `json:"url"`
+	Identity      string            `json:"identity,omitempty"`
+	Tenant        string            `json:"tenant,omitempty"`
+	Role          models.TenantRole `json:"role,omitempty"`
+	Fingerprint   string            `json:"fingerprint,omitempty"`
+	TLSSkipVerify bool              `json:"tls_skip_verify,omitempty"`
+}
+
+type agentListOutput struct {
+	Current string           `json:"current,omitempty"`
+	Agents  []agentListEntry `json:"agents"`
+}
+
+func agentList(_ context.Context, cmd *cli.Command) error {
+	store, err := loadAgents()
+	if err != nil {
+		return err
+	}
+	if len(store.Agents) == 0 {
+		if isJSON(cmd) {
+			return output(cmd, agentListOutput{Agents: []agentListEntry{}}, nil)
+		}
+		fmt.Fprintln(os.Stderr, "no agents configured (run `btrfs-nfs-csi agents login <name> --url ...`)")
+		return nil
+	}
+
+	names := slices.Sorted(maps.Keys(store.Agents))
+	entries := make([]agentListEntry, len(names))
+	for i, name := range names {
+		a := store.Agents[name]
+		entries[i] = agentListEntry{
+			Name:          name,
+			Active:        name == store.Current,
+			URL:           a.URL,
+			Identity:      a.Identity,
+			Tenant:        a.Tenant,
+			Role:          a.Role,
+			Fingerprint:   a.Fingerprint,
+			TLSSkipVerify: a.TLSSkipVerify,
+		}
+	}
+
+	return output(cmd, agentListOutput{Current: store.Current, Agents: entries}, func() {
+		wide := isWide(cmd)
+		w := tab()
+		if wide {
+			_, _ = fmt.Fprintln(w, "ACTIVE\tNAME\tURL\tTENANT\tROLE\tIDENTITY\tFINGERPRINT\tTLS")
+		} else {
+			_, _ = fmt.Fprintln(w, "ACTIVE\tNAME\tURL\tTENANT\tROLE\tIDENTITY\tFINGERPRINT")
+		}
+		for _, e := range entries {
+			marker := ""
+			if e.Active {
+				marker = "*"
+			}
+			if wide {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					marker, e.Name, e.URL, dash(e.Tenant), dash(string(e.Role)), dash(e.Identity), shortFP(e.Fingerprint, wide), tlsLabel(e.TLSSkipVerify))
+			} else {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					marker, e.Name, e.URL, dash(e.Tenant), dash(string(e.Role)), dash(e.Identity), shortFP(e.Fingerprint, wide))
+			}
+		}
+		_ = w.Flush()
+	})
+}
+
+func tlsLabel(skip bool) string {
+	if skip {
+		return "skip"
+	}
+	return "verify"
+}
+
+func agentUse(_ context.Context, cmd *cli.Command) error {
+	name := cmd.Args().First()
+	if name == "" {
+		return errors.New("missing agent name (usage: btrfs-nfs-csi agents use <name>)")
+	}
+	store, err := loadAgents()
+	if err != nil {
+		return err
+	}
+	if _, ok := store.Agents[name]; !ok {
+		return fmt.Errorf("agent %q not found", name)
+	}
+	store.Current = name
+	if err := store.save(); err != nil {
+		return err
+	}
+	fmt.Printf("switched to agent %q\n", name)
+	return nil
+}
+
+// verifyStatus marshals lowercase for JSON. The table view uppercases the
+// non-ok cases via displayStatus so failures catch the eye.
+type verifyStatus string
+
+const (
+	statusOk    verifyStatus = "ok"
+	statusStale verifyStatus = "stale"
+	statusFail  verifyStatus = "fail"
+)
+
+type verifyEntry struct {
+	Name        string            `json:"name"`
+	Active      bool              `json:"active,omitempty"`
+	Status      verifyStatus      `json:"status"`
+	Tenant      string            `json:"tenant,omitempty"`
+	Role        models.TenantRole `json:"role,omitempty"`
+	Fingerprint string            `json:"fingerprint,omitempty"`
+	Drift       string            `json:"drift,omitempty"`
+	Error       string            `json:"error,omitempty"`
+}
+
+type verifyOutput struct {
+	Results []verifyEntry `json:"results"`
+}
+
+func agentVerify(ctx context.Context, cmd *cli.Command) error {
+	store, err := loadAgents()
+	if err != nil {
+		return err
+	}
+
+	var names []string
+	switch {
+	case cmd.Bool("all"):
+		if len(store.Agents) == 0 {
+			if isJSON(cmd) {
+				return output(cmd, verifyOutput{Results: []verifyEntry{}}, nil)
+			}
+			fmt.Fprintln(os.Stderr, "no agents configured")
+			return nil
+		}
+		names = slices.Sorted(maps.Keys(store.Agents))
+	default:
+		name := cmd.Args().First()
+		if name == "" {
+			name = store.Current
+		}
+		if name == "" {
+			return errors.New("no active agent and no name given (use --all to verify every saved agent)")
+		}
+		if _, ok := store.Agents[name]; !ok {
+			return fmt.Errorf("agent %q not found", name)
+		}
+		names = []string{name}
+	}
+
+	entries := make([]verifyEntry, len(names))
+	var wg sync.WaitGroup
+	for i, name := range names {
+		wg.Go(func() {
+			entries[i] = checkAgent(ctx, name, store.Agents[name], name == store.Current)
+		})
+	}
+	wg.Wait()
+
+	failed := false
+	for _, e := range entries {
+		if e.Status != statusOk {
+			failed = true
+			break
+		}
+	}
+
+	if err := output(cmd, verifyOutput{Results: entries}, func() {
+		w := tab()
+		_, _ = fmt.Fprintln(w, "ACTIVE\tNAME\tSTATUS\tNOTE")
+		for _, e := range entries {
+			marker := ""
+			if e.Active {
+				marker = "*"
+			}
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", marker, e.Name, displayStatus(e.Status), verifyNote(e))
+		}
+		_ = w.Flush()
+	}); err != nil {
+		return err
+	}
+	if failed {
+		return errors.New("one or more agents failed verification")
+	}
+	return nil
+}
+
+func checkAgent(ctx context.Context, name string, a Agent, active bool) verifyEntry {
+	entry := verifyEntry{Name: name, Active: active}
+	client, err := newAgentClient(a)
+	if err != nil {
+		entry.Status, entry.Error = statusFail, err.Error()
+		return entry
+	}
+	if err := client.Resolve(ctx); err != nil {
+		entry.Status, entry.Error = statusFail, err.Error()
+		return entry
+	}
+	who := client.Whoami()
+	entry.Tenant, entry.Role, entry.Fingerprint = who.Tenant, who.Role, who.Fingerprint
+	if d := diffAgent(a, who); d != "" {
+		entry.Status, entry.Drift = statusStale, d
+		return entry
+	}
+	entry.Status = statusOk
+	return entry
+}
+
+func diffAgent(a Agent, who *models.WhoamiResponse) string {
+	var diffs []string
+	if a.Tenant != who.Tenant {
+		diffs = append(diffs, fmt.Sprintf("tenant: cached=%s, live=%s", a.Tenant, who.Tenant))
+	}
+	if a.Role != who.Role {
+		diffs = append(diffs, fmt.Sprintf("role: cached=%s, live=%s", a.Role, who.Role))
+	}
+	if a.Fingerprint != who.Fingerprint {
+		diffs = append(diffs, fmt.Sprintf("fingerprint: cached=%s, live=%s", shortFP(a.Fingerprint, false), shortFP(who.Fingerprint, false)))
+	}
+	return strings.Join(diffs, "; ")
+}
+
+func displayStatus(s verifyStatus) string {
+	if s == statusOk {
+		return string(s)
+	}
+	return strings.ToUpper(string(s))
+}
+
+func verifyNote(e verifyEntry) string {
+	switch e.Status {
+	case statusFail:
+		return e.Error
+	case statusStale:
+		return e.Drift + " (run `agents login <name>` to refresh)"
+	default:
+		return ""
+	}
+}
+

--- a/cmd/btrfs-nfs-csi/agents_test.go
+++ b/cmd/btrfs-nfs-csi/agents_test.go
@@ -16,26 +16,26 @@ func withTempConfigDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
-	t.Setenv("BTRFS_NFS_CSI_AGENTS_FILE", "")
+	t.Setenv("BTRFS_NFS_CSI_CONFIG_FILE", "")
 	return dir
 }
 
-func TestLoadAgents_MissingFileReturnsEmptyStore(t *testing.T) {
+func TestLoadConfig_MissingFileReturnsEmptyConfig(t *testing.T) {
 	withTempConfigDir(t)
-	store, err := loadAgents()
+	cfg, err := loadConfig()
 	require.NoError(t, err)
-	require.NotNil(t, store)
-	assert.Empty(t, store.Current)
-	assert.Empty(t, store.Agents)
-	_, ok := store.Active()
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg.CurrentAgent)
+	assert.Empty(t, cfg.Agents)
+	_, ok := cfg.Active()
 	assert.False(t, ok, "no current set, Active should report false")
 }
 
-func TestAgentStore_SaveLoadRoundTrip(t *testing.T) {
+func TestConfig_SaveLoadRoundTrip(t *testing.T) {
 	withTempConfigDir(t)
 
-	want := &AgentStore{
-		Current: "prod",
+	want := &Config{
+		CurrentAgent: "prod",
 		Agents: map[string]Agent{
 			"prod": {
 				URL: "https://agent:8080", Token: "s3cret", Identity: "cli",
@@ -46,9 +46,9 @@ func TestAgentStore_SaveLoadRoundTrip(t *testing.T) {
 	}
 	require.NoError(t, want.save())
 
-	got, err := loadAgents()
+	got, err := loadConfig()
 	require.NoError(t, err)
-	assert.Equal(t, want.Current, got.Current)
+	assert.Equal(t, want.CurrentAgent, got.CurrentAgent)
 	assert.Equal(t, want.Agents, got.Agents)
 
 	active, ok := got.Active()
@@ -56,49 +56,49 @@ func TestAgentStore_SaveLoadRoundTrip(t *testing.T) {
 	assert.Equal(t, "https://agent:8080", active.URL)
 }
 
-func TestAgentStore_SaveSetsRestrictivePermissions(t *testing.T) {
+func TestConfig_SaveSetsRestrictivePermissions(t *testing.T) {
 	configHome := withTempConfigDir(t)
-	store := &AgentStore{Agents: map[string]Agent{"a": {URL: "u", Token: "t"}}}
-	require.NoError(t, store.save())
+	cfg := &Config{Agents: map[string]Agent{"a": {URL: "u", Token: "t"}}}
+	require.NoError(t, cfg.save())
 
-	path := filepath.Join(configHome, ".btrfs-nfs-csi", "agents.json")
+	path := filepath.Join(configHome, ".btrfs-nfs-csi", "config.json")
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "agents.json must be 0600 (holds bearer tokens)")
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "config.json must be 0600 (holds bearer tokens)")
 
 	dirInfo, err := os.Stat(filepath.Dir(path))
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm(), "config dir must be 0700")
 }
 
-func TestAgentsPath_OverrideEnvWins(t *testing.T) {
-	custom := filepath.Join(t.TempDir(), "custom-agents.json")
-	t.Setenv("BTRFS_NFS_CSI_AGENTS_FILE", custom)
-	got, err := agentsPath()
+func TestConfigPath_OverrideEnvWins(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "custom-config.json")
+	t.Setenv("BTRFS_NFS_CSI_CONFIG_FILE", custom)
+	got, err := configPath()
 	require.NoError(t, err)
-	assert.Equal(t, custom, got, "BTRFS_NFS_CSI_AGENTS_FILE must take precedence over $HOME default")
+	assert.Equal(t, custom, got, "BTRFS_NFS_CSI_CONFIG_FILE must take precedence over $HOME default")
 }
 
-func TestAgentsPath_DefaultsToHomeDotdir(t *testing.T) {
+func TestConfigPath_DefaultsToHomeDotdir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("BTRFS_NFS_CSI_AGENTS_FILE", "")
-	got, err := agentsPath()
+	t.Setenv("BTRFS_NFS_CSI_CONFIG_FILE", "")
+	got, err := configPath()
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(home, ".btrfs-nfs-csi", "agents.json"), got)
+	assert.Equal(t, filepath.Join(home, ".btrfs-nfs-csi", "config.json"), got)
 }
 
 func TestAgent_TLSSkipVerifyRoundTrips(t *testing.T) {
 	withTempConfigDir(t)
-	want := &AgentStore{
-		Current: "prod",
+	want := &Config{
+		CurrentAgent: "prod",
 		Agents: map[string]Agent{
 			"prod": {URL: "https://agent:8443", Token: "t", TLSSkipVerify: true},
 			"dev":  {URL: "https://agent:8443", Token: "t"},
 		},
 	}
 	require.NoError(t, want.save())
-	got, err := loadAgents()
+	got, err := loadConfig()
 	require.NoError(t, err)
 	assert.True(t, got.Agents["prod"].TLSSkipVerify, "skip flag must persist for prod")
 	assert.False(t, got.Agents["dev"].TLSSkipVerify, "dev kept default verify")
@@ -109,12 +109,12 @@ func TestTLSLabel(t *testing.T) {
 	assert.Equal(t, "verify", tlsLabel(false))
 }
 
-func TestAgentStore_ActiveReturnsFalseWhenCurrentMissing(t *testing.T) {
-	store := &AgentStore{
-		Current: "ghost",
+func TestConfig_ActiveReturnsFalseWhenCurrentAgentMissing(t *testing.T) {
+	cfg := &Config{
+		CurrentAgent: "ghost",
 		Agents:  map[string]Agent{"prod": {URL: "u", Token: "t"}},
 	}
-	_, ok := store.Active()
+	_, ok := cfg.Active()
 	assert.False(t, ok, "Current names an agent that does not exist")
 }
 

--- a/cmd/btrfs-nfs-csi/agents_test.go
+++ b/cmd/btrfs-nfs-csi/agents_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/erikmagkekse/btrfs-nfs-csi/agent/api/v1/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withTempConfigDir points os.UserHomeDir at a temp dir for the test and
+// clears any explicit path override so the default location is exercised.
+func withTempConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("BTRFS_NFS_CSI_AGENTS_FILE", "")
+	return dir
+}
+
+func TestLoadAgents_MissingFileReturnsEmptyStore(t *testing.T) {
+	withTempConfigDir(t)
+	store, err := loadAgents()
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	assert.Empty(t, store.Current)
+	assert.Empty(t, store.Agents)
+	_, ok := store.Active()
+	assert.False(t, ok, "no current set, Active should report false")
+}
+
+func TestAgentStore_SaveLoadRoundTrip(t *testing.T) {
+	withTempConfigDir(t)
+
+	want := &AgentStore{
+		Current: "prod",
+		Agents: map[string]Agent{
+			"prod": {
+				URL: "https://agent:8080", Token: "s3cret", Identity: "cli",
+				Tenant: "team-a", Role: models.RoleAdmin, Fingerprint: "abc123def456",
+			},
+			"dev": {URL: "http://dev:8080", Token: "devtok"},
+		},
+	}
+	require.NoError(t, want.save())
+
+	got, err := loadAgents()
+	require.NoError(t, err)
+	assert.Equal(t, want.Current, got.Current)
+	assert.Equal(t, want.Agents, got.Agents)
+
+	active, ok := got.Active()
+	require.True(t, ok)
+	assert.Equal(t, "https://agent:8080", active.URL)
+}
+
+func TestAgentStore_SaveSetsRestrictivePermissions(t *testing.T) {
+	configHome := withTempConfigDir(t)
+	store := &AgentStore{Agents: map[string]Agent{"a": {URL: "u", Token: "t"}}}
+	require.NoError(t, store.save())
+
+	path := filepath.Join(configHome, ".btrfs-nfs-csi", "agents.json")
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "agents.json must be 0600 (holds bearer tokens)")
+
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm(), "config dir must be 0700")
+}
+
+func TestAgentsPath_OverrideEnvWins(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "custom-agents.json")
+	t.Setenv("BTRFS_NFS_CSI_AGENTS_FILE", custom)
+	got, err := agentsPath()
+	require.NoError(t, err)
+	assert.Equal(t, custom, got, "BTRFS_NFS_CSI_AGENTS_FILE must take precedence over $HOME default")
+}
+
+func TestAgentsPath_DefaultsToHomeDotdir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BTRFS_NFS_CSI_AGENTS_FILE", "")
+	got, err := agentsPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".btrfs-nfs-csi", "agents.json"), got)
+}
+
+func TestAgent_TLSSkipVerifyRoundTrips(t *testing.T) {
+	withTempConfigDir(t)
+	want := &AgentStore{
+		Current: "prod",
+		Agents: map[string]Agent{
+			"prod": {URL: "https://agent:8443", Token: "t", TLSSkipVerify: true},
+			"dev":  {URL: "https://agent:8443", Token: "t"},
+		},
+	}
+	require.NoError(t, want.save())
+	got, err := loadAgents()
+	require.NoError(t, err)
+	assert.True(t, got.Agents["prod"].TLSSkipVerify, "skip flag must persist for prod")
+	assert.False(t, got.Agents["dev"].TLSSkipVerify, "dev kept default verify")
+}
+
+func TestTLSLabel(t *testing.T) {
+	assert.Equal(t, "skip", tlsLabel(true))
+	assert.Equal(t, "verify", tlsLabel(false))
+}
+
+func TestAgentStore_ActiveReturnsFalseWhenCurrentMissing(t *testing.T) {
+	store := &AgentStore{
+		Current: "ghost",
+		Agents:  map[string]Agent{"prod": {URL: "u", Token: "t"}},
+	}
+	_, ok := store.Active()
+	assert.False(t, ok, "Current names an agent that does not exist")
+}
+
+func TestDiffAgent(t *testing.T) {
+	cached := Agent{Tenant: "team-a", Role: models.RoleAdmin, Fingerprint: "abc123def456"}
+
+	t.Run("identical returns empty", func(t *testing.T) {
+		live := &models.WhoamiResponse{Tenant: "team-a", Role: models.RoleAdmin, Fingerprint: "abc123def456"}
+		assert.Empty(t, diffAgent(cached, live))
+	})
+
+	t.Run("role drift reported", func(t *testing.T) {
+		live := &models.WhoamiResponse{Tenant: "team-a", Role: models.RoleUser, Fingerprint: "abc123def456"}
+		got := diffAgent(cached, live)
+		assert.Contains(t, got, "role: cached=admin, live=user")
+		assert.NotContains(t, got, "tenant")
+		assert.NotContains(t, got, "fingerprint")
+	})
+
+	t.Run("multiple drifts joined", func(t *testing.T) {
+		live := &models.WhoamiResponse{Tenant: "team-b", Role: models.RoleUser, Fingerprint: "xx99yy88zz77"}
+		got := diffAgent(cached, live)
+		assert.Contains(t, got, "tenant:")
+		assert.Contains(t, got, "role:")
+		assert.Contains(t, got, "fingerprint:")
+		assert.Contains(t, got, "; ", "diffs should be semicolon-joined")
+	})
+}

--- a/cmd/btrfs-nfs-csi/agents_test.go
+++ b/cmd/btrfs-nfs-csi/agents_test.go
@@ -112,7 +112,7 @@ func TestTLSLabel(t *testing.T) {
 func TestConfig_ActiveReturnsFalseWhenCurrentAgentMissing(t *testing.T) {
 	cfg := &Config{
 		CurrentAgent: "ghost",
-		Agents:  map[string]Agent{"prod": {URL: "u", Token: "t"}},
+		Agents:       map[string]Agent{"prod": {URL: "u", Token: "t"}},
 	}
 	_, ok := cfg.Active()
 	assert.False(t, ok, "Current names an agent that does not exist")

--- a/cmd/btrfs-nfs-csi/auth.go
+++ b/cmd/btrfs-nfs-csi/auth.go
@@ -121,11 +121,7 @@ func listTokens(ctx context.Context, cmd *cli.Command) error {
 		w := tab()
 		_, _ = fmt.Fprintln(w, "ROLE\tIDENTITY\tFINGERPRINT")
 		for _, tok := range resp.Tokens {
-			id := tok.Identity
-			if id == "" {
-				id = "-"
-			}
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", tok.Role, id, shortFP(tok.Fingerprint, wide))
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", tok.Role, dash(tok.Identity), shortFP(tok.Fingerprint, wide))
 		}
 		_ = w.Flush()
 	})

--- a/cmd/btrfs-nfs-csi/config.go
+++ b/cmd/btrfs-nfs-csi/config.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Config is the on-disk CLI config. Flat top-level keys leave room for
+// future settings (default_output, aliases, ...) without restructuring.
+type Config struct {
+	CurrentAgent string           `json:"current_agent,omitempty"`
+	Agents       map[string]Agent `json:"agents,omitempty"`
+}
+
+func (c *Config) Active() (Agent, bool) {
+	if c == nil || c.CurrentAgent == "" {
+		return Agent{}, false
+	}
+	a, ok := c.Agents[c.CurrentAgent]
+	return a, ok
+}
+
+// configPath honours BTRFS_NFS_CSI_CONFIG_FILE so tests and per-project
+// profiles can redirect away from the default $HOME location.
+func configPath() (string, error) {
+	if override := os.Getenv("BTRFS_NFS_CSI_CONFIG_FILE"); override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate home directory: %w", err)
+	}
+	return filepath.Join(home, ".btrfs-nfs-csi", "config.json"), nil
+}
+
+// loadConfig treats a missing file as an empty config so first-run is
+// indistinguishable from "no agents configured".
+func loadConfig() (*Config, error) {
+	path, err := configPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &Config{Agents: map[string]Agent{}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if c.Agents == nil {
+		c.Agents = map[string]Agent{}
+	}
+	return &c, nil
+}
+
+// save writes atomically with 0600 + 0700 because the file holds bearer
+// tokens in plaintext.
+func (c *Config) save() error {
+	path, err := configPath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, "config-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	// rename is atomic, but without fsync the new bytes can be lost on
+	// power loss while the directory entry already points at them.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename into place: %w", err)
+	}
+	cleanup = false
+	return nil
+}

--- a/cmd/btrfs-nfs-csi/main.go
+++ b/cmd/btrfs-nfs-csi/main.go
@@ -75,6 +75,7 @@ Issues: https://github.com/erikmagkekse/btrfs-nfs-csi/issues`,
 			),
 			hashTokenCmd(),
 			agentCmd(),
+			agentsCmd(),
 			integrationCmd(),
 			controllerBackwardsCompatibilityWillBeRemovedInTheFuture(),
 			driverBackwardsCompatibilityWillBeRemovedInTheFuture(),
@@ -93,7 +94,7 @@ Issues: https://github.com/erikmagkekse/btrfs-nfs-csi/issues`,
 func agentCmd() *cli.Command {
 	return &cli.Command{
 		Name:     "agent",
-		Usage:    "Start the agent",
+		Usage:    "Start the agent (server-side)",
 		Category: "Server",
 		Action: func(_ context.Context, _ *cli.Command) error {
 			log.Info().Str("version", version).Str("commit", commit).Msg("starting btrfs-nfs-csi agent by Erik Groh <me@eriks.life> (https://github.com/erikmagkekse)")
@@ -102,6 +103,14 @@ func agentCmd() *cli.Command {
 			}
 			return nil
 		},
+	}
+}
+
+func agentsCmd() *cli.Command {
+	return &cli.Command{
+		Name:     "agents",
+		Usage:    "Manage saved remote agents (client-side context)",
+		Commands: agentsSubcommands(),
 	}
 }
 

--- a/cmd/btrfs-nfs-csi/utils.go
+++ b/cmd/btrfs-nfs-csi/utils.go
@@ -353,8 +353,33 @@ var (
 )
 
 func initClient(ctx context.Context, cmd *cli.Command) error {
+	resolved := Agent{
+		URL:      cmd.String("agent-url"),
+		Token:    cmd.String("agent-token"),
+		Identity: config.IdentityCLI,
+	}
+	if resolved.URL == "" || resolved.Token == "" {
+		// Per-field merge so explicit --agent-url or AGENT_URL still
+		// wins when a saved agent is also present.
+		store, err := loadAgents()
+		if err != nil {
+			return err
+		}
+		if active, ok := store.Active(); ok {
+			if resolved.URL == "" {
+				resolved.URL = active.URL
+			}
+			if resolved.Token == "" {
+				resolved.Token = active.Token
+			}
+			if active.Identity != "" {
+				resolved.Identity = active.Identity
+			}
+			resolved.TLSSkipVerify = active.TLSSkipVerify
+		}
+	}
 	var err error
-	apiClient, err = agentclient.NewClient(cmd.String("agent-url"), cmd.String("agent-token"), config.IdentityCLI)
+	apiClient, err = newAgentClient(resolved)
 	if err != nil {
 		return err
 	}
@@ -366,7 +391,7 @@ func withCLIHooks(cmds ...*cli.Command) []*cli.Command {
 		cmd.Flags = append(cmd.Flags,
 			&cli.StringFlag{Name: "agent-url", Sources: cli.EnvVars("AGENT_URL"), Usage: "agent API URL"},
 			&cli.StringFlag{Name: "agent-token", Sources: cli.EnvVars("AGENT_TOKEN"), Usage: "tenant token"},
-			&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Value: outputTable, Usage: "output format: table, wide, json, json,wide"},
+			outputFlag(),
 		)
 		cmd.Before = func(ctx context.Context, c *cli.Command) (context.Context, error) {
 			if err := initClient(ctx, c); err != nil {
@@ -395,6 +420,22 @@ func watchAction(fn cli.ActionFunc) cli.ActionFunc {
 			return fn(ctx, cmd)
 		})
 	}
+}
+
+func outputFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:    "output",
+		Aliases: []string{"o"},
+		Value:   outputTable,
+		Usage:   "output format: table, wide, json, json,wide",
+	}
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }
 
 func isWide(cmd *cli.Command) bool {

--- a/cmd/btrfs-nfs-csi/utils.go
+++ b/cmd/btrfs-nfs-csi/utils.go
@@ -361,11 +361,11 @@ func initClient(ctx context.Context, cmd *cli.Command) error {
 	if resolved.URL == "" || resolved.Token == "" {
 		// Per-field merge so explicit --agent-url or AGENT_URL still
 		// wins when a saved agent is also present.
-		store, err := loadAgents()
+		cfg, err := loadConfig()
 		if err != nil {
 			return err
 		}
-		if active, ok := store.Active(); ok {
+		if active, ok := cfg.Active(); ok {
 			if resolved.URL == "" {
 				resolved.URL = active.URL
 			}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,8 +58,9 @@ Shared by CLI and all integrations (any `v1.Client` user).
 | `AGENT_URL` | - | Agent API URL |
 | `AGENT_TOKEN` | - | Tenant token |
 | `BTRFS_NFS_CSI_FORCE` | `false` | Skip delete protection when `true` |
+| `BTRFS_NFS_CSI_CONFIG_FILE` | `$HOME/.btrfs-nfs-csi/config.json` | Path to the CLI config file (saved agents, future CLI settings) |
 
-Also configurable via `--agent-url` and `--agent-token` flags.
+Also configurable via `--agent-url` and `--agent-token` flags, or per-shell via the `btrfs-nfs-csi agents` saved-agent manager (see [Operations: Saved Agents](operations.md#saved-agents)).
 
 ## TLS
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -194,9 +194,24 @@ btrfs-nfs-csi task create balance --dconvert=raid1 --mconvert=raid1 -W
 btrfs-nfs-csi task create balance --ddevid=3 --mdevid=3 -W
 ```
 
+## Saved Agents
+
+Saved agent endpoints, so the CLI does not need `AGENT_URL`/`AGENT_TOKEN` in every shell. `agents login <name> --url ...` verifies the token via `/v1/whoami` and persists it to `~/.btrfs-nfs-csi/config.json` (file `0600`, dir `0700`). Token reads from no-echo prompt or stdin pipe. Subsequent CLI commands fall back per field to the active entry.
+
+```bash
+echo "$TOKEN" | btrfs-nfs-csi agents login prod --url https://agent.example.com:8080
+btrfs-nfs-csi agents ls
+btrfs-nfs-csi agents use prod
+btrfs-nfs-csi volume list                  # no env vars needed
+btrfs-nfs-csi agents verify --all
+```
+
+Subcommands: `login`, `logout [<name>]`, `ls` (`-o wide`/`-o json`), `use <name>`, `verify [<name>] [--all]`. Precedence: flag > env > active entry. `agents login --tls-skip-verify` persists a per-agent TLS toggle for self-signed endpoints. Token is never written to any stdout, only the on-disk file. Override the path with `BTRFS_NFS_CSI_CONFIG_FILE`.
+
 ## More CLI examples
 
 ```bash
+# When no agent is saved, fall back to env vars:
 export AGENT_URL=http://10.0.0.5:8080
 export AGENT_TOKEN=changeme
 export AGENT_CSI_IDENTITY=cli              # optional, default: cli


### PR DESCRIPTION
## Summary

- `btrfs-nfs-csi agents login/logout/ls/use/verify` persists remote endpoints to `~/.btrfs-nfs-csi/config.json` (`0600`, atomic write).
- Subsequent CLI commands fall back per field to the active entry, no `AGENT_URL`/`AGENT_TOKEN` exports needed.
- `agents login` reads the token via stdin or no-echo prompt, verifies against `/v1/whoami`, caches `tenant`/`role`/`fingerprint`.
- `agents verify [--all]` re-checks tokens in parallel and reports drift against the cached values.
- `agents login --tls-skip-verify` persists a per-agent TLS toggle.
- `BTRFS_NFS_CSI_CONFIG_FILE` overrides the default path. Tokens never appear in `-o json` or any stdout.
